### PR TITLE
quickstart

### DIFF
--- a/src/Console/Commands/InspectorCommand.php
+++ b/src/Console/Commands/InspectorCommand.php
@@ -101,7 +101,6 @@ class InspectorCommand extends Command
             $guidance = [
                 'Transport Type' => 'Streamable HTTP',
                 'URL' => $serverUrl,
-                'Secure' => 'Your project must be accessible on HTTP for this to work due to how node manages SSL trust',
             ];
         }
 

--- a/src/Console/Commands/MakeMcpCommand.php
+++ b/src/Console/Commands/MakeMcpCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Console\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Console\Input\InputOption;
+
+abstract class MakeMcpCommand extends GeneratorCommand
+{
+    protected string $lowerType;
+
+    public function __construct(Filesystem $files)
+    {
+        $this->lowerType = strtolower($this->type);
+        $this->name = 'make:mcp-'.$this->lowerType;
+        $this->description = 'Create a new MCP '.$this->type.' class';
+        parent::__construct($files);
+    }
+
+    protected function getStub(): string
+    {
+        $filename = $this->lowerType.'.stub';
+        $custom = $this->laravel->basePath('stubs/'.$filename);
+        if (file_exists($custom)) {
+            return $custom;
+        }
+
+        $dir = __DIR__.'/../../../stubs/';
+        if ($this->option('quickstart')) {
+            $dir .= 'quickstart/';
+        }
+
+        return $dir.$filename;
+    }
+
+    protected function getDefaultNamespace($rootNamespace): string
+    {
+        return "{$rootNamespace}\\Mcp\\{$this->type}s";
+    }
+
+    /**
+     * @return array<int, array<int, string|int>>
+     */
+    protected function getOptions(): array
+    {
+        return [
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the '.$this->lowerType.' already exists'],
+            ['quickstart', 'qs', InputOption::VALUE_NONE, 'Create the quickstart version'],
+        ];
+    }
+}

--- a/src/Console/Commands/MakePromptCommand.php
+++ b/src/Console/Commands/MakePromptCommand.php
@@ -4,40 +4,10 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp\Console\Commands;
 
-use Illuminate\Console\GeneratorCommand;
-use Symfony\Component\Console\Attribute\AsCommand;
-use Symfony\Component\Console\Input\InputOption;
-
-#[AsCommand(
-    name: 'make:mcp-prompt',
-    description: 'Create a new MCP prompt class'
-)]
-class MakePromptCommand extends GeneratorCommand
+class MakePromptCommand extends MakeMcpCommand
 {
     /**
      * @var string
      */
     protected $type = 'Prompt';
-
-    protected function getStub(): string
-    {
-        return file_exists($customPath = $this->laravel->basePath('stubs/prompt.stub'))
-            ? $customPath
-            : __DIR__.'/../../../stubs/prompt.stub';
-    }
-
-    protected function getDefaultNamespace($rootNamespace): string
-    {
-        return "{$rootNamespace}\\Mcp\\Prompts";
-    }
-
-    /**
-     * @return array<int, array<int, string|int>>
-     */
-    protected function getOptions(): array
-    {
-        return [
-            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the prompt already exists'],
-        ];
-    }
 }

--- a/src/Console/Commands/MakeResourceCommand.php
+++ b/src/Console/Commands/MakeResourceCommand.php
@@ -4,40 +4,10 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp\Console\Commands;
 
-use Illuminate\Console\GeneratorCommand;
-use Symfony\Component\Console\Attribute\AsCommand;
-use Symfony\Component\Console\Input\InputOption;
-
-#[AsCommand(
-    name: 'make:mcp-resource',
-    description: 'Create a new MCP resource class'
-)]
-class MakeResourceCommand extends GeneratorCommand
+class MakeResourceCommand extends MakeMcpCommand
 {
     /**
      * @var string
      */
     protected $type = 'Resource';
-
-    protected function getStub(): string
-    {
-        return file_exists($customPath = $this->laravel->basePath('stubs/resource.stub'))
-            ? $customPath
-            : __DIR__.'/../../../stubs/resource.stub';
-    }
-
-    protected function getDefaultNamespace($rootNamespace): string
-    {
-        return "{$rootNamespace}\\Mcp\\Resources";
-    }
-
-    /**
-     * @return array<int, array<int, string|int>>
-     */
-    protected function getOptions(): array
-    {
-        return [
-            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the resource already exists'],
-        ];
-    }
 }

--- a/src/Console/Commands/MakeServerCommand.php
+++ b/src/Console/Commands/MakeServerCommand.php
@@ -4,46 +4,14 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp\Console\Commands;
 
