### PR TITLE
fix: preserve unicode characters in JSON-RPC responses

### DIFF
--- a/src/Facades/Mcp.php
+++ b/src/Facades/Mcp.php
@@ -16,7 +16,7 @@ use Laravel\Mcp\Server\Registrar;
  * @method static void oauthRoutes(string $oauthPrefix = 'oauth')
  * @method static array ensureMcpScope()
  *
- * @see \Laravel\Mcp\Server\Registrar
+ * @see Registrar
  */
 class Mcp extends Facade
 {

--- a/src/Server/Transport/JsonRpcResponse.php
+++ b/src/Server/Transport/JsonRpcResponse.php
@@ -71,6 +71,6 @@ class JsonRpcResponse implements Arrayable
 
     public function toJson(int $options = 0): string
     {
-        return json_encode($this->toArray(), $options) ?: '';
+        return json_encode($this->toArray(), $options | JSON_UNESCAPED_UNICODE) ?: '';
     }
 }

--- a/tests/Feature/CompletionTest.php
+++ b/tests/Feature/CompletionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server;

--- a/tests/Feature/Testing/Prompts/AssertErrorsTest.php
+++ b/tests/Feature/Testing/Prompts/AssertErrorsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Server;
 use Laravel\Mcp\Server\Prompt;

--- a/tests/Feature/Testing/Prompts/AssertMetadataTest.php
+++ b/tests/Feature/Testing/Prompts/AssertMetadataTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Laravel\Mcp\Server;
 use Laravel\Mcp\Server\Prompt;
 use PHPUnit\Framework\ExpectationFailedException;

--- a/tests/Feature/Testing/Resources/AssertErrorsTest.php
+++ b/tests/Feature/Testing/Resources/AssertErrorsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Server;
 use Laravel\Mcp\Server\Resource;

--- a/tests/Feature/Testing/Resources/AssertMetadataTest.php
+++ b/tests/Feature/Testing/Resources/AssertMetadataTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Laravel\Mcp\Server;
 use Laravel\Mcp\Server\Resource;
 use PHPUnit\Framework\ExpectationFailedException;

--- a/tests/Feature/Testing/Tools/AssertErrorsTest.php
+++ b/tests/Feature/Testing/Tools/AssertErrorsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Server;
 use Laravel\Mcp\Server\Tool;

--- a/tests/Feature/Testing/Tools/AssertMetadataTest.php
+++ b/tests/Feature/Testing/Tools/AssertMetadataTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Laravel\Mcp\Server;
 use Laravel\Mcp\Server\Tool;
 use PHPUnit\Framework\ExpectationFailedException;

--- a/tests/Fixtures/Clock.php
+++ b/tests/Fixtures/Clock.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Fixtures;
 
 class Clock

--- a/tests/Fixtures/CurrentTimeTool.php
+++ b/tests/Fixtures/CurrentTimeTool.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Fixtures;
 
 use Laravel\Mcp\Server\Tool;

--- a/tests/Fixtures/CustomMethodHandler.php
+++ b/tests/Fixtures/CustomMethodHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Fixtures;
 
 use Laravel\Mcp\Server\Contracts\Method;

--- a/tests/Fixtures/DailyPlanResource.php
+++ b/tests/Fixtures/DailyPlanResource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Fixtures;
 
 use Laravel\Mcp\Server\Resource;

--- a/tests/Fixtures/ExampleServer.php
+++ b/tests/Fixtures/ExampleServer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Fixtures;
 
 use Laravel\Mcp\Server;

--- a/tests/Fixtures/LastLogLineResource.php
+++ b/tests/Fixtures/LastLogLineResource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Fixtures;
 
 use Laravel\Mcp\Server\Resource;

--- a/tests/Fixtures/RecentMeetingRecordingResource.php
+++ b/tests/Fixtures/RecentMeetingRecordingResource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Fixtures;
 
 use Laravel\Mcp\Server\Resource;

