### PR TITLE
Update stubs to use attribute syntax

### DIFF
--- a/stubs/mcp-prompt.stub
+++ b/stubs/mcp-prompt.stub
@@ -4,21 +4,13 @@ namespace {{ namespace }};
 
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
 use Laravel\Mcp\Server\Prompt;
 use Laravel\Mcp\Server\Prompts\Argument;
 
+#[Description('A description of what this prompt does.')]
 class {{ class }} extends Prompt
 {
-    /**
-     * The prompt's description.
-     */
-    protected string $description = <<<'MARKDOWN'
-        A description of what this prompt does.
-    MARKDOWN;
-
-    /**
-     * Handle the prompt request.
-     */
     public function handle(Request $request): Response
     {
         //
@@ -27,8 +19,6 @@ class {{ class }} extends Prompt
     }
 
     /**
-     * Get the prompt's arguments.
-     *
      * @return array<int, \Laravel\Mcp\Server\Prompts\Argument>
      */
     public function arguments(): array

--- a/stubs/mcp-resource.stub
+++ b/stubs/mcp-resource.stub
@@ -2,22 +2,14 @@
 
 namespace {{ namespace }};
 
-use Laravel\Mcp\Server\Resource;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Resource;
 
+#[Description('A description of what this resource contains.')]
 class {{ class }} extends Resource
 {
-    /**
-     * The resource's description.
-     */
-    protected string $description = <<<'MARKDOWN'
-        A description of what this resource contains.
-    MARKDOWN;
-
-    /**
-     * Handle the resource request.
-     */
     public function handle(Request $request): Response
     {
         //

--- a/stubs/mcp-server.stub
+++ b/stubs/mcp-server.stub
@@ -3,49 +3,23 @@
 namespace {{ namespace }};
 
 use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Attributes\Instructions;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Attributes\Version;
 
+#[Name('{{ serverDisplayName }}')]
+#[Version('0.0.1')]
+#[Instructions('Instructions describing how to use the server and its features.')]
 class {{ class }} extends Server
 {
-    /**
-     * The MCP server's name.
-     */
-    protected string $name = '{{ serverDisplayName }}';
-
-    /**
-     * The MCP server's version.
-     */
-    protected string $version = '0.0.1';
-
-    /**
-     * The MCP server's instructions for the LLM.
-     */
-    protected string $instructions = <<<'MARKDOWN'
-        Instructions describing how to use the server and its features.
-    MARKDOWN;
-
-    /**
-     * The tools registered with this MCP server.
-     *
-     * @var array<int, class-string<\Laravel\Mcp\Server\Tool>>
-     */
     protected array $tools = [
         //
     ];
 
-    /**
-     * The resources registered with this MCP server.
-     *
-     * @var array<int, class-string<\Laravel\Mcp\Server\Resource>>
-     */
     protected array $resources = [
         //
     ];
 
-    /**
-     * The prompts registered with this MCP server.
-     *
-     * @var array<int, class-string<\Laravel\Mcp\Server\Prompt>>
-     */
     protected array $prompts = [
         //
     ];

--- a/stubs/mcp-tool.stub
+++ b/stubs/mcp-tool.stub
@@ -5,20 +5,12 @@ namespace {{ namespace }};
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
 use Laravel\Mcp\Server\Tool;
 
+#[Description('A description of what this tool does.')]
 class {{ class }} extends Tool
 {
-    /**
-     * The tool's description.
-     */
-    protected string $description = <<<'MARKDOWN'
-        A description of what this tool does.
-    MARKDOWN;
-
-    /**
-     * Handle the tool request.
-     */
     public function handle(Request $request): Response
     {
         //
@@ -27,8 +19,6 @@ class {{ class }} extends Tool
     }
 
     /**
-     * Get the tool's input schema.
-     *
      * @return array<string, \Illuminate\Contracts\JsonSchema\JsonSchema>
      */
     public function schema(JsonSchema $schema): array


### PR DESCRIPTION
The stubs still use protected property declarations for server/primitive configuration (`$name`, `$version`, `$instructions`, `$description`). This updates them to use the PHP attribute syntax introduced in #154, so newly generated classes follow the recommended pattern.

### Approach

- Replace property declarations with `#[Name]`, `#[Version]`, `#[Instructions]`, and `#[Description]` attributes across all four stubs
- Remove doc-block comments that described the replaced properties