### PR TITLE
Update boost skill description and remove core guideline

### DIFF
--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -1,5 +1,0 @@
-# Laravel MCP
-
-- Laravel MCP allows you to rapidly build MCP servers for your Laravel applications.
-- IMPORTANT: laravel/mcp is very new. Always use the `search-docs` tool for authoritative documentation on writing and testing Laravel MCP servers, tools, resources, and prompts.
-- IMPORTANT: Activate `mcp-development` every time you're working with an MCP-related task.

--- a/resources/boost/skills/mcp-development/SKILL.blade.php
+++ b/resources/boost/skills/mcp-development/SKILL.blade.php
@@ -1,6 +1,6 @@
 ---
 name: mcp-development
-description: "Develops MCP servers, tools, resources, and prompts. Activates when creating MCP tools, resources, or prompts; setting up AI integrations; debugging MCP connections; working with routes/ai.php; or when the user mentions MCP, Model Context Protocol, AI tools, AI server, or building tools for AI assistants."
+description: "Use this skill for Laravel MCP development only. Trigger when creating or editing MCP tools, resources, prompts, or servers in Laravel projects. Covers: artisan make:mcp-* generators, mcp:inspector, routes/ai.php, Tool/Resource/Prompt classes, schema validation, shouldRegister(), OAuth setup, URI templates, read-only attributes, and MCP debugging. Do not use for non-Laravel MCP projects or generic AI features without MCP."
 license: MIT
 metadata:
   author: laravel


### PR DESCRIPTION
Mirrors https://github.com/laravel/boost/pull/644

When we first added skill support, skill triggering wasn't reliable enough, so we added a `core.blade.php` guideline that duplicated instructions already in the MCP skill — things like "always use `search-docs`" and "activate `mcp-development` for MCP tasks". This burned extra context tokens on every request.

We now have an eval system for testing and improving skill descriptions, so they trigger reliably. This means the redundant guideline file is no longer needed.

### Approach

- Remove the redundant `core.blade.php` guideline that duplicated the MCP skill's own instructions
- Refine the skill description to be more specific about Laravel MCP scoping, validated through trigger evals (20/20 pass rate)