### PR TITLE
Add InvokingTool and ToolInvoked events

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,6 +10,3 @@ parameters:
   ignoreErrors:
     - "#Unsafe usage of new static\\(\\)#"
     - "#Call to an undefined method Illuminate\\\\Contracts\\\\Foundation\\\\Application::routesAreCached#"
-    -
-      message: "#no value type specified in iterable type array#"
-      path: src/Facades/Mcp.php

--- a/src/Events/InvokingTool.php
+++ b/src/Events/InvokingTool.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Events;
+
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Server\Tool;
+
+class InvokingTool
+{
+    public function __construct(
+        public string $invocationId,
+        public Tool $tool,
+        public Request $request,
+    ) {
+        //
+    }
+}

--- a/src/Events/ToolInvoked.php
+++ b/src/Events/ToolInvoked.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Events;
+
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Server\Tool;
+
+class ToolInvoked
+{
+    public function __construct(
+        public string $invocationId,
+        public Tool $tool,
+        public Request $request,
+        public mixed $response,
+    ) {
+        //
+    }
+}

--- a/src/Facades/Mcp.php
+++ b/src/Facades/Mcp.php
@@ -12,9 +12,9 @@ use Laravel\Mcp\Server\Registrar;
  * @method static void local(string $handle, string $serverClass)
  * @method static callable|null getLocalServer(string $handle)
  * @method static \Illuminate\Routing\Route|null getWebServer(string $route)
- * @method static array servers()
+ * @method static array<string, callable|\Illuminate\Routing\Route> servers()
  * @method static void oauthRoutes(string $oauthPrefix = 'oauth')
- * @method static array ensureMcpScope()
+ * @method static array<string, string> ensureMcpScope()
  *
  * @see Registrar
  */

--- a/src/Server/Methods/CallTool.php
+++ b/src/Server/Methods/CallTool.php
@@ -4,11 +4,16 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp\Server\Methods;
 
+use Closure;
 use Generator;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
+use Laravel\Mcp\Events\InvokingTool;
+use Laravel\Mcp\Events\ToolInvoked;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\ResponseFactory;
 use Laravel\Mcp\Server\Contracts\Errable;
@@ -50,6 +55,16 @@ class CallTool implements Errable, Method
                     $request->id,
                 ));
 
+        $events = Container::getInstance()->make(Dispatcher::class);
+        $toolRequest = $request->toRequest();
+        $invocationId = (string) Str::uuid7();
+
+        $events->dispatch(new InvokingTool(
+            invocationId: $invocationId,
+            tool: $tool,
+            request: $toolRequest,
+        ));
+
         try {
             // @phpstan-ignore-next-line
             $response = Container::getInstance()->call([$tool, 'handle']);
@@ -59,9 +74,46 @@ class CallTool implements Errable, Method
             $response = Response::error(ValidationMessages::from($validationException));
         }
 
+        $dispatchInvoked = fn (mixed $finalResponse): mixed => tap($finalResponse, fn () => $events->dispatch(new ToolInvoked(
+            invocationId: $invocationId,
+            tool: $tool,
+            request: $toolRequest,
+            response: $finalResponse,
+        )));
+
+        if ($response instanceof Generator) {
+            return $this->toJsonRpcStreamedResponse(
+                $request,
+                $this->collectStreamedResponses($response, $dispatchInvoked),
+                $this->serializable($tool),
+            );
+        }
+
+        $dispatchInvoked($response);
+
         return is_iterable($response)
             ? $this->toJsonRpcStreamedResponse($request, $response, $this->serializable($tool))
             : $this->toJsonRpcResponse($request, $response, $this->serializable($tool));
