### PR TITLE
Preserve existing OAuth discovery routes

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,6 +10,3 @@ parameters:
   ignoreErrors:
     - "#Unsafe usage of new static\\(\\)#"
     - "#Call to an undefined method Illuminate\\\\Contracts\\\\Foundation\\\\Application::routesAreCached#"
-    -
-      message: "#no value type specified in iterable type array#"
-      path: src/Facades/Mcp.php

--- a/src/Facades/Mcp.php
+++ b/src/Facades/Mcp.php
@@ -8,8 +8,8 @@ use Illuminate\Support\Facades\Facade;
 use Laravel\Mcp\Server\Registrar;
 
 /**
- * @method static \Illuminate\Routing\Route web(string $route, string<\Laravel\Mcp\Server> $serverClass)
- * @method static void local(string $handle, string<\Laravel\Mcp\Server> $serverClass)
+ * @method static \Illuminate\Routing\Route web(string $route, class-string<\Laravel\Mcp\Server> $serverClass)
+ * @method static void local(string $handle, class-string<\Laravel\Mcp\Server> $serverClass)
  * @method static callable|null getLocalServer(string $handle)
  * @method static \Illuminate\Routing\Route|null getWebServer(string $route)
  * @method static array<string, callable|\Illuminate\Routing\Route> servers()

--- a/src/Facades/Mcp.php
+++ b/src/Facades/Mcp.php
@@ -16,7 +16,7 @@ use Laravel\Mcp\Server\Registrar;
  * @method static void oauthRoutes(string $oauthPrefix = 'oauth')
  * @method static array<string, string> ensureMcpScope()
  *
- * @see \Laravel\Mcp\Server\Registrar
+ * @see Registrar
  */
 class Mcp extends Facade
 {

--- a/src/Server/Middleware/AddWwwAuthenticateHeader.php
+++ b/src/Server/Middleware/AddWwwAuthenticateHeader.php
@@ -22,11 +22,11 @@ class AddWwwAuthenticateHeader
             return $response;
         }
 