-use Illuminate\Console\GeneratorCommand;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
-use Symfony\Component\Console\Attribute\AsCommand;
-use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(
-    name: 'make:mcp-server',
-    description: 'Create a new MCP server class'
-)]
-class MakeServerCommand extends GeneratorCommand
+class MakeServerCommand extends MakeMcpCommand
 {
     /**
      * @var string
      */
     protected $type = 'Server';
-
-    protected function getStub(): string
-    {
-        return file_exists($customPath = $this->laravel->basePath('stubs/server.stub'))
-            ? $customPath
-            : __DIR__.'/../../../stubs/server.stub';
-    }
-
-    /**
-     * @param  string  $rootNamespace
-     */
-    protected function getDefaultNamespace($rootNamespace): string
-    {
-        return "{$rootNamespace}\\Mcp\\Servers";
-    }
-
-    /**
-     * @return array<int, array<int, string|int>>
-     */
-    protected function getOptions(): array
-    {
-        return [
-            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the server already exists'],
-        ];
-    }
 
     /**
      * @param  string  $name

--- a/src/Console/Commands/MakeToolCommand.php
+++ b/src/Console/Commands/MakeToolCommand.php
@@ -4,64 +4,10 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp\Console\Commands;
 
-use Illuminate\Console\GeneratorCommand;
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
-use Illuminate\Support\Str;
-use Symfony\Component\Console\Attribute\AsCommand;
-use Symfony\Component\Console\Input\InputOption;
-
-#[AsCommand(
-    name: 'make:mcp-tool',
-    description: 'Create a new MCP tool class'
-)]
-class MakeToolCommand extends GeneratorCommand
+class MakeToolCommand extends MakeMcpCommand
 {
     /**
      * @var string
      */
     protected $type = 'Tool';
-
-    protected function getStub(): string
-    {
-        return file_exists($customPath = $this->laravel->basePath('stubs/tool.stub'))
-            ? $customPath
-            : __DIR__.'/../../../stubs/tool.stub';
-    }
-
-    /**
-     * @param  string  $rootNamespace
-     */
-    protected function getDefaultNamespace($rootNamespace): string
-    {
-        return "{$rootNamespace}\\Mcp\\Tools";
-    }
-
-    /**
-     * @return array<int, array<int, string|int>>
-     */
-    protected function getOptions(): array
-    {
-        return [
-            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the tool already exists'],
-        ];
-    }
-
-    /**
-     * @param  string  $name
-     *
-     * @throws FileNotFoundException
-     */
-    protected function buildClass($name): string
-    {
-        $stub = parent::buildClass($name);
-
-        $className = class_basename($name);
-        $title = Str::headline($className);
-
-        return str_replace(
-            '{{ title }}',
-            $title,
-            $stub,
-        );
-    }
 }

--- a/src/Console/Commands/QuickstartCommand.php
+++ b/src/Console/Commands/QuickstartCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(
+    name: 'mcp:quickstart',
+    description: 'Quickly setup MCP fundamentals'
+)]
+class QuickstartCommand extends Command
+{
+    public function handle(): void
+    {
+        $serverName = Str::pascal(preg_replace('/[^a-zA-Z \-]/', '', config('app.name', 'Quickstart')));
+
+        $this->callSilently('vendor:publish', ['--tag' => 'ai-routes', '--no-interaction' => true]);
+        $this->make('server', $serverName);
+        $this->make('tool', 'QuickstartTool');
+        $this->make('resource', 'QuickstartResource');
+        $this->make('prompt', 'QuickstartPrompt');
+
+        $fc = file_get_contents(base_path('routes/ai.php')) ?: '';
+        if (str_contains($fc, 'mcp.quickstart') === false) {
+            file_put_contents(base_path('routes/ai.php'), "\nMcp::web('/mcp', App\\Mcp\\Servers\\{$serverName}::class)->name('mcp.quickstart');\n", FILE_APPEND);
+        }
+
+        $url = url('/mcp');
+        $isSecure = str_contains($url, 'https://');
+
+        $this->table(['Todo', 'Notes'], [
+            ['Read', 'routes/ai.php'],
+            ['Test with MCP Inspector', 'php artisan mcp:inspector mcp'],
+            ['Test in your IDE', 'https://addmcp.fyi/Quickstart/'.url('/mcp')],
+        ], 'box');
+        $this->info('Routes file, server, tool, resource, and prompt all setup. Time to test.');
+
+        if ($isSecure) {
+            $this->line('Please note many AI agents use node and won\'t work with self-signed certificates locally. You may need to use http:// explicitly if you encounter issues.');
+        }
+    }
+
+    protected function make(string $type, string $name): void
+    {
+        $this->call('make:mcp-'.$type, ['name' => $name, '--quickstart' => true, '--no-interaction' => true]);
+    }
+}

