### PR TITLE
add stdio transport example to MCP registration

### DIFF
--- a/resources/boost/skills/mcp-development/SKILL.blade.php
+++ b/resources/boost/skills/mcp-development/SKILL.blade.php
@@ -29,7 +29,11 @@ Register MCP servers in `routes/ai.php`:
 @boostsnippet("Register MCP Server", "php")
 use Laravel\Mcp\Facades\Mcp;
 
+// Register an HTTP-based MCP server
 Mcp::web();
+
+// Or register a STDIO-based MCP server (for local MCP clients)
+Mcp::stdio();
 @endboostsnippet
 
 ### Creating MCP Primitives


### PR DESCRIPTION
This PR adds a `Mcp::stdio()` example alongside `Mcp::web()` in the MCP
Development skill.

Since MCP supports both HTTP and STDIO transports, documenting both
options makes the registration section more complete while keeping
the example minimal and easy to follow.