### PR TITLE
Fix overly verbose version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "type": "library",
     "require": {
-        "php": "^8.1|^8.2",
+        "php": "^8.1",
         "illuminate/console": "^10.0|^11.0|^12.0",
         "illuminate/contracts": "^10.0|^11.0|^12.0",
         "illuminate/http": "^10.0|^11.0|^12.0",


### PR DESCRIPTION
`^8.1` is equivalent to `^8.1|^8.2`