### PR TITLE
Add facade documenter workflow and sync Mcp facade docblocks

### DIFF
--- a/.github/workflows/facade.yml
+++ b/.github/workflows/facade.yml
@@ -1,0 +1,46 @@
+name: facades
+
+on:
+  push:
+    branches:
+      - main
+      - '*.x'
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: true
+
+    name: Facade DocBlocks
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: "composer config repositories.facade-documenter vcs git@github.com:laravel/facade-documenter.git && composer require --dev laravel/facade-documenter:dev-main"
+
+      - name: Update facade docblocks
+        run: php -f vendor/bin/facade.php -- Laravel\\Mcp\\Facades\\Mcp
+
+      - name: Commit facade docblocks
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Update facade docblocks
+          file_pattern: src/

--- a/src/Facades/Mcp.php
+++ b/src/Facades/Mcp.php
@@ -10,9 +10,12 @@ use Laravel\Mcp\Server\Registrar;
 
 /**
  * @method static void local(string $handle, string $serverClass)
- * @method static Route web(string $handle, string $serverClass)
+ * @method static Route web(string $route, string $serverClass)
  * @method static callable|null getLocalServer(string $handle)
- * @method static string|null getWebServer(string $handle)
+ * @method static Route|null getWebServer(string $route)
+ * @method static array<string, callable|Route> servers()
+ * @method static void oauthRoutes(string $oauthPrefix = 'oauth')
+ * @method static array<string, string> ensureMcpScope()
  *
  * @see Registrar
  */


### PR DESCRIPTION
The Mcp facade docblock was out of sync with the Registrar's public API, and there was no automated way to keep it up to date.

### Approach

- Adds a GitHub Actions workflow that runs laravel/facade-documenter on every push to main and version branches, automatically committing updated docblocks
- Syncs the current facade docblock to reflect the actual Registrar public methods (corrected return type on `getWebServer`, added `servers`, `oauthRoutes`, and `ensureMcpScope`)