### PR TITLE
Bump Laravel version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
         "php": "^8.1",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "illuminate/container": "^10.49.0|^11.45.3|^12.28.1",
-        "illuminate/console": "^10.49.0|^11.45.3|^12.28.1",
-        "illuminate/contracts": "^10.49.0|^11.45.3|^12.28.1",
-        "illuminate/http": "^10.49.0|^11.45.3|^12.28.1",
-        "illuminate/routing": "^10.49.0|^11.45.3|^12.28.1",
-        "illuminate/support": "^10.49.0|^11.45.3|^12.28.1",
-        "illuminate/validation": "^10.49.0|^11.45.3|^12.28.1",
-        "illuminate/json-schema": "^12.28.1"
+        "illuminate/container": "^10.49.0|^11.45.3|^12.41.1",
+        "illuminate/console": "^10.49.0|^11.45.3|^12.41.1",
+        "illuminate/contracts": "^10.49.0|^11.45.3|^12.41.1",
+        "illuminate/http": "^10.49.0|^11.45.3|^12.41.1",
+        "illuminate/routing": "^10.49.0|^11.45.3|^12.41.1",
+        "illuminate/support": "^10.49.0|^11.45.3|^12.41.1",
+        "illuminate/validation": "^10.49.0|^11.45.3|^12.41.1",
+        "illuminate/json-schema": "^12.41.1"
     },
     "require-dev": {
         "laravel/pint": "^1.20",


### PR DESCRIPTION
The commit https://github.com/laravel/mcp/commit/2e662d0d13663fa2dc9fbed28e059ba30f065a25 requires the changes introduced in `illuminate/json-schema` by https://github.com/laravel/framework/commit/c387cbd0acaae9a3c880f5d64df898db984237bf, specifically the update that makes `JsonSchemaTypeFactory` implement `JsonSchemaContract`.

Without this change, you encounter the following error when trying to connect to an MCP server:

```
local.ERROR: Laravel\Mcp\Server\Tool::schema(): Argument #1 ($schema) must be of type Illuminate\Contracts\JsonSchema\JsonSchema, Illuminate\JsonSchema\JsonSchemaTypeFactory given, called in /var/www/html/vendor/laravel/framework/src/Illuminate/JsonSchema/JsonSchemaTypeFactory.php on line 17
```

The issue is that the required framework commit only exists starting from Laravel 12.40.2, whereas this package currently requires a minimum version of 12.28.1. Since I had an older version installed locally (12.36), it took some time to understand why connecting to the MCP failed (the error messages you get are not very helpful).

To prevent future users from running into the same problem, I bumped the required Laravel version to the most recent release (12.41.1).
