### PR TITLE
Implement validated method in Request.php

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -76,6 +76,48 @@ class Request implements Arrayable
         return Validator::validate($this->all(), $rules, $messages, $attributes);
     }
 
+    /**
+     * Get custom rules for validator errors.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [];
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array
+     */
+    public function messages()
+    {
+        return [];
+    }
+
+    /**
+     * Get custom attributes for validator errors.
+     *
+     * @return array
+     */
+    public function attributes()
+    {
+        return [];
+    }
+
+    /**
+     * Get the validated data from the request.
+     *
+     * @return array<string, mixed>
+     *
+     * @throws ValidationException
+     */
+    public function validated()
+    {
+        return $this->validate($this->rules(), $this->messages(), $this->attributes());
+    }
+
     public function user(?string $guard = null): ?Authenticatable
     {
         $auth = Container::getInstance()->make('auth');

--- a/src/Request.php
+++ b/src/Request.php
@@ -78,6 +78,8 @@ class Request implements Arrayable
 
     /**
      * Get custom rules for validator errors.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {
@@ -86,6 +88,8 @@ class Request implements Arrayable
 
     /**
      * Get custom messages for validator errors.
+     *
+     * @return array<string, string>
      */
     public function messages(): array
     {
@@ -94,6 +98,8 @@ class Request implements Arrayable
 
     /**
      * Get custom attributes for validator errors.
+     *
+     * @return array<string, string>
      */
     public function attributes(): array
     {

--- a/src/Request.php
+++ b/src/Request.php
@@ -81,7 +81,7 @@ class Request implements Arrayable
      *
      * @return array
      */
-    public function rules()
+    public function rules(): array
     {
         return [];
     }
@@ -91,7 +91,7 @@ class Request implements Arrayable
      *
      * @return array
      */
-    public function messages()
+    public function messages(): array
     {
         return [];
     }
@@ -101,7 +101,7 @@ class Request implements Arrayable
      *
      * @return array
      */
-    public function attributes()
+    public function attributes(): array
     {
         return [];
     }
@@ -113,7 +113,7 @@ class Request implements Arrayable
      *
      * @throws ValidationException
      */
-    public function validated()
+    public function validated(): array
     {
         return $this->validate($this->rules(), $this->messages(), $this->attributes());
     }

--- a/src/Request.php
+++ b/src/Request.php
@@ -78,8 +78,6 @@ class Request implements Arrayable
 
     /**
      * Get custom rules for validator errors.
-     *
-     * @return array
      */
     public function rules(): array
     {
@@ -88,8 +86,6 @@ class Request implements Arrayable
 
     /**
      * Get custom messages for validator errors.
-     *
-     * @return array
      */
     public function messages(): array
     {
@@ -98,8 +94,6 @@ class Request implements Arrayable
 
     /**
      * Get custom attributes for validator errors.
-     *
-     * @return array
      */
     public function attributes(): array
     {

--- a/tests/Feature/CustomRequestValidationTest.php
+++ b/tests/Feature/CustomRequestValidationTest.php
@@ -42,8 +42,8 @@ class Greet extends Tool
     {
         $validated = $request->validated();
         $name = $validated['name'];
-        $response = "Hello, {$name}!";
-        return $response;
+
+        return "Hello, {$name}!";
     }
 }
 

--- a/tests/Feature/CustomRequestValidationTest.php
+++ b/tests/Feature/CustomRequestValidationTest.php
@@ -12,6 +12,14 @@ class GreetingRequest extends Request
             'name' => 'required|string',
         ];
     }
+
+    public function messages(): array
+    {
+        return [
+            'name.required' => 'The name field is required.',
+            'name.string' => 'The name must be a string.',
+        ];
+    }
 }
 
 class GreetingServer extends Server
@@ -40,8 +48,8 @@ it('can use the custom request validation', function (): void {
     $response->assertSee('Hello, World!');
 });
 
-it('can throw validation errors', function (): void {
+it('can throw validation errors when required fields are missing', function (): void {
     $response = GreetingServer::tool(Greet::class, []);
 
-    $response->assertHasErrors();
+    $response->assertHasErrors(['name' => 'The name field is required.']);
 });

--- a/tests/Feature/CustomRequestValidationTest.php
+++ b/tests/Feature/CustomRequestValidationTest.php
@@ -16,8 +16,15 @@ class GreetingRequest extends Request
     public function messages(): array
     {
         return [
-            'name.required' => 'The name field is required.',
-            'name.string' => 'The name must be a string.',
+            'name.required' => 'The :attribute field is required.',
+            'name.string' => 'The :attribute must be a string.',
+        ];
+    }
+
+    public function attributes(): array
+    {
+        return [
+            'name' => 'Name',
         ];
     }
 }
@@ -51,5 +58,5 @@ it('can use the custom request validation', function (): void {
 it('can throw validation errors when required fields are missing', function (): void {
     $response = GreetingServer::tool(Greet::class, []);
 
-    $response->assertHasErrors(['name' => 'The name field is required.']);
+    $response->assertHasErrors(['name' => 'The Name field is required.']);
 });

--- a/tests/Feature/CustomRequestValidationTest.php
+++ b/tests/Feature/CustomRequestValidationTest.php
@@ -47,8 +47,8 @@ class Greet extends Tool
     }
 }
 
-it('returns empty arrays for default validation helpers', function () {
-    $request = new Request();
+it('returns empty arrays for default validation helpers', function (): void {
+    $request = new Request;
 
     expect($request->rules())->toBe([]);
     expect($request->messages())->toBe([]);

--- a/tests/Feature/CustomRequestValidationTest.php
+++ b/tests/Feature/CustomRequestValidationTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Tool;
+
+class GreetingRequest extends Request
+{
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string',
+        ];
+    }
+}
+
+class GreetingServer extends Server
+{
+    protected array $tools = [
+        Greet::class,
+    ];
+}
+
+class Greet extends Tool
+{
+    public function handle(GreetingRequest $request): string
+    {
+        $validated = $request->validated();
+        $name = $validated['name'];
+        $response = "Hello, {$name}!";
+        return $response;
+    }
+}
+
+it('can use the custom request validation', function (): void {
+    $response = GreetingServer::tool(Greet::class, [
+        'name' => 'World',
+    ]);
+
+    $response->assertSee('Hello, World!');
+});
+
+it('can throw validation errors', function (): void {
+    $response = GreetingServer::tool(Greet::class, []);
+
+    $response->assertHasErrors();
+});

--- a/tests/Feature/CustomRequestValidationTest.php
+++ b/tests/Feature/CustomRequestValidationTest.php
@@ -47,6 +47,15 @@ class Greet extends Tool
     }
 }
 
+it('returns empty arrays for default validation helpers', function () {
+    $request = new Request();
+
+    expect($request->rules())->toBe([]);
+    expect($request->messages())->toBe([]);
+    expect($request->attributes())->toBe([]);
+    expect($request->validated())->toBe([]);
+});
+
 it('can use the custom request validation', function (): void {
     $response = GreetingServer::tool(Greet::class, [
         'name' => 'World',


### PR DESCRIPTION
Adds a method `validated` similar to formRequest so you can simply define the rules, messages and attributes & call validated on the request instead of having to rewrite it.

Example MCP Request
```php
<?php

namespace App\Mcp\Requests;

use Laravel\Mcp\Request;

class QueryMCPRequest extends Request
{
    public function rules()
    {
        return [
            'query' => 'required|string',
            'page' => 'nullable|page',
            'pageSize' => 'nullable|page_size',
        ];
    }
}
```

Example handling in a tool
```php
    ...
    public function handle(QueryMCPRequest $request): Response
    {
        $validated = $request->validated();
    ...
```
