### PR TITLE
Prevent OAuth discovery routes from overriding existing routes

### DIFF
--- a/src/Facades/Mcp.php
+++ b/src/Facades/Mcp.php
@@ -13,7 +13,7 @@ use Laravel\Mcp\Server\Registrar;
  * @method static callable|null getLocalServer(string $handle)
  * @method static \Illuminate\Routing\Route|null getWebServer(string $route)
  * @method static array servers()
- * @method static void oauthRoutes(string $oauthPrefix = 'oauth')
+ * @method static void oauthRoutes(string $oauthPrefix = 'oauth', array $options = [])
  * @method static array ensureMcpScope()
  *
  * @see \Laravel\Mcp\Server\Registrar

--- a/src/Server/Registrar.php
+++ b/src/Server/Registrar.php
@@ -86,27 +86,55 @@ class Registrar
         );
     }
 
-    public function oauthRoutes(string $oauthPrefix = 'oauth'): void
+    /**
+     * @param  array{discovery?: bool, protected_resource?: bool, registration?: bool}  $options
+     */
+    public function oauthRoutes(string $oauthPrefix = 'oauth', array $options = []): void
     {
         static::ensureMcpScope();
-        Router::get('/.well-known/oauth-protected-resource/{path?}', fn (?string $path = '') => response()->json([
-            'resource' => url('/'.$path),
-            'authorization_servers' => [url('/'.$path)],
-            'scopes_supported' => ['mcp:use'],
-        ]))->where('path', '.*')->name('mcp.oauth.protected-resource');
 
-        Router::get('/.well-known/oauth-authorization-server/{path?}', fn (?string $path = '') => response()->json([
-            'issuer' => url('/'.$path),
-            'authorization_endpoint' => route('passport.authorizations.authorize'),
-            'token_endpoint' => route('passport.token'),
-            'registration_endpoint' => url($oauthPrefix.'/register'),
-            'response_types_supported' => ['code'],
-            'code_challenge_methods_supported' => ['S256'],
-            'scopes_supported' => ['mcp:use'],
-            'grant_types_supported' => ['authorization_code', 'refresh_token'],
-        ]))->where('path', '.*')->name('mcp.oauth.authorization-server');
+        $registerProtectedResource = $options['protected_resource'] ?? $options['discovery'] ?? true;
+        $registerAuthorizationServer = $options['authorization_server'] ?? $options['discovery'] ?? true;
+        $registerRegistration = $options['registration'] ?? true;
 
-        Router::post($oauthPrefix.'/register', OAuthRegisterController::class);
+        if ($registerProtectedResource && ! $this->routeExists('GET', '.well-known/oauth-protected-resource')) {
+            Router::get('/.well-known/oauth-protected-resource/{path?}', fn (?string $path = '') => response()->json([
+                'resource' => url('/'.$path),
+                'authorization_servers' => [url('/'.$path)],
+                'scopes_supported' => ['mcp:use'],
+            ]))->where('path', '.*')->name('mcp.oauth.protected-resource');
+        }
+
+        if ($registerAuthorizationServer && ! $this->routeExists('GET', '.well-known/oauth-authorization-server')) {
+            Router::get('/.well-known/oauth-authorization-server/{path?}', fn (?string $path = '') => response()->json([
+                'issuer' => url('/'.$path),
+                'authorization_endpoint' => route('passport.authorizations.authorize'),
+                'token_endpoint' => route('passport.token'),
+                'registration_endpoint' => url($oauthPrefix.'/register'),
+                'response_types_supported' => ['code'],
+                'code_challenge_methods_supported' => ['S256'],
+                'scopes_supported' => ['mcp:use'],
+                'grant_types_supported' => ['authorization_code', 'refresh_token'],
+            ]))->where('path', '.*')->name('mcp.oauth.authorization-server');
+        }
+
+        if ($registerRegistration) {
+            Router::post($oauthPrefix.'/register', OAuthRegisterController::class);
+        }
+    }
+
+    /**
+     * Determine if a route already exists for the given method and URI.
+     */
+    protected function routeExists(string $method, string $uri): bool
+    {
+        foreach (Router::getRoutes()->get($method) ?? [] as $route) {
+            if (trim($route->uri(), '/') === trim($uri, '/')) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Unit/Server/RegistrarTest.php
+++ b/tests/Unit/Server/RegistrarTest.php
@@ -531,3 +531,134 @@ it('handles oauth discovery with no path', function (): void {
         'issuer' => url('/'),
     ]);
 });
