### PR TITLE
[0.x] Add command to stub out an MCP Prompt class

### DIFF
--- a/src/Server/McpServiceProvider.php
+++ b/src/Server/McpServiceProvider.php
@@ -7,6 +7,7 @@ namespace Laravel\Mcp\Server;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Mcp\Console\Commands\McpInspectorCommand;
+use Laravel\Mcp\Console\Commands\PromptMakeCommand;
 use Laravel\Mcp\Console\Commands\ResourceMakeCommand;
 use Laravel\Mcp\Console\Commands\ServerMakeCommand;
 use Laravel\Mcp\Console\Commands\StartServerCommand;
@@ -26,6 +27,7 @@ class McpServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands([
                 StartServerCommand::class,
+                PromptMakeCommand::class,
                 ServerMakeCommand::class,
                 ToolMakeCommand::class,
                 ResourceMakeCommand::class,


### PR DESCRIPTION
In this PR, I've added the already available `PromptMakeCommand` class to allow a developer to quickly stub out a Prompt class template.

Closes #13 
