### PR TITLE
Change JSON response formatting to compact by default

### DIFF
--- a/config/mcp.php
+++ b/config/mcp.php
@@ -20,17 +20,4 @@ return [
         // 'https://example.com',
     ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | JSON Response Formatting
-    |--------------------------------------------------------------------------
-    |
-    | This option controls whether JSON responses use pretty-printing with
-    | indentation and line breaks. Pretty-printing improves readability
-    | for humans, but will increase your agent's token usage by ~40%.
-    |
-    */
-
-    'pretty_json' => env('MCP_PRETTY_JSON', true),
-
 ];

--- a/src/Response.php
+++ b/src/Response.php
@@ -48,15 +48,7 @@ class Response
      */
     public static function json(mixed $content): static
     {
-        $flags = JSON_THROW_ON_ERROR;
-
-        if (config('mcp.pretty_json', true)) {
-            $flags |= JSON_PRETTY_PRINT;
-        } else {
-            $flags |= JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
-        }
-
-        return static::text(json_encode($content, $flags));
+        return static::text(json_encode($content, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
     }
 
     public static function blob(string $content): static
@@ -76,15 +68,7 @@ class Response
         }
 
         try {
-            $flags = JSON_THROW_ON_ERROR;
-
-            if (config('mcp.pretty_json', true)) {
-                $flags |= JSON_PRETTY_PRINT;
-            } else {
-                $flags |= JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
-            }
-
-            $json = json_encode($response, $flags);
+            $json = json_encode($response, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
         } catch (JsonException $jsonException) {
             throw new InvalidArgumentException("Invalid structured content: {$jsonException->getMessage()}", 0, $jsonException);
         }

--- a/tests/Unit/Methods/CallToolTest.php
+++ b/tests/Unit/Methods/CallToolTest.php
@@ -395,7 +395,7 @@ it('returns structured content in tool response', function (): void {
         ])
         ->and($payload['result']['content'])->toHaveCount(1)
         ->and($payload['result']['content'][0]['type'])->toBe('text')
-        ->and($payload['result']['content'][0]['text'])->toContain('"temperature": 22.5')
+        ->and($payload['result']['content'][0]['text'])->toContain('"temperature":22.5')
         ->and($payload['result']['isError'])->toBeFalse();
 });
 

--- a/tests/Unit/ResponseFactoryTest.php
+++ b/tests/Unit/ResponseFactoryTest.php
@@ -81,7 +81,7 @@ it('creates a structured content response with Response::structured', function (
 
     $textResponse = $factory->responses()->first();
     expect($textResponse->content()->toArray()['text'])
-        ->toContain('"result": "The result of the tool."');
+        ->toContain('"result":"The result of the tool."');
 });
 
 it('creates a structured content response with meta using Response::structured', function (): void {

--- a/tests/Unit/ResponseTest.php
+++ b/tests/Unit/ResponseTest.php
@@ -86,7 +86,7 @@ it('creates a json response', function (): void {
         ->and($response->role())->toBe(Role::User);
 
     $content = $response->content();
-    expect((string) $content)->toBe(json_encode($data, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+    expect((string) $content)->toBe(json_encode($data, JSON_THROW_ON_ERROR));
 });
 
 it('handles nested arrays in json response', function (): void {
@@ -103,7 +103,7 @@ it('handles nested arrays in json response', function (): void {
     expect($response->content())->toBeInstanceOf(Text::class);
 
     $content = $response->content();
-    expect((string) $content)->toBe(json_encode($data, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+    expect((string) $content)->toBe(json_encode($data, JSON_THROW_ON_ERROR));
 });
 
 it('throws JsonException for invalid json data', function (): void {
@@ -121,7 +121,7 @@ it('handles empty array in json response', function (): void {
     expect($response->content())->toBeInstanceOf(Text::class);
 
     $content = $response->content();
-    expect((string) $content)->toBe(json_encode($data, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+    expect((string) $content)->toBe(json_encode($data, JSON_THROW_ON_ERROR));
 });
 
 it('creates text response with content meta', function (): void {
@@ -178,58 +178,13 @@ it('throws exception when an array contains null', function (): void {
     );
 });
 
-it('creates json response with pretty printing when config is true', function (): void {
-    config(['mcp.pretty_json' => true]);
-
+it('creates compact json response', function (): void {
     $data = ['key' => 'value', 'number' => 123];
     $response = Response::json($data);
 
     expect($response->content())->toBeInstanceOf(Text::class);
 
     $content = (string) $response->content();
-    expect($content)->toBe(json_encode($data, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT))
-        ->and($content)->toContain("\n")
-        ->and($content)->toContain('    ');
-});
-
-it('creates json response without pretty printing when config is false', function (): void {
-    config(['mcp.pretty_json' => false]);
-
-    $data = ['key' => 'value', 'number' => 123];
-    $response = Response::json($data);
-
-    expect($response->content())->toBeInstanceOf(Text::class);
-
-    $content = (string) $response->content();
-    $expectedFlags = JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
-    expect($content)->toBe(json_encode($data, $expectedFlags))
-        ->and($content)->not->toContain("\n")
-        ->and($content)->toBe('{"key":"value","number":123}');
-});
-
-it('compact json reduces token usage significantly', function (): void {
-    $data = [
-        'user_id' => '42',
-        'name' => 'S2S token',
-        'project_roles' => [
-            ['project_id' => '1', 'project_name' => 'Project A', 'role_name' => 'owner'],
-        ],
-    ];
-
-    // Pretty version
-    config(['mcp.pretty_json' => true]);
-    $prettyResponse = Response::json($data);
-    $prettyContent = (string) $prettyResponse->content();
-
-    // Compact version
-    config(['mcp.pretty_json' => false]);
-    $compactResponse = Response::json($data);
-    $compactContent = (string) $compactResponse->content();
-
-    $prettySizeKb = strlen($prettyContent);
-    $compactSizeKb = strlen($compactContent);
-    $savings = round((1 - $compactSizeKb / $prettySizeKb) * 100, 1);
-
-    expect($compactSizeKb)->toBeLessThan($prettySizeKb)
-        ->and($savings)->toBeGreaterThan(30); // At least 30% savings
+    expect($content)->toBe('{"key":"value","number":123}')
+        ->and($content)->not->toContain("\n");
 });


### PR DESCRIPTION
 The configurable `mcp.pretty_json` parameter has been removed from #150.  This defaultes to compact JSON output (`JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE`).

-  All MCP inspector tools and clients already have built-in JSON formatting, so pretty-printed JSON from the server is unnecessary.
-  Agents consuming tool responses don’t benefit from formatted JSON.  Compact output reduces token usage without any loss of functionality.
-  No feature flag is needed as this is purely a transport optimisation with no impact on parsed data.