### PR TITLE
Add `2025-11-25` to supported `protocolVersion`

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -47,6 +47,7 @@ abstract class Server
      * @var array<int, string>
      */
     protected array $supportedProtocolVersion = [
+        '2025-11-25',
         '2025-06-18',
         '2025-03-26',
         '2024-11-05',

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -69,7 +69,7 @@ function expectedInitializeResponse(): array
         'jsonrpc' => '2.0',
         'id' => 456,
         'result' => [
-            'protocolVersion' => '2025-06-18',
+            'protocolVersion' => '2025-11-25',
             'capabilities' => $capabilities,
             'serverInfo' => [
                 'name' => $name,


### PR DESCRIPTION
Add Support for the new MCP spec 2025-11-25

Changelog: https://modelcontextprotocol.io/specification/2025-11-25/changelog