### PR TITLE
fix: allow multi-segment issuer paths

### DIFF
--- a/src/Server/Registrar.php
+++ b/src/Server/Registrar.php
@@ -89,7 +89,7 @@ class Registrar
             'resource' => url('/'.$path),
             'authorization_servers' => [url('/'.$path)],
             'scopes_supported' => ['mcp:use'],
-        ]))->name('mcp.oauth.protected-resource');
+        ]))->where('path', '.*')->name('mcp.oauth.protected-resource');
 
         Router::get('/.well-known/oauth-authorization-server/{path?}', fn (?string $path = '') => response()->json([
             'issuer' => url('/'.$path),
@@ -100,7 +100,7 @@ class Registrar
             'code_challenge_methods_supported' => ['S256'],
             'scopes_supported' => ['mcp:use'],
             'grant_types_supported' => ['authorization_code', 'refresh_token'],
-        ]))->name('mcp.oauth.authorization-server');
+        ]))->where('path', '.*')->name('mcp.oauth.authorization-server');
 
         Router::post($oauthPrefix.'/register', OAuthRegisterController::class);
     }

--- a/tests/Unit/Server/RegistrarTest.php
+++ b/tests/Unit/Server/RegistrarTest.php
@@ -269,3 +269,96 @@ it('handles oauth registration with incorrect redirect domain', function (): voi
 
     $response->assertStatus(422);
 });
+
+it('handles oauth discovery with multi-segment paths', function (): void {
+    // Fake Passport's routes so the oauthRoutes() helper can resolve them.
+    Route::get('/oauth/authorize')->name('passport.authorizations.authorize');
+    Route::post('/oauth/token')->name('passport.token');
+
+    $registrar = new Registrar;
+    $registrar->oauthRoutes();
+
+    // Test protected resource endpoint with multi-segment path
+    $response = $this->getJson('/.well-known/oauth-protected-resource/mcp/weather');
+
+    $response->assertStatus(200);
+    $response->assertJson([
+        'resource' => url('/mcp/weather'),
+        'authorization_servers' => [url('/mcp/weather')],
+        'scopes_supported' => ['mcp:use'],
+    ]);
+
+    // Test authorization server endpoint with multi-segment path
+    $response = $this->getJson('/.well-known/oauth-authorization-server/mcp/weather');
+
+    $response->assertStatus(200);
+    $response->assertJsonStructure([
+        'issuer',
+        'authorization_endpoint',
+        'token_endpoint',
+        'registration_endpoint',
+        'response_types_supported',
+        'code_challenge_methods_supported',
+        'scopes_supported',
+        'grant_types_supported',
+    ]);
+    $response->assertJson([
+        'issuer' => url('/mcp/weather'),
+        'scopes_supported' => ['mcp:use'],
+        'response_types_supported' => ['code'],
+        'code_challenge_methods_supported' => ['S256'],
+        'grant_types_supported' => ['authorization_code', 'refresh_token'],
+    ]);
+});
+
+it('handles oauth discovery with single segment paths', function (): void {
+    // Fake Passport's routes so the oauthRoutes() helper can resolve them.
+    Route::get('/oauth/authorize')->name('passport.authorizations.authorize');
+    Route::post('/oauth/token')->name('passport.token');
+
+    $registrar = new Registrar;
+    $registrar->oauthRoutes();
+
+    // Test backward compatibility with single-segment paths
+    $response = $this->getJson('/.well-known/oauth-protected-resource/mcp');
+
+    $response->assertStatus(200);
+    $response->assertJson([
+        'resource' => url('/mcp'),
+        'authorization_servers' => [url('/mcp')],
+        'scopes_supported' => ['mcp:use'],
+    ]);
+
+    $response = $this->getJson('/.well-known/oauth-authorization-server/mcp');
+
+    $response->assertStatus(200);
+    $response->assertJson([
+        'issuer' => url('/mcp'),
+    ]);
+});
+
+it('handles oauth discovery with no path', function (): void {
+    // Fake Passport's routes so the oauthRoutes() helper can resolve them.
+    Route::get('/oauth/authorize')->name('passport.authorizations.authorize');
+    Route::post('/oauth/token')->name('passport.token');
+
+    $registrar = new Registrar;
+    $registrar->oauthRoutes();
+
+    // Test with no path (root)
+    $response = $this->getJson('/.well-known/oauth-protected-resource');
+
+    $response->assertStatus(200);
+    $response->assertJson([
+        'resource' => url('/'),
+        'authorization_servers' => [url('/')],
+        'scopes_supported' => ['mcp:use'],
+    ]);
+
+    $response = $this->getJson('/.well-known/oauth-authorization-server');
+
+    $response->assertStatus(200);
+    $response->assertJson([
+        'issuer' => url('/'),
+    ]);
+});


### PR DESCRIPTION
### What does this PR do?
Adds support for multi-segment issuer paths in the OAuth well-known endpoints registered by `Registrar::oauthRoutes()`.

### Why is this needed?
According to the OAuth 2.1 / OpenID Connect Discovery specification, the `issuer` URI may contain path segments (e.g. `https://api.example.com/mcp/weather`).  
Previously, the route definition only matched a single path segment, so requests to nested issuers like `/mcp/weather` were not discoverable.

This patch updates both the `/.well-known/oauth-protected-resource/{path?}` and `/.well-known/oauth-authorization-server/{path?}` routes to allow multi-segment paths.

### How does this benefit users?
- Enables mounting MCP OAuth discovery routes under nested prefixes (e.g. `https://example.com/mcp/weather`).  
- Maintains backward compatibility for single-segment and root-level issuers.  
- Aligns with OAuth 2.1 / OIDC Discovery, which permits issuer URIs with sub-paths.  

### What changed?
- Updated the `.well-known` routes to use `.where('path', '.*')`, allowing multiple path segments.  
- No behavioural changes for existing single-segment or root-level issuers.

### Breaking changes?
None.

### Tests
Added new tests in `tests/Unit/Server/RegistrarTest.php`:
- `it('handles oauth discovery with multi-segment paths')`
- `it('handles oauth discovery with single segment paths')`
- `it('handles oauth discovery with no path')`

These verify correct JSON responses and ensure backward compatibility across all cases.

### References
- [OpenID Connect Discovery 1.0 §2](https://openid.net/specs/openid-connect-discovery-1_0-final.html#:~:text=optionally%2C%20port%20and%20path%20components) — issuer URIs may include path components.  
- [Laravel MCP documentation](https://laravel.com/docs/12.x/mcp#web-servers:~:text=Mcp%3A%3Aweb(%27/-,mcp/weather,-%27%2C%20WeatherServer%3A%3Aclass)%3B) — official example shows `/mcp/weather` as a nested path.