-        $isOauth = app('router')->has('mcp.oauth.protected-resource');
+        $isOauth = app('router')->has('mcp.oauth.protected-resource.nested');
         if ($isOauth) {
             $response->header(
                 'WWW-Authenticate',
-                'Bearer realm="mcp", resource_metadata="'.route('mcp.oauth.protected-resource', ['path' => $request->path()]).'"'
+                'Bearer realm="mcp", resource_metadata="'.route('mcp.oauth.protected-resource.nested', ['path' => $request->path()]).'"'
             );
 
             return $response;

--- a/src/Server/Registrar.php
+++ b/src/Server/Registrar.php
@@ -89,24 +89,26 @@ class Registrar
     public function oauthRoutes(string $oauthPrefix = 'oauth'): void
     {
         static::ensureMcpScope();
-        if (! $this->hasGetRoute('.well-known/oauth-protected-resource')) {
+        $hasExactProtectedResourceRoute = $this->hasGetRoute('.well-known/oauth-protected-resource');
+        if (! $hasExactProtectedResourceRoute) {
             Router::get('/.well-known/oauth-protected-resource', fn () => response()->json(
                 $this->protectedResourceMetadata(''),
             ))->name('mcp.oauth.protected-resource');
         }
 
         Router::get('/.well-known/oauth-protected-resource/{path}', fn (string $path) => response()->json(
-            $this->protectedResourceMetadata($path),
+            $this->protectedResourceMetadata($path, $hasExactProtectedResourceRoute),
         ))->where('path', '.*')->name('mcp.oauth.protected-resource.nested');
 
-        if (! $this->hasGetRoute('.well-known/oauth-authorization-server')) {
+        $hasExactAuthorizationServerRoute = $this->hasGetRoute('.well-known/oauth-authorization-server');
+        if (! $hasExactAuthorizationServerRoute) {
             Router::get('/.well-known/oauth-authorization-server', fn () => response()->json(
                 $this->authorizationServerMetadata('', $oauthPrefix),
             ))->name('mcp.oauth.authorization-server');
         }
 
         Router::get('/.well-known/oauth-authorization-server/{path}', fn (string $path) => response()->json(
-            $this->authorizationServerMetadata($path, $oauthPrefix),
+            $this->authorizationServerMetadata($path, $oauthPrefix, $hasExactAuthorizationServerRoute),
         ))->where('path', '.*')->name('mcp.oauth.authorization-server.nested');
 
         Router::post($oauthPrefix.'/register', OAuthRegisterController::class);
@@ -115,10 +117,10 @@ class Registrar
     /**
      * @return array<string, array<int, string>|string>
      */
-    protected function authorizationServerMetadata(string $path, string $oauthPrefix): array
+    protected function authorizationServerMetadata(string $path, string $oauthPrefix, bool $preserveExactRoute = false): array
     {
         return [
-            'issuer' => url('/'.$path),
+            'issuer' => $preserveExactRoute ? url('/'.$path) : (config('mcp.authorization_server') ?? url('/')),
             'authorization_endpoint' => route('passport.authorizations.authorize'),
             'token_endpoint' => route('passport.token'),
             'registration_endpoint' => url($oauthPrefix.'/register'),
@@ -132,11 +134,11 @@ class Registrar
     /**
      * @return array<string, array<int, string>|string>
      */
-    protected function protectedResourceMetadata(string $path): array
+    protected function protectedResourceMetadata(string $path, bool $preserveExactRoute = false): array
     {
         return [
             'resource' => url('/'.$path),
-            'authorization_servers' => [url('/'.$path)],
+            'authorization_servers' => [$preserveExactRoute ? url('/'.$path) : (config('mcp.authorization_server') ?? url('/'))],
             'scopes_supported' => ['mcp:use'],
         ];
     }

--- a/src/Server/Registrar.php
+++ b/src/Server/Registrar.php
@@ -90,26 +90,25 @@ class Registrar
     {
         static::ensureMcpScope();
         $hasExactProtectedResourceRoute = $this->hasGetRoute('.well-known/oauth-protected-resource');
-        if (! $hasExactProtectedResourceRoute) {
-            Router::get('/.well-known/oauth-protected-resource', fn () => response()->json(
-                $this->protectedResourceMetadata(''),
-            ))->name('mcp.oauth.protected-resource');
-        }
-
-        Router::get('/.well-known/oauth-protected-resource/{path}', fn (string $path) => response()->json(
-            $this->protectedResourceMetadata($path, $hasExactProtectedResourceRoute),
-        ))->where('path', '.*')->name('mcp.oauth.protected-resource.nested');
-
         $hasExactAuthorizationServerRoute = $this->hasGetRoute('.well-known/oauth-authorization-server');
-        if (! $hasExactAuthorizationServerRoute) {
-            Router::get('/.well-known/oauth-authorization-server', fn () => response()->json(
-                $this->authorizationServerMetadata('', $oauthPrefix),
-            ))->name('mcp.oauth.authorization-server');
+
+        if (! $hasExactProtectedResourceRoute) {
+            Router::get('/.well-known/oauth-protected-resource', fn () => response()->json($this->protectedResourceMetadata('')))
+                ->name('mcp.oauth.protected-resource');
         }
 
-        Router::get('/.well-known/oauth-authorization-server/{path}', fn (string $path) => response()->json(
-            $this->authorizationServerMetadata($path, $oauthPrefix, $hasExactAuthorizationServerRoute),
-        ))->where('path', '.*')->name('mcp.oauth.authorization-server.nested');
+        if (! $hasExactAuthorizationServerRoute) {
+            Router::get('/.well-known/oauth-authorization-server', fn () => response()->json($this->authorizationServerMetadata($oauthPrefix)))
+                ->name('mcp.oauth.authorization-server');
+        }
+
+        Router::get('/.well-known/oauth-protected-resource/{path}', fn (string $path) => response()->json($this->protectedResourceMetadata($path)))
+            ->where('path', '.*')
+            ->name('mcp.oauth.protected-resource.nested');
+
+        Router::get('/.well-known/oauth-authorization-server/{path}', fn (string $path) => response()->json($this->authorizationServerMetadata($oauthPrefix)))
+            ->where('path', '.*')
+            ->name('mcp.oauth.authorization-server.nested');
 
         Router::post($oauthPrefix.'/register', OAuthRegisterController::class);
     }
@@ -117,10 +116,10 @@ class Registrar
     /**
      * @return array<string, array<int, string>|string>
      */
-    protected function authorizationServerMetadata(string $path, string $oauthPrefix, bool $preserveExactRoute = false): array
+    protected function authorizationServerMetadata(string $oauthPrefix): array
     {
         return [
-            'issuer' => $preserveExactRoute ? url('/'.$path) : (config('mcp.authorization_server') ?? url('/')),
+            'issuer' => config('mcp.authorization_server') ?? url('/'),
             'authorization_endpoint' => route('passport.authorizations.authorize'),
             'token_endpoint' => route('passport.token'),
             'registration_endpoint' => url($oauthPrefix.'/register'),
@@ -134,11 +133,11 @@ class Registrar
     /**
      * @return array<string, array<int, string>|string>
      */
-    protected function protectedResourceMetadata(string $path, bool $preserveExactRoute = false): array
+    protected function protectedResourceMetadata(string $path): array
     {
         return [
             'resource' => url('/'.$path),
-            'authorization_servers' => [$preserveExactRoute ? url('/'.$path) : (config('mcp.authorization_server') ?? url('/'))],
+            'authorization_servers' => [config('mcp.authorization_server') ?? url('/')],
             'scopes_supported' => ['mcp:use'],
         ];
     }

--- a/src/Server/Registrar.php
+++ b/src/Server/Registrar.php
@@ -89,14 +89,36 @@ class Registrar
     public function oauthRoutes(string $oauthPrefix = 'oauth'): void
     {
         static::ensureMcpScope();
-        Router::get('/.well-known/oauth-protected-resource/{path?}', fn (?string $path = '') => response()->json([
-            'resource' => url('/'.$path),
-            'authorization_servers' => [config('mcp.authorization_server') ?? url('/')],
-            'scopes_supported' => ['mcp:use'],
-        ]))->where('path', '.*')->name('mcp.oauth.protected-resource');
+        if (! $this->hasGetRoute('.well-known/oauth-protected-resource')) {
+            Router::get('/.well-known/oauth-protected-resource', fn () => response()->json(
+                $this->protectedResourceMetadata(''),
+            ))->name('mcp.oauth.protected-resource');
+        }
 
-        Router::get('/.well-known/oauth-authorization-server/{path?}', fn (?string $path = '') => response()->json([
-            'issuer' => config('mcp.authorization_server') ?? url('/'),
+        Router::get('/.well-known/oauth-protected-resource/{path}', fn (string $path) => response()->json(
+            $this->protectedResourceMetadata($path),
+        ))->where('path', '.*')->name('mcp.oauth.protected-resource.nested');
+
+        if (! $this->hasGetRoute('.well-known/oauth-authorization-server')) {
+            Router::get('/.well-known/oauth-authorization-server', fn () => response()->json(
+                $this->authorizationServerMetadata('', $oauthPrefix),
+            ))->name('mcp.oauth.authorization-server');
+        }
+
+        Router::get('/.well-known/oauth-authorization-server/{path}', fn (string $path) => response()->json(
+            $this->authorizationServerMetadata($path, $oauthPrefix),
+        ))->where('path', '.*')->name('mcp.oauth.authorization-server.nested');
+
+        Router::post($oauthPrefix.'/register', OAuthRegisterController::class);
+    }
+
+    /**
+     * @return array<string, array<int, string>|string>
+     */
+    protected function authorizationServerMetadata(string $path, string $oauthPrefix): array
+    {
+        return [
+            'issuer' => url('/'.$path),
             'authorization_endpoint' => route('passport.authorizations.authorize'),
             'token_endpoint' => route('passport.token'),
             'registration_endpoint' => url($oauthPrefix.'/register'),
@@ -104,9 +126,30 @@ class Registrar
             'code_challenge_methods_supported' => ['S256'],
             'scopes_supported' => ['mcp:use'],
             'grant_types_supported' => ['authorization_code', 'refresh_token'],
-        ]))->where('path', '.*')->name('mcp.oauth.authorization-server');
+        ];
+    }
 
-        Router::post($oauthPrefix.'/register', OAuthRegisterController::class);
+    /**
+     * @return array<string, array<int, string>|string>
+     */
+    protected function protectedResourceMetadata(string $path): array
+    {
+        return [
+            'resource' => url('/'.$path),
+            'authorization_servers' => [url('/'.$path)],
+            'scopes_supported' => ['mcp:use'],
+        ];
+    }
+
+    protected function hasGetRoute(string $uri): bool
+    {
+        foreach (Router::getRoutes()->getRoutes() as $route) {
+            if ($route->uri() === $uri && in_array('GET', $route->methods(), true)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Unit/Server/RegistrarTest.php
+++ b/tests/Unit/Server/RegistrarTest.php
@@ -136,7 +136,7 @@ it('does not override an existing exact oauth authorization server route', funct
 
     $nestedResponse->assertStatus(200);
     $nestedResponse->assertJson([
-        'issuer' => url('/mcp/weather'),
+        'issuer' => url('/'),
         'registration_endpoint' => url('oauth/register'),
         'scopes_supported' => ['mcp:use'],
     ]);
@@ -160,7 +160,7 @@ it('does not override an existing exact oauth protected resource route', functio
     $nestedResponse->assertStatus(200);
     $nestedResponse->assertJson([
         'resource' => url('/mcp/weather'),
-        'authorization_servers' => [url('/mcp/weather')],
+        'authorization_servers' => [url('/')],
         'scopes_supported' => ['mcp:use'],
     ]);
 });

--- a/tests/Unit/Server/RegistrarTest.php
+++ b/tests/Unit/Server/RegistrarTest.php
@@ -142,6 +142,29 @@ it('does not override an existing exact oauth authorization server route', funct
     ]);
 });
 
+it('does not override an existing exact oauth protected resource route', function (): void {
+    Route::get('/.well-known/oauth-protected-resource', fn () => response()->json(['existing' => true]));
+    Route::get('/oauth/authorize')->name('passport.authorizations.authorize');
+    Route::post('/oauth/token')->name('passport.token');
+
+    $registrar = new Registrar;
+    $registrar->oauthRoutes();
+
+    $response = $this->getJson('/.well-known/oauth-protected-resource');
+
+    $response->assertStatus(200);
+    $response->assertJson(['existing' => true]);
+
+    $nestedResponse = $this->getJson('/.well-known/oauth-protected-resource/mcp/weather');
+
+    $nestedResponse->assertStatus(200);
+    $nestedResponse->assertJson([
+        'resource' => url('/mcp/weather'),
+        'authorization_servers' => [url('/mcp/weather')],
+        'scopes_supported' => ['mcp:use'],
+    ]);
+});
+
 it('adds mcp scope when passport is available', function (): void {
     if (! class_exists(Passport::class)) {
         require_once __DIR__.'/../../Fixtures/PassportPassport.php';

--- a/tests/Unit/Server/RegistrarTest.php
+++ b/tests/Unit/Server/RegistrarTest.php
@@ -119,6 +119,29 @@ it('registers oauth routes with custom prefix', function (): void {
     expect($hasRegisterRoute)->toBeTrue();
 });
 
+it('does not override an existing exact oauth authorization server route', function (): void {
+    Route::get('/.well-known/oauth-authorization-server', fn () => response()->json(['existing' => true]));
+    Route::get('/oauth/authorize')->name('passport.authorizations.authorize');
+    Route::post('/oauth/token')->name('passport.token');
+
+    $registrar = new Registrar;
+    $registrar->oauthRoutes();
+
+    $response = $this->getJson('/.well-known/oauth-authorization-server');
+
+    $response->assertStatus(200);
+    $response->assertJson(['existing' => true]);
+
+    $nestedResponse = $this->getJson('/.well-known/oauth-authorization-server/mcp/weather');
+
+    $nestedResponse->assertStatus(200);
+    $nestedResponse->assertJson([
+        'issuer' => url('/mcp/weather'),
+        'registration_endpoint' => url('oauth/register'),
+        'scopes_supported' => ['mcp:use'],
+    ]);
+});
+
 it('adds mcp scope when passport is available', function (): void {
     if (! class_exists(Passport::class)) {
         require_once __DIR__.'/../../Fixtures/PassportPassport.php';


### PR DESCRIPTION
When an application registers its own `/.well-known/oauth-authorization-server` or `/.well-known/oauth-protected-resource` routes before calling `oauthRoutes()`, the MCP package unconditionally overwrites them with its own handlers. This means apps that need custom OAuth discovery metadata (e.g. a separate authorization server) lose their routes silently.

This PR detects pre-existing exact GET routes at those well-known paths and skips registering the MCP handler when one already exists. Nested discovery (e.g. `/.well-known/oauth-authorization-server/mcp/weather`) continues to work on a separate `{path}` route that is always registered.

Also fixes the `Mcp` facade docblock types for PHPStan and updates `AddWwwAuthenticateHeader` middleware to reference the always-present `.nested` route name.

Supersedes #179.