### PR TITLE
fix(phpdoc): correct docblock closing and class-string types

### DIFF
--- a/stubs/resource.stub
+++ b/stubs/resource.stub
@@ -8,7 +8,7 @@ class {{ class }} extends Resource
 {
     /**
      * The resource's description.
-     /*
+     */
     protected string $description = 'A description of what this resource contains.';
 
     /**

--- a/stubs/server.stub
+++ b/stubs/server.stub
@@ -3,6 +3,9 @@
 namespace {{ namespace }};
 
 use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Resource;
+use Laravel\Mcp\Server\Prompt;
 
 class {{ class }} extends Server
 {
@@ -24,7 +27,7 @@ class {{ class }} extends Server
     /**
      * The tools registered with this MCP server.
      *
-     * @var array<int, class-string<\Laravel\Mcp\Server\Tool>>
+     * @var array<int, class-string<Tool>>
      */
     protected array $tools = [
         // ExampleTool::class,
@@ -33,7 +36,7 @@ class {{ class }} extends Server
     /**
      * The resources registered with this MCP server.
      *
-     * @var array<int, class-string<\Laravel\Mcp\Server\Resource>>
+     * @var array<int, class-string<Resource>>
      */
     protected array $resources = [
         // ExampleResource::class,
@@ -42,7 +45,7 @@ class {{ class }} extends Server
     /**
      * The prompts registered with this MCP server.
      *
-     * @var array<int, class-string<\Laravel\Mcp\Server\Prompt>>
+     * @var array<int, class-string<Prompt>>
      */
     protected array $prompts = [
         // ExamplePrompt::class,


### PR DESCRIPTION
This PR fixes minor PHPDoc issues in the MCP server templates:

- Corrected a stray `/*` to `*/` in docblocks.  
- Updated `@var` annotations to use `class-string<T>` with imported classes (Tool, Resource, Prompt).  

### Benefits
- Improves IDE auto-completion and static analysis (PHPStan).  
- Enhances code readability and consistency.  
- No functional changes, safe for all users.
