### PR TITLE
[0.x] Fix OAuth Supported Grants

### DIFF
--- a/src/Server/Registrar.php
+++ b/src/Server/Registrar.php
@@ -73,7 +73,7 @@ class Registrar
                 'registration_endpoint' => url($oauthPrefix.'/register'),
                 'response_types_supported' => ['code'],
                 'code_challenge_methods_supported' => ['S256'],
-                'grant_types_supported' => ['authorization_code'],
+                'grant_types_supported' => ['authorization_code', 'refresh_token'],
             ]);
         });
 
@@ -86,7 +86,7 @@ class Registrar
                 redirectUris: $payload['redirect_uris'],
                 confidential: false,
                 user: null,
-                enableDeviceFlow: true,
+                enableDeviceFlow: false,
             );
 
             return response()->json([


### PR DESCRIPTION
When creating a client via [`createAuthorizationCodeGrantClient`](https://github.com/laravel/passport/blob/0356d18201f6dd9b3f47dc086d85d4656582a1af/src/ClientRepository.php#L177-L190)  method of Passport's `ClientRepository` class, the created client has `'authorization_code'` and `'refresh_token'` grant types by default. This PR fixes supported grant types when registering a new client.

When creating a client using the [`createAuthorizationCodeGrantClient`](https://github.com/laravel/passport/blob/0356d18201f6dd9b3f47dc086d85d4656582a1af/src/ClientRepository.php#L177-L190) method of Passport's `ClientRepository` class, the generated client is assigned the `'authorization_code'` and `'refresh_token'` grant types by default.

This PR ensures that the supported grant types are set correctly when registering a new client.