### PR TITLE
Fix JSON-RPC notification param serialization

### DIFF
--- a/src/Server/Testing/TestResponse.php
+++ b/src/Server/Testing/TestResponse.php
@@ -32,7 +32,7 @@ class TestResponse
      * @param  iterable<int, JsonRpcResponse>|JsonRpcResponse  $response
      */
     public function __construct(
-        protected Primitive $premitive,
+        protected Primitive $primitive,
         iterable|JsonRpcResponse $response,
     ) {
         $responses = is_iterable($response)
@@ -133,8 +133,8 @@ class TestResponse
     {
         Assert::assertEquals(
             $name,
-            $this->premitive->name(),
-            "The expected name [{$name}] does not match the actual name [{$this->premitive->name()}].",
+            $this->primitive->name(),
+            "The expected name [{$name}] does not match the actual name [{$this->primitive->name()}].",
         );
 
         return $this;
@@ -144,8 +144,8 @@ class TestResponse
     {
         Assert::assertEquals(
             $title,
-            $this->premitive->title(),
-            "The expected title [{$title}] does not match the actual title [{$this->premitive->title()}].",
+            $this->primitive->title(),
+            "The expected title [{$title}] does not match the actual title [{$this->primitive->title()}].",
         );
 
         return $this;
@@ -155,8 +155,8 @@ class TestResponse
     {
         Assert::assertEquals(
             $description,
-            $this->premitive->description(),
-            "The expected description [{$description}] does not match the actual description [{$this->premitive->description()}].",
+            $this->primitive->description(),
+            "The expected description [{$description}] does not match the actual description [{$this->primitive->description()}].",
         );
 
         return $this;
@@ -306,14 +306,14 @@ class TestResponse
     {
         return (match (true) {
             // @phpstan-ignore-next-line
-            $this->premitive instanceof Tool => collect($this->response->toArray()['result']['content'] ?? [])
+            $this->primitive instanceof Tool => collect($this->response->toArray()['result']['content'] ?? [])
                 ->map(fn (array $message): string => $message['text'] ?? ''),
             // @phpstan-ignore-next-line
-            $this->premitive instanceof Prompt => collect($this->response->toArray()['result']['messages'] ?? [])
+            $this->primitive instanceof Prompt => collect($this->response->toArray()['result']['messages'] ?? [])
                 ->map(fn (array $message): array => $message['content'])
                 ->map(fn (array $content): string => $content['text'] ?? ''),
             // @phpstan-ignore-next-line
-            $this->premitive instanceof Resource => collect($this->response->toArray()['result']['contents'] ?? [])
+            $this->primitive instanceof Resource => collect($this->response->toArray()['result']['contents'] ?? [])
                 ->map(fn (array $item): string => $item['text'] ?? $item['blob'] ?? ''),
             default => throw new RuntimeException('This primitive type is not supported.'),
         })->filter()->unique()->values()->all();

--- a/src/Server/Transport/JsonRpcResponse.php
+++ b/src/Server/Transport/JsonRpcResponse.php
@@ -34,7 +34,7 @@ class JsonRpcResponse implements Arrayable
     {
         return new static([
             'method' => $method,
-            'params' => $params,
+            'params' => $params === [] ? (object) [] : $params,
         ]);
     }
 

--- a/tests/Unit/Transport/JsonRpcResponseTest.php
+++ b/tests/Unit/Transport/JsonRpcResponseTest.php
@@ -70,3 +70,27 @@ it('does not include _meta when not in result', function (): void {
 
     expect($response->toArray()['result'])->not->toHaveKey('_meta');
 });
+
+it('can create a notification with params', function (): void {
+    $response = JsonRpcResponse::notification('notifications/progress', ['progress' => 50]);
+
+    $expectedArray = [
+        'jsonrpc' => '2.0',
+        'method' => 'notifications/progress',
+        'params' => ['progress' => 50],
+    ];
+
+    expect($response->toArray())->toEqual($expectedArray);
+});
+
+it('converts empty array params in notification to object', function (): void {
+    $response = JsonRpcResponse::notification('notifications/initialized', []);
+
+    $expectedJson = json_encode([
+        'jsonrpc' => '2.0',
+        'method' => 'notifications/initialized',
+        'params' => (object) [],
+    ]);
+
+    expect($response->toJson())->toEqual($expectedJson);
+});


### PR DESCRIPTION
Hello,

This PR fixes an interop issues caused by PHP JSON serialization, correctly, of `[]` (PHP empty array) into `[]` (JSON empty array). But MCP notifications expect params to be an object, even if it's empty.

Here is the link from the specification.

https://modelcontextprotocol.io/specification/2025-03-26/basic?utm_source=chatgpt.com#notifications

**User benefits**

- Prevents empty notifications from being rejected due to shape (this is how I discovered this using the MCP Inspector)
- Removes a subtle PHP-specific edge case for users implement MCP with Laravel.

**Safety**

- This is safe because it only affects the empty case. Non-empty arrays (associative arrays) will be correctly serialized into objects as expected.

**Tests**

- Added test confirmining that `[]` params pass.
- Non-empty arrays are unaffected.

I had earlier on discovered a meaningless typo, that I did not intend to bring up, but since I am submitting a PR anyway I figured that would be okay to resolve.

**Other options**

I do see that the spec allows for `params` to be omitted entirely, but I consider that a larger and potentially more risky resolution.

```ts
{
  jsonrpc: "2.0";
  method: string;
  params?: {
    [key: string]: unknown;
  };
}
```

**AI**

I delegated the fix for this to GitHub Copilot. I have reviewed and verified the fix.