### PR TITLE
Remove incorrect Response::structured docblock throw

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -61,8 +61,6 @@ class Response
 
     /**
      * @param  array<string, mixed>  $response
-     *
-     * @throws JsonException
      */
     public static function structured(array $response): ResponseFactory
     {


### PR DESCRIPTION
I noticed that the structured function on the Response object says it throws a JsonException, when in reality it catches the JsonException and throws an InvalidArgumentException. My PHPStorm is very unhappy that I am catching the "wrong" exception and would love to get rid of this warning.