### PR TITLE
fix: allow custom-scheme OAuth redirect URIs

### DIFF
--- a/src/Facades/Mcp.php
+++ b/src/Facades/Mcp.php
@@ -16,7 +16,7 @@ use Laravel\Mcp\Server\Registrar;
  * @method static void oauthRoutes(string $oauthPrefix = 'oauth')
  * @method static array ensureMcpScope()
  *
- * @see \Laravel\Mcp\Server\Registrar
+ * @see Registrar
  */
 class Mcp extends Facade
 {

--- a/src/Server/Http/Controllers/OAuthRegisterController.php
+++ b/src/Server/Http/Controllers/OAuthRegisterController.php
@@ -21,7 +21,13 @@ class OAuthRegisterController
     {
         $validated = $request->validate([
             'redirect_uris' => ['required', 'array', 'min:1'],
-            'redirect_uris.*' => ['required', 'url', function (string $attribute, $value, $fail): void {
+            'redirect_uris.*' => ['required', 'string', function (string $attribute, $value, $fail): void {
+                if (! is_string($value) || ! $this->isValidRedirectUri($value)) {
+                    $fail($attribute.' must be a valid URL.');
+
+                    return;
+                }
+
                 if (in_array('*', config('mcp.redirect_domains', []), true)) {
                     return;
                 }
@@ -56,6 +62,25 @@ class OAuthRegisterController
             'scope' => 'mcp:use',
             'token_endpoint_auth_method' => 'none',
         ]);
+    }
+
+    protected function isValidRedirectUri(string $uri): bool
+    {
+        $scheme = parse_url($uri, PHP_URL_SCHEME);
+
+        if (! is_string($scheme) || $scheme === '') {
+            return false;
+        }
+
+        if (in_array($scheme, ['http', 'https'], true)) {
+            return filter_var($uri, FILTER_VALIDATE_URL) !== false;
+        }
+
+        $parts = parse_url($uri);
+
+        return is_array($parts)
+            && Str::contains($uri, '://')
+            && ((is_string($parts['host'] ?? null) && $parts['host'] !== '') || (is_string($parts['path'] ?? null) && $parts['path'] !== ''));
     }
 
     protected function isLocalhostUrl(string $url): bool

--- a/tests/Feature/Testing/Tools/AssertStructuredContentTest.php
+++ b/tests/Feature/Testing/Tools/AssertStructuredContentTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Testing\Fluent\AssertableJson;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\ResponseFactory;
 use Laravel\Mcp\Server;
@@ -79,11 +80,11 @@ it('fails to assert the structured content is not present', function (): void {
 it('succeeds to assert the structured content with closure', function (): void {
     $response = BookingServer::tool(GetBookingTool::class);
 
-    $response->assertStructuredContent(fn (AssertableJson $json) => $json->where('type', 'booking')->etc());
+    $response->assertStructuredContent(fn (AssertableJson $json): AssertableJson => $json->where('type', 'booking')->etc());
 });
 
 it('fails to assert the structured content with closure', function (): void {
     $response = BookingServer::tool(GetBookingTool::class);
 
-    $response->assertStructuredContent(fn (AssertableJson $json) => $json->where('type', 'foo')->etc());
+    $response->assertStructuredContent(fn (AssertableJson $json): AssertableJson => $json->where('type', 'foo')->etc());
 })->throws(ExpectationFailedException::class);

--- a/tests/Unit/Server/RegistrarTest.php
+++ b/tests/Unit/Server/RegistrarTest.php
@@ -240,6 +240,74 @@ it('handles oauth registration with allowed domains', function (): void {
     ]);
 });
 
+it('allows custom-scheme redirect uris when all redirect domains are permitted', function (): void {
+    if (! class_exists('Laravel\Passport\ClientRepository')) {
+        eval('
+            namespace Laravel\Passport;
+            class ClientRepository {
+                public function createAuthorizationCodeGrantClient(string $name, array $redirectUris, bool $confidential = true, $user = null, bool $enableDeviceFlow = false) {
+                    return (object) [
+                        "id" => "test-client-id",
+                        "grant_types" => ["authorization_code"],
+                        "redirect_uris" => $redirectUris,
+                    ];
+                }
+            }
+        ');
+    }
+
+    $registrar = new Registrar;
+    $registrar->oauthRoutes();
+
+    $this->app->instance('Laravel\Passport\ClientRepository', new ClientRepository);
+
+    $response = $this->postJson('/oauth/register', [
+        'client_name' => 'Test Client',
+        'redirect_uris' => ['cursor://anysphere.cursor-mcp/oauth/callback'],
+    ]);
+
+    $response->assertStatus(200);
+    $response->assertJson([
+        'client_id' => 'test-client-id',
+        'grant_types' => ['authorization_code'],
+        'response_types' => ['code'],
+        'redirect_uris' => ['cursor://anysphere.cursor-mcp/oauth/callback'],
+        'scope' => 'mcp:use',
+        'token_endpoint_auth_method' => 'none',
+    ]);
+});
+
+it('rejects custom-scheme redirect uris that do not match redirect domains', function (): void {
+    if (! class_exists('Laravel\Passport\ClientRepository')) {
+        eval('
+            namespace Laravel\Passport;
+            class ClientRepository {
+                public function createAuthorizationCodeGrantClient(string $name, array $redirectUris, bool $confidential = true, $user = null, bool $enableDeviceFlow = false) {
+                    return (object) [
+                        "id" => "test-client-id",
+                        "grant_types" => ["authorization_code"],
+                        "redirect_uris" => $redirectUris,
+                    ];
+                }
+            }
+        ');
+    }
+
+    $registrar = new Registrar;
+    $registrar->oauthRoutes();
+
+    config()->set('mcp.redirect_domains', ['cursor://other-app']);
+
+    $this->app->instance('Laravel\Passport\ClientRepository', new ClientRepository);
+
+    $response = $this->postJson('/oauth/register', [
+        'client_name' => 'Test Client',
+        'redirect_uris' => ['cursor://anysphere.cursor-mcp/oauth/callback'],
+    ]);
+
+    $response->assertStatus(422);
+});
+
 it('allows localhost with dynamic port when localhost is in redirect_domains', function (string $uri): void {
     if (! class_exists('Laravel\Passport\ClientRepository')) {
         eval('


### PR DESCRIPTION
## Summary
- allow custom-scheme OAuth redirect URIs during client registration when they still match the configured redirect-domain policy
- keep the existing localhost and domain allowlist checks intact for normal HTTP/HTTPS redirects
- add focused coverage for valid and invalid custom-scheme redirects in the Registrar tests

## End-user benefit
Native clients often need redirect URIs like `myapp://oauth/callback` instead of `https://...`. Today the registration endpoint rejects those even when the host/application path is otherwise allowed. This fix lets MCP OAuth registration support native-app redirect schemes without weakening the existing domain checks.

## Testing
- `./vendor/bin/pest tests/Unit/Server/RegistrarTest.php`
- `./vendor/bin/pint --test src/Server/Http/Controllers/OAuthRegisterController.php tests/Unit/Server/RegistrarTest.php src/Facades/Mcp.php`