### PR TITLE
Add Meta and Structured Content to tool response

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -19,12 +19,52 @@ class Response
     use Conditionable;
     use Macroable;
 
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $meta = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $structured_content = [];
+
     protected function __construct(
         protected Content $content,
         protected Role $role = Role::USER,
         protected bool $isError = false,
     ) {
         //
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $meta
+     * @return ($meta is null ? array<string, mixed> : self)
+     */
+    public function meta(?array $meta = null): array|self
+    {
+        if (is_null($meta)) {
+            return $this->meta;
+        }
+
+        $this->meta = array_merge($this->meta, $meta);
+
+        return $this;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $structuredContent
+     * @return ($structuredContent is null ? array<string, mixed> : self)
+     */
+    public function structuredContent(?array $structuredContent = null): array|self
+    {
+        if (is_null($structuredContent)) {
+            return $this->structured_content;
+        }
+
+        $this->structured_content = array_merge($this->structured_content, $structuredContent);
+
+        return $this;
     }
 
     /**

--- a/src/Server/Methods/CallTool.php
+++ b/src/Server/Methods/CallTool.php
@@ -61,13 +61,20 @@ class CallTool implements Errable, Method
     }
 
     /**
-     * @return callable(Collection<int, Response>): array{content: array<int, array<string, mixed>>, isError: bool}
+     * @return callable(Collection<int, Response>):array{
+     *     _meta?: array<string, mixed>,
+     *     content?: array<int, array<string, mixed>>,
+     *     isError?: bool,
+     *     structuredContent?: array<string, mixed>,
+     * }
      */
     protected function serializable(Tool $tool): callable
     {
-        return fn (Collection $responses): array => [
+        return fn (Collection $responses): array => array_filter([
             'content' => $responses->map(fn (Response $response): array => $response->content()->toTool($tool))->all(),
             'isError' => $responses->contains(fn (Response $response): bool => $response->isError()),
-        ];
+            'structuredContent' => $responses->flatMap(fn (Response $response): array => $response->structuredContent())->all(),
+            '_meta' => $responses->flatMap(fn (Response $response): array => $response->meta())->all(),
+        ], filled(...));
     }
 }

--- a/tests/Unit/ResponseTest.php
+++ b/tests/Unit/ResponseTest.php
@@ -122,3 +122,31 @@ it('handles empty array in json response', function (): void {
     $content = $response->content();
     expect((string) $content)->toBe(json_encode($data, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
 });
+
+it('handles adding meta to a text response', function (): void {
+    $response = Response::text('Hello world')
+        ->meta(['key1' => 'value1', 'key2' => 2]);
+
+    expect($response->content())->toBeInstanceOf(Text::class);
+    expect($response->isNotification())->toBeFalse();
+    expect($response->isError())->toBeFalse();
+    expect($response->role())->toBe(Role::USER);
+    expect($response->meta())->toEqual(['key1' => 'value1', 'key2' => 2]);
+});
+
+it('handles adding structured content to a text response', function (): void {
+    $response = Response::text('Hello world')
+        ->structuredContent([
+            'section1' => ['item1', 'item2'],
+            'section2' => ['item3', 'item4'],
+        ]);
+
+    expect($response->content())->toBeInstanceOf(Text::class);
+    expect($response->isNotification())->toBeFalse();
+    expect($response->isError())->toBeFalse();
+    expect($response->role())->toBe(Role::USER);
+    expect($response->structuredContent())->toEqual([
+        'section1' => ['item1', 'item2'],
+        'section2' => ['item3', 'item4'],
+    ]);
+});


### PR DESCRIPTION
A few new fluent methods have been added to the `text()` response type for `meta()` and `structuredContent()`. You may use the methods as a getter or setter for the corresponding property.

These properties are then read in the `CallTool` method and returned in the response, if they're available. 

Example:

```php
#[IsReadOnly()]
class WeatherTool extends Tool
{
    // ...

    /**
     * Handle the tool request.
     */
    public function handle(Request $request, WeatherData $weatherData): Response
    {
        $city = $request->get('city');

        return Response::text("Here is the current weather information you requested for {$city}.")
            ->meta(['route' => 'weather'])
            ->structuredContent($weatherData->handle());
    }
```

Ref #99 