+
+it('does not override existing oauth-authorization-server route', function (): void {
+    // Register an existing route before MCP's oauthRoutes
+    Route::get('/.well-known/oauth-authorization-server', fn () => response()->json([
+        'issuer' => 'https://existing-issuer.example.com',
+    ]))->name('existing.oauth-authorization-server');
+
+    // Fake Passport's routes so the oauthRoutes() helper can resolve them.
+    Route::get('/oauth/authorize')->name('passport.authorizations.authorize');
+    Route::post('/oauth/token')->name('passport.token');
+
+    $registrar = new Registrar;
+    $registrar->oauthRoutes();
+
+    // The existing route should still be in place
+    $response = $this->getJson('/.well-known/oauth-authorization-server');
+
+    $response->assertStatus(200);
+    $response->assertJson([
+        'issuer' => 'https://existing-issuer.example.com',
+    ]);
+
+    // The MCP named route should not exist
+    $routes = Route::getRoutes();
+    $mcpRoute = $routes->getByName('mcp.oauth.authorization-server');
+    expect($mcpRoute)->toBeNull();
+});
+
+it('does not override existing oauth-protected-resource route', function (): void {
+    // Register an existing route before MCP's oauthRoutes
+    Route::get('/.well-known/oauth-protected-resource', fn () => response()->json([
+        'resource' => 'https://existing-resource.example.com',
+    ]))->name('existing.oauth-protected-resource');
+
+    // Fake Passport's routes so the oauthRoutes() helper can resolve them.
+    Route::get('/oauth/authorize')->name('passport.authorizations.authorize');
+    Route::post('/oauth/token')->name('passport.token');
+
+    $registrar = new Registrar;
+    $registrar->oauthRoutes();
+
+    // The existing route should still be in place
+    $response = $this->getJson('/.well-known/oauth-protected-resource');
+
+    $response->assertStatus(200);
+    $response->assertJson([
+        'resource' => 'https://existing-resource.example.com',
+    ]);
+
+    // The MCP named route should not exist
+    $routes = Route::getRoutes();
+    $mcpRoute = $routes->getByName('mcp.oauth.protected-resource');
+    expect($mcpRoute)->toBeNull();
+});
+
+it('allows disabling discovery routes via options', function (): void {
+    $registrar = new Registrar;
+
+    $registrar->oauthRoutes('oauth', ['discovery' => false]);
+
+    $routes = Route::getRoutes();
+    $hasProtectedResource = false;
+    $hasAuthServer = false;
+    $hasRegisterRoute = false;
+
+    foreach ($routes as $route) {
+        if ($route->getName() === 'mcp.oauth.protected-resource') {
+            $hasProtectedResource = true;
+        }
+
+        if ($route->getName() === 'mcp.oauth.authorization-server') {
+            $hasAuthServer = true;
+        }
+
+        if ($route->uri() === 'oauth/register') {
+            $hasRegisterRoute = true;
+        }
+    }
+
+    expect($hasProtectedResource)->toBeFalse();
+    expect($hasAuthServer)->toBeFalse();
+    expect($hasRegisterRoute)->toBeTrue();
+});
+
+it('allows disabling individual discovery routes via options', function (): void {
+    // Fake Passport's routes so the oauthRoutes() helper can resolve them.
+    Route::get('/oauth/authorize')->name('passport.authorizations.authorize');
+    Route::post('/oauth/token')->name('passport.token');
+
+    $registrar = new Registrar;
+
+    $registrar->oauthRoutes('oauth', ['authorization_server' => false]);
+
+    $routes = Route::getRoutes();
+    $hasProtectedResource = false;
+    $hasAuthServer = false;
+
+    foreach ($routes as $route) {
+        if ($route->getName() === 'mcp.oauth.protected-resource') {
+            $hasProtectedResource = true;
+        }
+
+        if ($route->getName() === 'mcp.oauth.authorization-server') {
+            $hasAuthServer = true;
+        }
+    }
+
+    expect($hasProtectedResource)->toBeTrue();
+    expect($hasAuthServer)->toBeFalse();
+});
+
+it('allows disabling registration route via options', function (): void {
+    // Fake Passport's routes so the oauthRoutes() helper can resolve them.
+    Route::get('/oauth/authorize')->name('passport.authorizations.authorize');
+    Route::post('/oauth/token')->name('passport.token');
+
+    $registrar = new Registrar;
+
+    $registrar->oauthRoutes('oauth', ['registration' => false]);
+
+    $routes = Route::getRoutes();
+    $hasRegisterRoute = false;
+
+    foreach ($routes as $route) {
+        if ($route->uri() === 'oauth/register') {
+            $hasRegisterRoute = true;
+        }
+    }
+
+    expect($hasRegisterRoute)->toBeFalse();
+});


### PR DESCRIPTION
## Summary

- **Fixes #138** - MCP's wildcard `.well-known/oauth-authorization-server/{path?}` and `.well-known/oauth-protected-resource/{path?}` routes silently override existing OAuth discovery routes (e.g. from Laravel Passport or custom controllers)
- Before registering each discovery route, the `oauthRoutes()` method now checks whether a route already exists for that URI, and skips registration if so
- Adds an `$options` array parameter to `oauthRoutes()` for explicit control over which routes are registered (`discovery`, `authorization_server`, `protected_resource`, `registration`)

## Usage

Existing behavior is unchanged — if no conflicting routes exist, MCP registers all routes as before.

For users with existing discovery routes:
```php
// MCP will automatically detect and skip conflicting routes
Mcp::oauthRoutes('mcp/oauth');

// Or explicitly disable specific routes
Mcp::oauthRoutes('mcp/oauth', [
    'discovery' => false,           // disables both discovery routes
    'authorization_server' => false, // disables only the authorization server route
    'protected_resource' => false,   // disables only the protected resource route
    'registration' => false,         // disables the client registration route
]);
```

## Test plan

- [x] Existing tests pass (31 registrar tests, 616 total)
- [x] New test: does not override existing `oauth-authorization-server` route
- [x] New test: does not override existing `oauth-protected-resource` route
- [x] New test: `discovery => false` option disables both discovery routes
- [x] New test: individual route options (`authorization_server => false`)
- [x] New test: `registration => false` option disables registration route

🤖 Generated with [Claude Code](https://claude.com/claude-code)