### PR TITLE
InspectorCommand error message improvement

### DIFF
--- a/src/Console/Commands/InspectorCommand.php
+++ b/src/Console/Commands/InspectorCommand.php
@@ -53,7 +53,7 @@ class InspectorCommand extends Command
         }
 
         if (is_null($localServer) && is_null($route)) {
-            $availableServers = Arr::map(array_keys($servers), fn ($server) => "[{$server}]");
+            $availableServers = Arr::map(array_keys($servers), fn ($server): string => "[{$server}]");
             $this->components->error('MCP Server with name ['.$handle.'] not found. Available servers: '.Arr::join($availableServers, ', '));
 
             return static::FAILURE;

--- a/src/Console/Commands/InspectorCommand.php
+++ b/src/Console/Commands/InspectorCommand.php
@@ -53,7 +53,8 @@ class InspectorCommand extends Command
         }
 
         if (is_null($localServer) && is_null($route)) {
-            $this->components->error('MCP Server with name ['.$handle.'] not found. Available servers: '.Arr::join(array_keys($servers), ', '));
+            $availableServers = Arr::map(array_keys($servers), fn ($server) => "[{$server}]");
+            $this->components->error('MCP Server with name ['.$handle.'] not found. Available servers: '.Arr::join($availableServers, ', '));
 
             return static::FAILURE;
         }


### PR DESCRIPTION
This pull request enhances the formatting of `InspectorCommand` error message. The improvement include highlighting available servers and separating the last item from the concluding period in the error message.

Before:
<img width="671" height="35" alt="Screenshot 2025-09-19 at 0 09 18" src="https://github.com/user-attachments/assets/980aa32a-556a-4893-8763-53e04d95c930" />


After:
<img width="702" height="33" alt="Screenshot 2025-09-18 at 23 49 11" src="https://github.com/user-attachments/assets/426df132-2991-414d-b603-f305013a0dfd" />
