### PR TITLE
use nowdoc for instructions and fix changelog URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Release Notes
 
-## [Unreleased](https://github.com/laravel/package-template/compare/v0.2.0...main)
+## [Unreleased](https://github.com/laravel/mcp/compare/v0.2.0...main)
 
-## [v0.2.0](https://github.com/laravel/package-template/compare/v0.1.0...v0.2.0) - 2025-09-18
+## [v0.2.0](https://github.com/laravel/mcp/compare/v0.1.0...v0.2.0) - 2025-09-18
 
 - First official "beta" release of Laravel MCP package.
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -37,7 +37,9 @@ abstract class Server
 
     protected string $version = '0.0.1';
 
-    protected string $instructions = 'This MCP server lets AI agents interact with our Laravel application.';
+    protected string $instructions = <<<'MARKDOWN'
+        This MCP server lets AI agents interact with our Laravel application.
+    MARKDOWN;
 
     /**
      * @var array<int, string>


### PR DESCRIPTION
- Convert `Server` instructions to nowdoc format for better LLM-friendly documentation.
- Fix `CHANGELOG.md` URLs that were still pointing to `package-template` instead of `mcp`.
