### PR TITLE
Return 201 from OAuth client registration per RFC 7591

### DIFF
--- a/.github/workflows/facade.yml
+++ b/.github/workflows/facade.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Update facade docblocks
         run: php -f vendor/bin/facade.php -- Laravel\\Mcp\\Facades\\Mcp
 
+      - name: Format with Pint
+        run: vendor/bin/pint src/Facades/Mcp.php
+
       - name: Commit facade docblocks
         uses: stefanzweifel/git-auto-commit-action@v5
         with:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,3 +10,6 @@ parameters:
   ignoreErrors:
     - "#Unsafe usage of new static\\(\\)#"
     - "#Call to an undefined method Illuminate\\\\Contracts\\\\Foundation\\\\Application::routesAreCached#"
+    -
+      message: "#no value type specified in iterable type array#"
+      path: src/Facades/Mcp.php

--- a/src/Facades/Mcp.php
+++ b/src/Facades/Mcp.php
@@ -16,7 +16,7 @@ use Laravel\Mcp\Server\Registrar;
  * @method static void oauthRoutes(string $oauthPrefix = 'oauth')
  * @method static array ensureMcpScope()
  *
- * @see \Laravel\Mcp\Server\Registrar
+ * @see Registrar
  */
 class Mcp extends Facade
 {

--- a/src/Server/Http/Controllers/OAuthRegisterController.php
+++ b/src/Server/Http/Controllers/OAuthRegisterController.php
@@ -90,7 +90,7 @@ class OAuthRegisterController
             'redirect_uris' => $client->redirect_uris,
             'scope' => 'mcp:use',
             'token_endpoint_auth_method' => 'none',
-        ]);
+        ], 201);
     }
 
     protected function isValidRedirectUri(string $value): bool

--- a/tests/Unit/Server/RegistrarTest.php
+++ b/tests/Unit/Server/RegistrarTest.php
@@ -210,7 +210,7 @@ it('handles oauth registration endpoint', function (): void {
         'redirect_uris' => ['http://localhost:3000/callback'],
     ]);
 
-    $response->assertStatus(200);
+    $response->assertStatus(201);
     $response->assertJson([
         'client_id' => 'test-client-id',
         'grant_types' => ['authorization_code'],
@@ -280,7 +280,7 @@ it('falls back to the legacy name field for oauth registration', function (): vo
         'redirect_uris' => ['http://localhost:3000/callback'],
     ]);
 
-    $response->assertStatus(200);
+    $response->assertStatus(201);
 
     expect($clientRepository->capturedName)->toBe('Legacy Client');
 });
@@ -313,7 +313,7 @@ it('prefers client_name over name for oauth registration', function (): void {
         'redirect_uris' => ['http://localhost:3000/callback'],
     ]);
 
-    $response->assertStatus(200);
+    $response->assertStatus(201);
 
     expect($clientRepository->capturedName)->toBe('Preferred Client');
 });
@@ -333,7 +333,7 @@ it('handles oauth registration with allowed domains', function (): void {
         'redirect_uris' => ['http://localhost:3000/callback'],
     ]);
 
-    $response->assertStatus(200);
+    $response->assertStatus(201);
     $response->assertJson([
         'client_id' => 'test-client-id',
         'grant_types' => ['authorization_code'],
@@ -359,7 +359,7 @@ it('allows localhost with dynamic port when localhost is in redirect_domains', f
         'redirect_uris' => [$uri],
     ]);
 
-    $response->assertStatus(200);
+    $response->assertStatus(201);
 })->with([
     'localhost' => ['http://localhost:18293/callback'],
     '127.0.0.1' => ['http://127.0.0.1:29100/callback'],
@@ -439,7 +439,7 @@ it('allows all localhost hosts when any localhost variant is in redirect_domains
         'redirect_uris' => ['http://localhost:18293/callback'],
     ]);
 
-    $response->assertStatus(200);
+    $response->assertStatus(201);
 })->with([
     'http://127.0.0.1' => ['http://127.0.0.1'],
     'http://[::1]' => ['http://[::1]'],
@@ -607,7 +607,7 @@ it('accepts custom scheme redirect URIs when the scheme is configured', function
         'redirect_uris' => [$uri],
     ]);
 
-    $response->assertStatus(200);
+    $response->assertStatus(201);
     $response->assertJson([
         'client_id' => 'test-client-id',
         'redirect_uris' => [$uri],
@@ -687,7 +687,7 @@ it('still allows standard http URLs when custom schemes are configured', functio
         'redirect_uris' => ['http://localhost:3000/callback'],
     ]);
 
-    $response->assertStatus(200);
+    $response->assertStatus(201);
 });
 
 it('returns json validation errors even without Accept application/json header', function (): void {


### PR DESCRIPTION
This PR adjusts the response code of the OAuth client registration to match the spec https://www.rfc-editor.org/rfc/rfc7591.html#section-3.2

Today it's responding with 200 while spec specifies 201.

I ran into this issue when attempting to use our MCP server in Antigravity which seems to be more strict when it comes to spec alignment. Where-as ChatGPT and others seem to allow 200 just the same.

Adjusted unit tests to match the new expected status code.

Not sure in terms of compatibility. Some users may rely on status code 200, even though the spec dictates 201.