### PR TITLE
[0.] Meta data on Tools

### DIFF
--- a/src/Server/Tool.php
+++ b/src/Server/Tool.php
@@ -20,6 +20,14 @@ abstract class Tool extends Primitive
     }
 
     /**
+     * @return array<string, string>
+     */
+    public function meta(): array
+    {
+        return [];
+    }
+
+    /**
      * @return array<string, mixed>
      */
     public function annotations(): array
@@ -51,7 +59,8 @@ abstract class Tool extends Primitive
      *     title?: string|null,
      *     description?: string|null,
      *     inputSchema?: array<string, mixed>,
-     *     annotations?: array<string, mixed>|object
+     *     annotations?: array<string, mixed>|object,
+     *     _meta?: array<string, string>
      * }
      */
     public function toArray(): array
@@ -66,6 +75,7 @@ abstract class Tool extends Primitive
                 fn (JsonSchema $schema): array => $this->schema($schema),
             )->toArray(),
             'annotations' => $annotations === [] ? (object) [] : $annotations,
+            '_meta' => $this->meta(),
         ];
     }
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -111,6 +111,7 @@ function expectedListToolsResponse(): array
                     ],
                     'annotations' => [],
                     'title' => 'Say Hi Tool',
+                    '_meta' => [],
                 ],
                 [
                     'name' => 'streaming-tool',
@@ -127,6 +128,7 @@ function expectedListToolsResponse(): array
                     ],
                     'annotations' => [],
                     'title' => 'Streaming Tool',
+                    '_meta' => [],
                 ],
             ],
         ],

--- a/tests/Unit/Methods/ListToolsTest.php
+++ b/tests/Unit/Methods/ListToolsTest.php
@@ -68,6 +68,7 @@ it('returns a valid list tools response', function (): void {
                     ],
                     'annotations' => (object) [],
                     'title' => 'Say Hi Tool',
+                    '_meta' => [],
                 ],
             ],
         ]);

--- a/tests/Unit/Resources/ListToolsTest.php
+++ b/tests/Unit/Resources/ListToolsTest.php
@@ -68,6 +68,7 @@ it('returns a valid list tools response', function (): void {
                     ],
                     'annotations' => (object) [],
                     'title' => 'Say Hi Tool',
+                    '_meta' => [],
                 ],
             ],
         ]);

--- a/tests/Unit/Tools/ToolTest.php
+++ b/tests/Unit/Tools/ToolTest.php
@@ -62,6 +62,18 @@ it('can be open world', function (): void {
     expect($tool->annotations()['openWorldHint'])->toBeTrue();
 });
 
+it('returns empty array when meta not defined', function (): void {
+    $tool = new TestTool;
+    expect($tool->meta())->toEqual([]);
+});
+
+it('returns meta when defined', function (): void {
+    $tool = new ToolWithMeta;
+    expect($tool->meta())->toEqual([
+        'foo' => 'bar',
+    ]);
+});
+
 it('can have multiple annotations', function (): void {
     $tool = new KitchenSinkTool;
     expect($tool->annotations())->toEqual([
@@ -122,4 +134,14 @@ class AnotherComplexToolName extends TestTool {}
 class CustomToolName extends TestTool
 {
     protected string $name = 'my_custom_tool_name';
+}
+
+class ToolWithMeta extends TestTool
+{
+    public function meta(): array
+    {
+        return [
+            'foo' => 'bar',
+        ];
+    }
 }


### PR DESCRIPTION
This is a first chunk for #78 issue.

Usage:
```
public function meta(): array
{
    return [
        'openai/outputTemplate' => 'ui://my-app/component',
    ];
}
```

[source](https://developers.openai.com/apps-sdk/plan/tools)