### PR TITLE
Use fully-qualified class string for Passport existence check

### DIFF
--- a/src/Server/Registrar.php
+++ b/src/Server/Registrar.php
@@ -112,7 +112,7 @@ class Registrar
      */
     public static function ensureMcpScope(): array
     {
-        if (class_exists('Laravel\Passport\Passport') === false) {
+        if (! class_exists('\Laravel\Passport\Passport')) {
             return [];
         }
 


### PR DESCRIPTION
This PR replaces the boolean string comparison with a fully-qualified class string for checking the existence of Laravel Passport.

Using `\Laravel\Passport\Passport` ensures:

- Cleaner and more readable code
- Safe execution even when Passport is not installed
- Alignment with Laravel best practices

No behavioral changes are introduced.