### PR TITLE
Add host and port options to MCP Inspector command

### DIFF
--- a/src/Console/Commands/InspectorCommand.php
+++ b/src/Console/Commands/InspectorCommand.php
@@ -62,13 +62,11 @@ class InspectorCommand extends Command
 
         $env = [];
 
-        $host = $this->option('host');
-        if (is_string($host)) {
+        if (is_string($host = $this->option('host'))) {
             $env['HOST'] = $host;
         }
 
-        $port = $this->option('port');
-        if (is_string($port)) {
+        if (is_string($port = $this->option('port'))) {
             $env['CLIENT_PORT'] = $port;
         }
 


### PR DESCRIPTION
The MCP Inspector command now accepts optional `—host` and `—port` options to configure where the inspector should bind. These options are passed to the Node.js inspector tool via environment variables (HOST and CLIENT_PORT).

- Add an import for InputOption.
- Support the `—host` option (optional, passed as the HOST environment variable).
- Support the `—port` option (optional, passed as the CLIENT_PORT environment variable).
- Add tests to verify that the options are properly configured.
