### PR TITLE
Fix tool annotation type error when using custom Attributes

### DIFF
--- a/src/Server/Tool.php
+++ b/src/Server/Tool.php
@@ -9,8 +9,6 @@ use Laravel\Mcp\Server\Contracts\Tools\Annotation;
 use ReflectionAttribute;
 use ReflectionClass;
 
-use function is_a;
-
 abstract class Tool extends Primitive
 {
     /**
@@ -31,7 +29,7 @@ abstract class Tool extends Primitive
         // @phpstan-ignore-next-line
         return collect($reflection->getAttributes())
             ->map(fn (ReflectionAttribute $attributeReflection): object => $attributeReflection->newInstance())
-            ->filter(fn (object $attribute) => is_a($attribute, Annotation::class))
+            ->filter(fn (object $attribute): bool => $attribute instanceof Annotation)
             // @phpstan-ignore-next-line
             ->mapWithKeys(fn (Annotation $attribute): array => [$attribute->key() => $attribute->value])
             ->all();

--- a/src/Server/Tool.php
+++ b/src/Server/Tool.php
@@ -9,6 +9,8 @@ use Laravel\Mcp\Server\Contracts\Tools\Annotation;
 use ReflectionAttribute;
 use ReflectionClass;
 
+use function is_a;
+
 abstract class Tool extends Primitive
 {
     /**
@@ -29,6 +31,7 @@ abstract class Tool extends Primitive
         // @phpstan-ignore-next-line
         return collect($reflection->getAttributes())
             ->map(fn (ReflectionAttribute $attributeReflection): object => $attributeReflection->newInstance())
+            ->filter(fn (object $attribute) => is_a($attribute, Annotation::class))
             // @phpstan-ignore-next-line
             ->mapWithKeys(fn (Annotation $attribute): array => [$attribute->key() => $attribute->value])
             ->all();


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When defining a Tool that uses a custom Attribute, e.g.:
```php
#[MyCustomAttribute]
class CurrentWeatherTool extends Tool
{
   
}
```

An exception is thrown:
```php
Laravel\Mcp\Server\Tool::{closure:Laravel\Mcp\Server\Tool::annotations():33}(): Argument #1 ($attribute) must be of type Laravel\Mcp\Server\Contracts\Tools\Annotation, MyCustomAttribute given
```

This is because Tool::annotations() falsely assumes that all Attributes are of type `\Laravel\Mcp\Server\Contracts\Tools\Annotation` 

This pull request attempts to fix this problem by filtering the Attributes before generating the annotations.


P.S. Great work on this package, it's amazing! 🚀 
