### PR TITLE
Fix TypeError when JSON-RPC request id is not a string or int

### DIFF
--- a/src/Server/Exceptions/JsonRpcException.php
+++ b/src/Server/Exceptions/JsonRpcException.php
@@ -23,8 +23,12 @@ class JsonRpcException extends Exception
 
     public function toJsonRpcResponse(): JsonRpcResponse
     {
+        $id = is_string($this->requestId) || is_int($this->requestId)
+            ? $this->requestId
+            : null;
+
         return JsonRpcResponse::error(
-            id: $this->requestId,
+            id: $id,
             code: $this->getCode(),
             message: $this->getMessage(),
             data: $this->data,

--- a/tests/Unit/Exceptions/JsonRpcExceptionTest.php
+++ b/tests/Unit/Exceptions/JsonRpcExceptionTest.php
@@ -42,3 +42,26 @@ it('converts to JsonRpc error with id and without data', function (): void {
         ],
     ]);
 });
+
+it('coerces non-string and non-integer request ids to null', function (mixed $invalidId): void {
+    $exception = new JsonRpcException(
+        message: 'Invalid Request',
+        code: -32600,
+        requestId: $invalidId,
+    );
+
+    $response = $exception->toJsonRpcResponse();
+
+    expect($response->toArray())->toEqual([
+        'jsonrpc' => '2.0',
+        'error' => [
+            'code' => -32600,
+            'message' => 'Invalid Request',
+        ],
+    ]);
+})->with([
+    'float' => [1.0],
+    'array' => [['foo' => 'bar']],
+    'bool' => [true],
+    'object' => [(object) ['foo' => 'bar']],
+]);


### PR DESCRIPTION
Closes #206