+    }
+
+    /**
+     * @param  Generator<int, Response|ResponseFactory|string>  $stream
+     * @param  Closure(array<int, Response|ResponseFactory|string>): mixed  $afterCompleted
+     * @return Generator<int, Response|ResponseFactory|string>
+     */
+    protected function collectStreamedResponses(Generator $stream, Closure $afterCompleted): Generator
+    {
+        $collected = [];
+
+        try {
+            foreach ($stream as $key => $value) {
+                $collected[] = $value;
+
+                yield $key => $value;
+            }
+        } finally {
+            $afterCompleted($collected);
+        }
     }
 
     /**

--- a/tests/Unit/Events/ToolInvokedTest.php
+++ b/tests/Unit/Events/ToolInvokedTest.php
@@ -59,11 +59,11 @@ it('uses the same invocationId for InvokingTool and ToolInvoked', function (): v
     $invoking = null;
     $invoked = null;
 
-    Event::listen(function (InvokingTool $event) use (&$invoking) {
+    Event::listen(function (InvokingTool $event) use (&$invoking): void {
         $invoking = $event;
     });
 
-    Event::listen(function (ToolInvoked $event) use (&$invoked) {
+    Event::listen(function (ToolInvoked $event) use (&$invoked): void {
         $invoked = $event;
     });
 
@@ -181,12 +181,10 @@ it('dispatches ToolInvoked with collected responses after a streamed tool finish
     iterator_to_array($responses);
 
     Event::assertDispatched(InvokingTool::class, 1);
-    Event::assertDispatched(ToolInvoked::class, function (ToolInvoked $event): bool {
-        return is_array($event->response)
-            && count($event->response) === 2
-            && $event->response[0] instanceof Response
-            && $event->response[1] instanceof Response;
-    });
+    Event::assertDispatched(ToolInvoked::class, fn (ToolInvoked $event): bool => is_array($event->response)
+        && count($event->response) === 2
+        && $event->response[0] instanceof Response
+        && $event->response[1] instanceof Response);
 });
 
 it('does not break the streamed response when a listener inspects ToolInvoked', function (): void {
@@ -210,7 +208,7 @@ it('does not break the streamed response when a listener inspects ToolInvoked', 
     $this->instance($toolClass, $tool);
 
     $listenerSawResponses = null;
-    Event::listen(function (ToolInvoked $event) use (&$listenerSawResponses) {
+    Event::listen(function (ToolInvoked $event) use (&$listenerSawResponses): void {
         $listenerSawResponses = is_array($event->response) ? count($event->response) : null;
     });
 
@@ -431,7 +429,7 @@ it('dispatches InvokingTool but not ToolInvoked when the tool throws an uncaught
 
     $this->instance('mcp.request', $request->toRequest());
 
-    expect(fn () => (new CallTool)->handle($request, $context))
+    expect(fn (): Generator|\Laravel\Mcp\Server\Transport\JsonRpcResponse => (new CallTool)->handle($request, $context))
         ->toThrow(RuntimeException::class, 'boom');
 
     Event::assertDispatched(InvokingTool::class);

--- a/tests/Unit/Events/ToolInvokedTest.php
+++ b/tests/Unit/Events/ToolInvokedTest.php
@@ -1,0 +1,439 @@
+<?php
+
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Facades\Event;
+use Laravel\Mcp\Events\InvokingTool;
+use Laravel\Mcp\Events\ToolInvoked;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Methods\CallTool;
+use Laravel\Mcp\Server\ServerContext;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Transport\JsonRpcRequest;
+use Tests\Fixtures\SayHiTool;
+use Tests\Fixtures\SayHiTwiceTool;
+
+it('dispatches InvokingTool and ToolInvoked on a successful tool call', function (): void {
+    Event::fake([InvokingTool::class, ToolInvoked::class]);
+
+    $request = JsonRpcRequest::from([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => 'say-hi-tool',
+            'arguments' => ['name' => 'John Doe'],
+        ],
+    ]);
+
+    $context = new ServerContext(
+        supportedProtocolVersions: ['2025-03-26'],
+        serverCapabilities: [],
+        serverName: 'Test Server',
+        serverVersion: '1.0.0',
+        instructions: 'Test instructions',
+        maxPaginationLength: 50,
+        defaultPaginationLength: 10,
+        tools: [SayHiTool::class],
+        resources: [],
+        prompts: [],
+    );
+
+    $this->instance('mcp.request', $request->toRequest());
+    (new CallTool)->handle($request, $context);
+
+    Event::assertDispatched(InvokingTool::class, fn (InvokingTool $event): bool => $event->tool instanceof SayHiTool
+        && $event->request instanceof Request
+        && $event->request->get('name') === 'John Doe'
+        && $event->invocationId !== '');
+
+    Event::assertDispatched(ToolInvoked::class, fn (ToolInvoked $event): bool => $event->tool instanceof SayHiTool
+        && $event->response instanceof Response
+        && ! $event->response->isError()
+        && $event->invocationId !== '');
+});
+
+it('uses the same invocationId for InvokingTool and ToolInvoked', function (): void {
+    $invoking = null;
+    $invoked = null;
+
+    Event::listen(function (InvokingTool $event) use (&$invoking) {
+        $invoking = $event;
+    });
+
+    Event::listen(function (ToolInvoked $event) use (&$invoked) {
+        $invoked = $event;
+    });
+
+    $request = JsonRpcRequest::from([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => 'say-hi-tool',
+            'arguments' => ['name' => 'John Doe'],
+        ],
+    ]);
+
+    $context = new ServerContext(
+        supportedProtocolVersions: ['2025-03-26'],
+        serverCapabilities: [],
+        serverName: 'Test Server',
+        serverVersion: '1.0.0',
+        instructions: 'Test instructions',
+        maxPaginationLength: 50,
+        defaultPaginationLength: 10,
+        tools: [SayHiTool::class],
+        resources: [],
+        prompts: [],
+    );
+
+    $this->instance('mcp.request', $request->toRequest());
+    (new CallTool)->handle($request, $context);
+
+    expect($invoking)->not->toBeNull()
+        ->and($invoked)->not->toBeNull()
+        ->and($invoking->invocationId)->toBe($invoked->invocationId);
+});
+
+it('dispatches both events when the tool returns multiple responses', function (): void {
+    Event::fake([InvokingTool::class, ToolInvoked::class]);
+
+    $request = JsonRpcRequest::from([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => 'say-hi-twice-tool',
+            'arguments' => ['name' => 'John Doe'],
+        ],
+    ]);
+
+    $context = new ServerContext(
+        supportedProtocolVersions: ['2025-03-26'],
+        serverCapabilities: [],
+        serverName: 'Test Server',
+        serverVersion: '1.0.0',
+        instructions: 'Test instructions',
+        maxPaginationLength: 50,
+        defaultPaginationLength: 10,
+        tools: [SayHiTwiceTool::class],
+        resources: [],
+        prompts: [],
+    );
+
+    $this->instance('mcp.request', $request->toRequest());
+    (new CallTool)->handle($request, $context);
+
+    Event::assertDispatched(InvokingTool::class);
+    Event::assertDispatched(ToolInvoked::class, fn (ToolInvoked $event): bool => is_array($event->response));
+});
+
+it('dispatches ToolInvoked with collected responses after a streamed tool finishes', function (): void {
+    Event::fake([InvokingTool::class, ToolInvoked::class]);
+
+    $tool = new class extends Tool
+    {
+        protected string $description = 'Streaming tool';
+
+        public function handle(Request $request): Generator
+        {
+            yield Response::text('first');
+            yield Response::text('second');
+        }
+
+        public function schema(JsonSchema $schema): array
+        {
+            return [];
+        }
+    };
+
+    $toolClass = $tool::class;
+    $this->instance($toolClass, $tool);
+
+    $request = JsonRpcRequest::from([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => $tool->name(),
+            'arguments' => [],
+        ],
+    ]);
+
+    $context = new ServerContext(
+        supportedProtocolVersions: ['2025-03-26'],
+        serverCapabilities: [],
+        serverName: 'Test Server',
+        serverVersion: '1.0.0',
+        instructions: 'Test instructions',
+        maxPaginationLength: 50,
+        defaultPaginationLength: 10,
+        tools: [$toolClass],
+        resources: [],
+        prompts: [],
+    );
+
+    $this->instance('mcp.request', $request->toRequest());
+    $responses = (new CallTool)->handle($request, $context);
+    iterator_to_array($responses);
+
+    Event::assertDispatched(InvokingTool::class, 1);
+    Event::assertDispatched(ToolInvoked::class, function (ToolInvoked $event): bool {
+        return is_array($event->response)
+            && count($event->response) === 2
+            && $event->response[0] instanceof Response
+            && $event->response[1] instanceof Response;
+    });
+});
+
+it('does not break the streamed response when a listener inspects ToolInvoked', function (): void {
+    $tool = new class extends Tool
+    {
+        protected string $description = 'Streaming tool';
+
+        public function handle(Request $request): Generator
+        {
+            yield Response::text('first');
+            yield Response::text('second');
+        }
+
+        public function schema(JsonSchema $schema): array
+        {
+            return [];
+        }
+    };
+
+    $toolClass = $tool::class;
+    $this->instance($toolClass, $tool);
+
+    $listenerSawResponses = null;
+    Event::listen(function (ToolInvoked $event) use (&$listenerSawResponses) {
+        $listenerSawResponses = is_array($event->response) ? count($event->response) : null;
+    });
+
+    $request = JsonRpcRequest::from([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => $tool->name(),
+            'arguments' => [],
+        ],
+    ]);
+
+    $context = new ServerContext(
+        supportedProtocolVersions: ['2025-03-26'],
+        serverCapabilities: [],
+        serverName: 'Test Server',
+        serverVersion: '1.0.0',
+        instructions: 'Test instructions',
+        maxPaginationLength: 50,
+        defaultPaginationLength: 10,
+        tools: [$toolClass],
+        resources: [],
+        prompts: [],
+    );
+
+    $this->instance('mcp.request', $request->toRequest());
+    $responses = (new CallTool)->handle($request, $context);
+    $envelopes = iterator_to_array($responses);
+
+    expect($envelopes)->toHaveCount(1)
+        ->and($listenerSawResponses)->toBe(2);
+
+    $payload = $envelopes[0]->toArray();
+    expect($payload['result']['content'])->toHaveCount(2)
+        ->and($payload['result']['content'][0]['text'])->toBe('first')
+        ->and($payload['result']['content'][1]['text'])->toBe('second');
+});
+
+it('dispatches both events when the tool returns a ResponseFactory', function (): void {
+    Event::fake([InvokingTool::class, ToolInvoked::class]);
+
+    $tool = new class extends Tool
+    {
+        protected string $description = 'Factory tool';
+
+        public function handle(Request $request): ResponseFactory
+        {
+            return Response::make([Response::text('hello')]);
+        }
+
+        public function schema(JsonSchema $schema): array
+        {
+            return [];
+        }
+    };
+
+    $toolClass = $tool::class;
+    $this->instance($toolClass, $tool);
+
+    $request = JsonRpcRequest::from([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => $tool->name(),
+            'arguments' => [],
+        ],
+    ]);
+
+    $context = new ServerContext(
+        supportedProtocolVersions: ['2025-03-26'],
+        serverCapabilities: [],
+        serverName: 'Test Server',
+        serverVersion: '1.0.0',
+        instructions: 'Test instructions',
+        maxPaginationLength: 50,
+        defaultPaginationLength: 10,
+        tools: [$toolClass],
+        resources: [],
+        prompts: [],
+    );
+
+    $this->instance('mcp.request', $request->toRequest());
+    (new CallTool)->handle($request, $context);
+
+    Event::assertDispatched(ToolInvoked::class, fn (ToolInvoked $event): bool => $event->response instanceof ResponseFactory);
+});
+
+it('dispatches ToolInvoked when validation errors are converted to error responses', function (): void {
+    Event::fake([InvokingTool::class, ToolInvoked::class]);
+
+    $request = JsonRpcRequest::from([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => 'say-hi-tool',
+            'arguments' => ['name' => ''],
+        ],
+    ]);
+
+    $context = new ServerContext(
+        supportedProtocolVersions: ['2025-03-26'],
+        serverCapabilities: [],
+        serverName: 'Test Server',
+        serverVersion: '1.0.0',
+        instructions: 'Test instructions',
+        maxPaginationLength: 50,
+        defaultPaginationLength: 10,
+        tools: [SayHiTool::class],
+        resources: [],
+        prompts: [],
+    );
+
+    $this->instance('mcp.request', $request->toRequest());
+    (new CallTool)->handle($request, $context);
+
+    Event::assertDispatched(InvokingTool::class);
+    Event::assertDispatched(ToolInvoked::class, fn (ToolInvoked $event): bool => $event->response instanceof Response
+        && $event->response->isError());
+});
+
+it('dispatches ToolInvoked when authentication errors are converted to error responses', function (): void {
+    Event::fake([InvokingTool::class, ToolInvoked::class]);
+
+    $tool = new class extends Tool
+    {
+        protected string $description = 'Unauthenticated tool';
+
+        public function handle(Request $request): Response
+        {
+            throw new AuthenticationException('Unauthenticated.');
+        }
+
+        public function schema(JsonSchema $schema): array
+        {
+            return [];
+        }
+    };
+
+    $toolClass = $tool::class;
+    $this->instance($toolClass, $tool);
+
+    $request = JsonRpcRequest::from([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => $tool->name(),
+            'arguments' => [],
+        ],
+    ]);
+
+    $context = new ServerContext(
+        supportedProtocolVersions: ['2025-03-26'],
+        serverCapabilities: [],
+        serverName: 'Test Server',
+        serverVersion: '1.0.0',
+        instructions: 'Test instructions',
+        maxPaginationLength: 50,
+        defaultPaginationLength: 10,
+        tools: [$toolClass],
+        resources: [],
+        prompts: [],
+    );
+
+    $this->instance('mcp.request', $request->toRequest());
+    (new CallTool)->handle($request, $context);
+
+    Event::assertDispatched(ToolInvoked::class, fn (ToolInvoked $event): bool => $event->response instanceof Response
+        && $event->response->isError());
+});
+
+it('dispatches InvokingTool but not ToolInvoked when the tool throws an uncaught exception', function (): void {
+    Event::fake([InvokingTool::class, ToolInvoked::class]);
+
+    $tool = new class extends Tool
+    {
+        protected string $description = 'Boom tool';
+
+        public function handle(Request $request): Response
+        {
+            throw new RuntimeException('boom');
+        }
+
+        public function schema(JsonSchema $schema): array
+        {
+            return [];
+        }
+    };
+
+    $toolClass = $tool::class;
+    $this->instance($toolClass, $tool);
+
+    $request = JsonRpcRequest::from([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => $tool->name(),
+            'arguments' => [],
+        ],
+    ]);
+
+    $context = new ServerContext(
+        supportedProtocolVersions: ['2025-03-26'],
+        serverCapabilities: [],
+        serverName: 'Test Server',
+        serverVersion: '1.0.0',
+        instructions: 'Test instructions',
+        maxPaginationLength: 50,
+        defaultPaginationLength: 10,
+        tools: [$toolClass],
+        resources: [],
+        prompts: [],
+    );
+
+    $this->instance('mcp.request', $request->toRequest());
+
+    expect(fn () => (new CallTool)->handle($request, $context))
+        ->toThrow(RuntimeException::class, 'boom');
+
+    Event::assertDispatched(InvokingTool::class);
+    Event::assertNotDispatched(ToolInvoked::class);
+});


### PR DESCRIPTION
Adds a pre/post invocation event pair around tool calls, mirroring the pattern already used by `laravel/ai` (`InvokingTool` / `ToolInvoked`). Listeners can hook tool invocations for audit logs, metrics, rate limiting, and similar cross-cutting concerns without subclassing every `Tool`.

## Behaviour

- `InvokingTool` fires before the tool's `handle()` runs.
- `ToolInvoked` fires after, on successful responses and on `AuthenticationException` / `AuthorizationException` / `ValidationException` that `CallTool` already converts to error responses.
- Uncaught exceptions propagate without firing `ToolInvoked`, matching `laravel/ai`'s convention.
- The shared `invocationId` correlates the two events.

## Streamed tools

For tools that return a `Generator`, a passthrough generator collects yielded responses as they're consumed by the framework and dispatches `ToolInvoked` from a `finally` block once iteration completes. Listeners receive the full collected response set without consuming the stream the framework iterates.

## Usage

```php
use Laravel\Mcp\Events\ToolInvoked;

Event::listen(function (ToolInvoked $event): void {
    activity('user')
        ->causedBy($event->request->user())
        ->event($event->tool->name())
        ->withProperties([
            'tool'       => $event->tool->name(),
            'arguments'  => $event->request->all(),
            'session_id' => $event->request->sessionId(),
        ])
        ->log('MCP '.$event->tool->name());
});
```

Implement `ShouldQueue` on the listener to push the work off the request thread.

## Compatibility

Purely additive, no existing behaviour changes.