### PR TITLE
Return tool errors for authorization failures

### DIFF
--- a/src/Server/Methods/CallTool.php
+++ b/src/Server/Methods/CallTool.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laravel\Mcp\Server\Methods;
 
 use Generator;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Container\Container;
 use Illuminate\Validation\ValidationException;
 use Laravel\Mcp\Response;
@@ -51,6 +52,8 @@ class CallTool implements Errable, Method
         try {
             // @phpstan-ignore-next-line
             $response = Container::getInstance()->call([$tool, 'handle']);
+        } catch (AuthorizationException $authorizationException) {
+            $response = Response::error($authorizationException->getMessage());
         } catch (ValidationException $validationException) {
             $response = Response::error(ValidationMessages::from($validationException));
         }

--- a/tests/Unit/Methods/CallToolTest.php
+++ b/tests/Unit/Methods/CallToolTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
@@ -150,6 +151,69 @@ it('returns a valid call tool response with validation error', function (): void
                 [
                     'type' => 'text',
                     'text' => 'The name field is required.',
+                ],
+            ],
+            'isError' => true,
+        ]);
+});
+
+it('returns a valid call tool response with authorization error', function (): void {
+    $tool = new class extends Tool
+    {
+        protected string $description = 'Unauthorized tool';
+
+        public function handle(Request $request): Response
+        {
+            throw new AuthorizationException;
+        }
+
+        public function schema(JsonSchema $schema): array
+        {
+            return [];
+        }
+    };
+
+    $toolClass = $tool::class;
+    $this->instance($toolClass, $tool);
+
+    $request = JsonRpcRequest::from([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => $tool->name(),
+            'arguments' => [],
+        ],
+    ]);
+
+    $context = new ServerContext(
+        supportedProtocolVersions: ['2025-03-26'],
+        serverCapabilities: [],
+        serverName: 'Test Server',
+        serverVersion: '1.0.0',
+        instructions: 'Test instructions',
+        maxPaginationLength: 50,
+        defaultPaginationLength: 10,
+        tools: [$toolClass],
+        resources: [],
+        prompts: [],
+    );
+
+    $method = new CallTool;
+
+    $this->instance('mcp.request', $request->toRequest());
+    $response = $method->handle($request, $context);
+
+    expect($response)->toBeInstanceOf(JsonRpcResponse::class);
+
+    $payload = $response->toArray();
+
+    expect($payload['id'])->toEqual(1)
+        ->and($payload['result'])->toEqual([
+            'content' => [
+                [
+                    'type' => 'text',
+                    'text' => 'This action is unauthorized.',
                 ],
             ],
             'isError' => true,


### PR DESCRIPTION
## Summary
- convert `AuthorizationException` thrown from tool handlers into a normal tool execution error instead of letting it escape as a generic protocol failure
- keep the existing validation-error formatting path unchanged and scope this follow-up to the smallest useful slice of issue #143
- add a focused `CallTool` unit test that proves authorization failures now surface as `isError: true` tool output with the expected message

## Validation
- `vendor/bin/pest tests/Unit/Methods/CallToolTest.php --filter='authorization error'`
- `vendor/bin/pest tests/Unit/Methods/CallToolTest.php`
- `vendor/bin/pint --test src/Server/Methods/CallTool.php tests/Unit/Methods/CallToolTest.php`

## Notes
- The touched test file still carries the repo's usual Pest/Intelephense magic-method baseline noise (`instance()`), but the changed source file is clean and the focused tests pass locally.