### PR TITLE
refactor: move to first class callable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "orchestra/testbench": "^8.36.0|^9.15.0|^10.6.0",
         "pestphp/pest": "^2.36.0|^3.8.4|^4.1.0",
         "phpstan/phpstan": "^2.1.27",
-        "rector/rector": "^2.1.7"
+        "rector/rector": "^2.2.4"
     },
     "autoload": {
         "psr-4": {

--- a/rector.php
+++ b/rector.php
@@ -21,5 +21,4 @@ return RectorConfig::configure()
         codingStyle: true,
         typeDeclarations: true,
         earlyReturn: true,
-        strictBooleans: true,
     )->withPhpSets(php81: true);

--- a/src/Server.php
+++ b/src/Server.php
@@ -144,7 +144,7 @@ abstract class Server
     {
         $this->boot();
 
-        $this->transport->onReceive(fn (string $message) => $this->handle($message));
+        $this->transport->onReceive($this->handle(...));
     }
 
     protected function boot(): void

--- a/src/Server/Middleware/ReorderJsonAccept.php
+++ b/src/Server/Middleware/ReorderJsonAccept.php
@@ -19,7 +19,7 @@ class ReorderJsonAccept
     {
         $accept = $request->header('Accept');
         if (is_string($accept) && str_contains($accept, ',')) {
-            $accept = array_map('trim', explode(',', $accept));
+            $accept = array_map(trim(...), explode(',', $accept));
         }
 
         if (! is_array($accept)) {

--- a/src/Server/Tool.php
+++ b/src/Server/Tool.php
@@ -63,7 +63,7 @@ abstract class Tool extends Primitive
             'title' => $this->title(),
             'description' => $this->description(),
             'inputSchema' => JsonSchema::object(
-                fn (JsonSchema $schema): array => $this->schema($schema),
+                $this->schema(...),
             )->toArray(),
             'annotations' => $annotations === [] ? (object) [] : $annotations,
         ];

--- a/tests/Unit/Server/Middleware/ReorderJsonAcceptTest.php
+++ b/tests/Unit/Server/Middleware/ReorderJsonAcceptTest.php
@@ -56,7 +56,7 @@ it('handles multiple json types correctly', function (): void {
     $middleware->handle($request, fn ($req): \Illuminate\Contracts\Routing\ResponseFactory|\Illuminate\Http\Response => response('test'));
 
     $accept = $request->header('Accept');
-    $parts = array_map('trim', explode(',', $accept));
+    $parts = array_map(trim(...), explode(',', $accept));
 
     expect($parts)->toMatchArray(['application/json', 'text/html', 'application/vnd.api+json', 'text/plain'])
         ->and(count($parts))->toBe(4);
@@ -71,7 +71,7 @@ it('handles accept header with quality values', function (): void {
     $middleware->handle($request, fn ($req): \Illuminate\Contracts\Routing\ResponseFactory|\Illuminate\Http\Response => response('test'));
 
     $accept = $request->header('Accept');
-    $parts = array_map('trim', explode(',', $accept));
+    $parts = array_map(trim(...), explode(',', $accept));
 
     expect($parts[0])->toBe('application/json;q=0.8');
 });


### PR DESCRIPTION
Matches rector 2.2.4

Fixes CI issue on https://github.com/laravel/mcp/pull/93 and on main scheduled task https://github.com/laravel/mcp/actions/runs/18733294311