### PR TITLE
Fix CI failures in facade documenter and static analysis

### DIFF
--- a/src/Facades/Mcp.php
+++ b/src/Facades/Mcp.php
@@ -17,7 +17,7 @@ use Laravel\Mcp\Server\Registrar;
  * @method static void oauthRoutes(string $oauthPrefix = 'oauth')
  * @method static array<string, string> ensureMcpScope()
  *
- * @see Registrar
+ * @see \Laravel\Mcp\Server\Registrar
  */
 class Mcp extends Facade
 {

--- a/src/Server/Concerns/HasAnnotations.php
+++ b/src/Server/Concerns/HasAnnotations.php
@@ -29,7 +29,7 @@ trait HasAnnotations
             ->each(function (AnnotationContract $attribute): void {
                 $this->validateAnnotationUsage($attribute);
             })
-            ->mapWithKeys(fn (AnnotationContract $attribute): array => [
+            ->mapWithKeys(fn (AnnotationContract $attribute): array => [ // @phpstan-ignore argument.templateType
                 $attribute->key() => $attribute->value, // @phpstan-ignore property.notFound
             ])
             ->all();


### PR DESCRIPTION
Two unrelated CI jobs have been failing on every push to main since recent upstream changes.

### Approach

- The facade documenter reads `@see` tags and passes them directly to `ReflectionClass`. The short class name `Registrar` was used instead of the FQCN, causing a fatal error. Updated to `\Laravel\Mcp\Server\Registrar` to match how all other Laravel facades declare their `@see` tags.

- PHPStan 2.1.40 (picked up via the `^2.1.27` constraint) added stricter template type resolution for `mapWithKeys`. The existing `@phpstan-ignore` on the `each()` call above did not cover the `mapWithKeys` line, so a second ignore was added inline.