--- a/tests/Fixtures/SayHiTool.php
+++ b/tests/Fixtures/SayHiTool.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Fixtures;
 
 use Illuminate\Contracts\JsonSchema\JsonSchema;

--- a/tests/Fixtures/SayHiTwiceTool.php
+++ b/tests/Fixtures/SayHiTwiceTool.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Fixtures;
 
 use Illuminate\Contracts\JsonSchema\JsonSchema;

--- a/tests/Fixtures/ServerWithDynamicTools.php
+++ b/tests/Fixtures/ServerWithDynamicTools.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Fixtures;
 
 use Laravel\Mcp\Server;

--- a/tests/Fixtures/StreamingTool.php
+++ b/tests/Fixtures/StreamingTool.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Fixtures;
 
 use Generator;

--- a/tests/Unit/Completions/ArrayCompletionResponseTest.php
+++ b/tests/Unit/Completions/ArrayCompletionResponseTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Laravel\Mcp\Server\Completions\ArrayCompletionResponse;
 use Laravel\Mcp\Server\Completions\DirectCompletionResponse;
 

--- a/tests/Unit/Completions/CompletionHelperTest.php
+++ b/tests/Unit/Completions/CompletionHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Laravel\Mcp\Server\Completions\CompletionHelper;
 
 it('filters items by prefix case-insensitively', function (): void {

--- a/tests/Unit/Completions/CompletionResponseTest.php
+++ b/tests/Unit/Completions/CompletionResponseTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Laravel\Mcp\Server\Completions\CompletionResponse;
 
 it('creates a completion result with values', function (): void {

--- a/tests/Unit/Completions/DirectCompletionResponseTest.php
+++ b/tests/Unit/Completions/DirectCompletionResponseTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Laravel\Mcp\Server\Completions\DirectCompletionResponse;
 
 it('returns self when resolved', function (): void {

--- a/tests/Unit/Exceptions/JsonRpcExceptionTest.php
+++ b/tests/Unit/Exceptions/JsonRpcExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Laravel\Mcp\Server\Exceptions\JsonRpcException;
 
 it('converts to JsonRpc error without id and with data', function (): void {

--- a/tests/Unit/ServerContextTest.php
+++ b/tests/Unit/ServerContextTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Laravel\Mcp\Server\ServerContext;
 
 it('clamps perPage to default and max values', function (): void {

--- a/tests/Unit/Support/UriTemplateTest.php
+++ b/tests/Unit/Support/UriTemplateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Laravel\Mcp\Support\UriTemplate;
 
 it('requires a valid URI scheme', function (): void {

--- a/tests/Unit/Transport/JsonRpcNotificationTest.php
+++ b/tests/Unit/Transport/JsonRpcNotificationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Laravel\Mcp\Server\Exceptions\JsonRpcException;
 use Laravel\Mcp\Server\Transport\JsonRpcNotification;
 

--- a/tests/Unit/Transport/JsonRpcRequestTest.php
+++ b/tests/Unit/Transport/JsonRpcRequestTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Laravel\Mcp\Server\Exceptions\JsonRpcException;
 use Laravel\Mcp\Server\Transport\JsonRpcRequest;
 

--- a/tests/Unit/Transport/JsonRpcResponseTest.php
+++ b/tests/Unit/Transport/JsonRpcResponseTest.php
@@ -83,6 +83,17 @@ it('can create a notification with params', function (): void {
     expect($response->toArray())->toEqual($expectedArray);
 });
 
+it('does not escape unicode characters in json output', function (): void {
+    $unicodeString = "\u{1F600} caf\u{00E9} \u{4F60}\u{597D}";
+
+    $response = JsonRpcResponse::result(1, ['text' => $unicodeString]);
+
+    $json = $response->toJson();
+
+    expect($json)->toContain($unicodeString)
+        ->and($json)->not->toMatch('/\\\\u[0-9a-fA-F]{4}/');
+});
+
 it('converts empty array params in notification to object', function (): void {
     $response = JsonRpcResponse::notification('notifications/initialized', []);
 

--- a/tests/Unit/Transport/JsonRpcResponseTest.php
+++ b/tests/Unit/Transport/JsonRpcResponseTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Laravel\Mcp\Server\Transport\JsonRpcResponse;
 
 it('can return response as array', function (): void {


### PR DESCRIPTION
## Summary

- Add `JSON_UNESCAPED_UNICODE` flag to `JsonRpcResponse::toJson()` to prevent PHP from escaping non-ASCII characters as `\uXXXX` sequences
- Fix code style issues: add missing `declare(strict_types=1)` to 28 test/fixture files, use short class reference in Facade PHPDoc (these pre-existing issues were breaking CI on `main`)
- Add focused test coverage for unicode preservation in JSON output

## Problem

`JsonRpcResponse::toJson()` calls `json_encode()` with default options (`0`), which causes PHP to escape all non-ASCII Unicode characters. For example, a tool description like:

```
Получить статистику по позициям
```

becomes:

```
\u043f\u043e\u043b\u0443\u0447\u0438\u0442\u044c \u0441\u0442\u0430\u0442\u0438\u0441\u0442\u0438\u043a\u0443 \u043f\u043e \u043f\u043e\u0437\u0438\u0446\u0438\u044f\u043c
```

This affects every JSON-RPC protocol message — `tools/list`, `resources/list`, `prompts/list`, error responses, and notifications. Any server using non-ASCII characters in tool names, descriptions, or schema descriptions will have them escaped.

### Impact on AI clients

MCP servers are consumed by AI models (Claude, GPT, etc.) where every token counts against the context window. Escaped Unicode sequences are significantly larger than their UTF-8 originals:

| Text | UTF-8 | Escaped | Bloat |
|------|-------|---------|-------|
| `Получить` (Cyrillic, "Get") | 8 chars | 48 chars (`\u043f\u043e\u043b\u0443\u0447\u0438\u0442\u044c`) | 6× |
| `获取列表` (CJK, "Get list") | 4 chars | 24 chars (`\u83b7\u53d6\u5217\u8868`) | 6× |
| `café` (Latin with diacritics) | 4 chars | 9 chars (`caf\u00e9`) | 2.25× |

For a typical MCP server with 10-15 tools and descriptions in a non-Latin language, this can add hundreds of unnecessary tokens to every `tools/list` response. These tokens are loaded into the AI context window but carry no information — they are semantically identical to the original characters.

### Existing precedent in the codebase

The `Response` class already uses `JSON_UNESCAPED_UNICODE` for tool response payloads ([Response.php#L55](src/Response.php#L55), [Response.php#L73](src/Response.php#L73)):

```php
// Response::json()
json_encode($content, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);

// Response::structured()
json_encode($response, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
```

This fix aligns `JsonRpcResponse` with the same behavior, ensuring consistency across all JSON output.

## Changes

**Modified:**
- `src/Server/Transport/JsonRpcResponse.php` — add `JSON_UNESCAPED_UNICODE` to `toJson()`
- `src/Facades/Mcp.php` — use short class reference in PHPDoc `@see`
- `tests/Unit/Transport/JsonRpcResponseTest.php` — add test for unicode preservation + `declare(strict_types=1)`
- 27 test/fixture files — add missing `declare(strict_types=1)` (fixes pre-existing Rector failures on `main`)

## Compatibility

This is fully backwards compatible. Both escaped (`\uXXXX`) and unescaped UTF-8 are valid JSON per [RFC 8259 §7](https://datatracker.ietf.org/doc/html/rfc8259#section-7). Any conformant JSON parser will handle both forms identically. The `$options` parameter is preserved via bitwise OR, so callers passing custom flags are unaffected.

## Test plan

- [x] New test: verifies unicode characters (emoji, Latin diacritics, CJK) are preserved in JSON output
- [x] All 639 existing tests pass
- [x] Pint clean
- [x] Rector clean