--- a/src/Server/McpServiceProvider.php
+++ b/src/Server/McpServiceProvider.php
@@ -11,6 +11,7 @@ use Laravel\Mcp\Console\Commands\MakePromptCommand;
 use Laravel\Mcp\Console\Commands\MakeResourceCommand;
 use Laravel\Mcp\Console\Commands\MakeServerCommand;
 use Laravel\Mcp\Console\Commands\MakeToolCommand;
+use Laravel\Mcp\Console\Commands\QuickstartCommand;
 use Laravel\Mcp\Console\Commands\StartCommand;
 use Laravel\Mcp\Request;
 
@@ -81,12 +82,13 @@ class McpServiceProvider extends ServiceProvider
     protected function registerCommands(): void
     {
         $this->commands([
-            StartCommand::class,
+            InspectorCommand::class,
+            QuickstartCommand::class,
             MakeServerCommand::class,
             MakeToolCommand::class,
             MakePromptCommand::class,
             MakeResourceCommand::class,
-            InspectorCommand::class,
+            StartCommand::class,
         ]);
     }
 }

--- a/src/Server/Prompt.php
+++ b/src/Server/Prompt.php
@@ -35,7 +35,7 @@ abstract class Prompt extends Primitive
         return [
             'name' => $this->name(),
             'title' => $this->title(),
-            'description' => $this->description(),
+            'description' => trim($this->description()),
             'arguments' => array_map(
                 fn (Argument $argument): array => $argument->toArray(),
                 $this->arguments(),

--- a/src/Server/Resource.php
+++ b/src/Server/Resource.php
@@ -39,7 +39,7 @@ abstract class Resource extends Primitive
         return [
             'name' => $this->name(),
             'title' => $this->title(),
-            'description' => $this->description(),
+            'description' => trim($this->description()),
             'uri' => $this->uri(),
             'mimeType' => $this->mimeType(),
         ];

--- a/src/Server/Tool.php
+++ b/src/Server/Tool.php
@@ -60,7 +60,7 @@ abstract class Tool extends Primitive
         return [
             'name' => $this->name(),
             'title' => $this->title(),
-            'description' => $this->description(),
+            'description' => trim($this->description()),
             'inputSchema' => JsonSchema::object(
                 fn (JsonSchema $schema): array => $this->schema($schema),
             )->toArray(),

--- a/stubs/quickstart/prompt.stub
+++ b/stubs/quickstart/prompt.stub
@@ -1,0 +1,40 @@
+<?php
+
+namespace {{ namespace }};
+
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Prompt;
+use Laravel\Mcp\Server\Prompts\Argument;
+
+class {{ class }} extends Prompt
+{
+    /**
+     * The prompt's description.
+     */
+    protected string $description = <<<'MARKDOWN'
+        Test the tool and resource in combination
+    MARKDOWN;
+
+    /**
+     * Handle the prompt request.
+     */
+    public function handle(Request $request): Response
+    {
+        $request->validate(['test_count' => 'required|numeric|min:1|max:20']);
+
+        return Response::text("Test this MCP server by creating {$request->get('test_count')} debug log entries, then reading the QuickstartResource for the user, or asking the user to attach or read it themselves. Your debug log entries should be fun Laravel facts.");
+    }
+
+    /**
+     * Get the prompt's arguments.
+     *
+     * @return array<int, \Laravel\Mcp\Server\Prompts\Argument>
+     */
+    public function arguments(): array
+    {
+        return [
+            new Argument('test_count', 'How many log entries should be created to test the tool and resource?', true),
+        ];
+    }
+}

--- a/stubs/quickstart/resource.stub
+++ b/stubs/quickstart/resource.stub
@@ -1,0 +1,63 @@
+<?php
+
+namespace {{ namespace }};
+
+use Laravel\Mcp\Server\Resource;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Illuminate\Support\Facades\Log;
+use Monolog\Handler\StreamHandler;
+use Monolog\Handler\RotatingFileHandler;
+
+class {{ class }} extends Resource
+{
+    /**
+     * The resource's description.
+     */
+    protected string $description = <<<'MARKDOWN'
+        Get latest logs from the app
+    MARKDOWN;
+
+    /**
+     * Handle the resource request.
+     */
+    public function handle(Request $request): Response
+    {
+        return Response::text($this->read($this->filename()));
+    }
+
+    protected function filename(): string|null
+    {
+        $filenames = array_map(
+            fn($handler) => match (true) {
+                $handler instanceof StreamHandler => $handler->getUrl(),
+                $handler instanceof RotatingFileHandler => $handler->getFilename(),
+                default => null
+            },
+            Log::driver()->getHandlers()
+        );
+
+        return array_filter($filenames)[0] ?? null;
+    }
+
+    protected function read(?string $filename, int $bytes = 4000): string
+    {
+        if (is_null($filename)) {
+            return '';
+        }
+
+        if (!file_exists($filename) || !is_readable($filename)) {
+            return '';
+        }
+
+        $size = filesize($filename);
+        $bytes = min($bytes, $size);
+        $fp = fopen($filename, 'r');
+        fseek($fp, -$bytes, SEEK_END);
+        $content = fread($fp, $bytes);
+        fclose($fp);
+
+        return $content;
+
+    }
+}

--- a/stubs/quickstart/server.stub
+++ b/stubs/quickstart/server.stub
@@ -1,0 +1,53 @@
+<?php
+
+namespace {{ namespace }};
+
+use Laravel\Mcp\Server;
+
+class {{ class }} extends Server
+{
+    /**
+     * The MCP server's name.
+     */
+    protected string $name = '{{ serverDisplayName }}';
+
+    /**
+     * The MCP server's version.
+     */
+    protected string $version = '0.0.1';
+
+    /**
+     * The MCP server's instructions for the LLM.
+     */
+    protected string $instructions = <<<'MARKDOWN'
+        Instructions describing how to use the server and its features.
+        Use {{ serverDisplayName }} to learn more about the app.
+    MARKDOWN;
+
+    /**
+     * The tools registered with this MCP server.
+     *
+     * @var array<int, class-string<\Laravel\Mcp\Server\Tool>>
+     */
+    protected array $tools = [
+        \App\Mcp\Tools\QuickstartTool::class,
+    ];
+
+    /**
+     * The resources registered with this MCP server.
+     *
+     * @var array<int, class-string<\Laravel\Mcp\Server\Resource>>
+     */
+    protected array $resources = [
+        \App\Mcp\Resources\QuickstartResource::class,
+    ];
+
+    /**
+     * The prompts registered with this MCP server.
+     *
+     * @var array<int, class-string<\Laravel\Mcp\Server\Prompt>>
+     */
+    protected array $prompts = [
+        \App\Mcp\Prompts\QuickstartPrompt::class,
+    ];
+}

--- a/stubs/quickstart/tool.stub
+++ b/stubs/quickstart/tool.stub
@@ -1,0 +1,48 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Illuminate\Support\Facades\Log;
+
+class {{ class }} extends Tool
+{
+    /**
+     * The tool's description.
+     */
+    protected string $description = <<<'MARKDOWN'
+        Add debug log entries
+    MARKDOWN;
+
+    /**
+     * Handle the tool request.
+     */
+    public function handle(Request $request): Response
+    {
+        $request->validate(['messages' => 'required|array']);
+
+        foreach ($request->get('messages') as $message) {
+            Log::debug($message);
+        }
+
+        return Response::text('Added ' . count($request->get('messages')) . ' log entries');
+    }
+
+    /**
+     * Get the tool's input schema.
+     *
+     * @return array<string, \Illuminate\JsonSchema\JsonSchema>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'messages' => $schema->array()
+                ->items($schema->string()->description('Log message'))
+                ->description('Messages to add to the log as debug entries')
+                ->required()
+        ];
+    }
+}

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -4,7 +4,6 @@ use Illuminate\Console\Command;
 use Laravel\Mcp\Server\Contracts\Method;
 use Laravel\Mcp\Server\Contracts\Tools\Annotation;
 use Laravel\Mcp\Server\Testing\TestResponse;
-use Symfony\Component\Console\Attribute\AsCommand;
 
 arch('strict and safe')
     ->expect('Laravel\Mcp')
@@ -31,5 +30,4 @@ arch('exceptions extend')
 
 arch('commands extend command')
     ->expect('Laravel\Mcp\Console\Commands')
-    ->toExtend(Command::class)
-    ->toHaveAttribute(attribute: AsCommand::class);
+    ->toExtend(Command::class);


### PR DESCRIPTION
- **feat: trim nowdoc descriptions in primitives**
- **fix: remove 'Secure' message on mcp:inspector**
- **feat: add 'quickstart' support to make:mcp commands**
- **feat: add mcp:quickstart command and stubs**
