### PR TITLE
fix: use root URL for authorization_servers in oauth-protected-resource discovery 

### DIFF
--- a/src/Server/Registrar.php
+++ b/src/Server/Registrar.php
@@ -89,7 +89,7 @@ class Registrar
         static::ensureMcpScope();
         Router::get('/.well-known/oauth-protected-resource/{path?}', fn (?string $path = '') => response()->json([
             'resource' => url('/'.$path),
-            'authorization_servers' => [url('/'.$path)],
+            'authorization_servers' => [url('/')],
             'scopes_supported' => ['mcp:use'],
         ]))->where('path', '.*')->name('mcp.oauth.protected-resource');
 

--- a/tests/Unit/Server/RegistrarTest.php
+++ b/tests/Unit/Server/RegistrarTest.php
@@ -451,7 +451,7 @@ it('handles oauth discovery with multi-segment paths', function (): void {
     $response->assertStatus(200);
     $response->assertJson([
         'resource' => url('/mcp/weather'),
-        'authorization_servers' => [url('/mcp/weather')],
+        'authorization_servers' => [url('/')],
         'scopes_supported' => ['mcp:use'],
     ]);
 
@@ -492,7 +492,7 @@ it('handles oauth discovery with single segment paths', function (): void {
     $response->assertStatus(200);
     $response->assertJson([
         'resource' => url('/mcp'),
-        'authorization_servers' => [url('/mcp')],
+        'authorization_servers' => [url('/')],
         'scopes_supported' => ['mcp:use'],
     ]);
 


### PR DESCRIPTION
Tested with v0.5.3 / Laravel 12

##  Problem

The `/.well-known/oauth-protected-resource`  discovery endpoint returns as the  `authorization_servers`  URL instead of the root URL:  https://example.com/mcp/example instead of  https://example.com.

This causes strict OAuth clients like Claude Desktop to look for the authorization  server metadata at: 
https://example.com/mcp/example/.well-known/oauth-authorization-server

instead of the correct:
https://example.com/.well-known/oauth-authorization-server

The result is a McpAuthorizationError — the OAuth discovery fails silently and the client rejects the credentials after a successful authorization.

## Root cause
In oauthRoutes(), authorization_servers was set to url('/'.$path), which includes the MCP server path. The resource field correctly uses the path, but authorization_servers should always point to the root — there is one OAuth authorization server per application, regardless of how many MCP servers are registered.

## Fix
Return url('/') as authorization server instead of url('/' .$path).

## Steps to reproduce
1. Set up an MCP server with OAuth routes
2. Request /.well-known/oauth-protected-resource/mcp/your-server
3. Observe that authorization_servers contains the full MCP path instead of the base URL




