### PR TITLE
feat(response): add resource link content

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -15,6 +15,7 @@ use Laravel\Mcp\Server\Content\Audio;
 use Laravel\Mcp\Server\Content\Blob;
 use Laravel\Mcp\Server\Content\Image;
 use Laravel\Mcp\Server\Content\Notification;
+use Laravel\Mcp\Server\Content\ResourceLink;
 use Laravel\Mcp\Server\Content\Text;
 use Laravel\Mcp\Server\Contracts\Content;
 use League\Flysystem\UnableToReadFile;
@@ -136,6 +137,15 @@ class Response
     public static function image(string $data, string $mimeType = 'image/png'): static
     {
         return new static(new Image($data, $mimeType));
+    }
+
+    public static function resourceLink(
+        string $uri,
+        string $name,
+        ?string $mimeType = null,
+        ?string $description = null,
+    ): static {
+        return new static(new ResourceLink($uri, $name, $mimeType, $description));
     }
 
     public static function fromStorage(string $path, ?string $disk = null, ?string $mimeType = null): static

--- a/src/Server/Content/ResourceLink.php
+++ b/src/Server/Content/ResourceLink.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Server\Content;
+
+use Laravel\Mcp\Server\Concerns\HasAnnotations;
+use Laravel\Mcp\Server\Concerns\HasMeta;
+use Laravel\Mcp\Server\Contracts\Content;
+use Laravel\Mcp\Server\Prompt;
+use Laravel\Mcp\Server\Resource;
+use Laravel\Mcp\Server\Tool;
+
+class ResourceLink implements Content
+{
+    use HasAnnotations;
+    use HasMeta;
+
+    public function __construct(
+        protected string $uri,
+        protected string $name,
+        protected ?string $mimeType = null,
+        protected ?string $description = null,
+    ) {
+        //
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toTool(Tool $tool): array
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toPrompt(Prompt $prompt): array
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toResource(Resource $resource): array
+    {
+        return $this->mergeMeta([
+            'uri' => $resource->uri(),
+            'mimeType' => $resource->mimeType(),
+        ]);
+    }
+
+    public function __toString(): string
+    {
+        return $this->uri;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $data = [
+            'type' => 'resource_link',
+            'uri' => $this->uri,
+            'name' => $this->name,
+        ];
+
+        if ($this->description !== null) {
+            $data['description'] = $this->description;
+        }
+
+        if ($this->mimeType !== null) {
+            $data['mimeType'] = $this->mimeType;
+        }
+
+        $annotations = $this->annotations();
+
+        if ($annotations !== []) {
+            $data['annotations'] = $annotations;
+        }
+
+        return $this->mergeMeta($data);
+    }
+
+    /**
+     * @return array<int, class-string>
+     */
+    protected function allowedAnnotations(): array
+    {
+        return [
+            \Laravel\Mcp\Server\Annotations\Annotation::class,
+        ];
+    }
+}

--- a/src/Server/Content/ResourceLink.php
+++ b/src/Server/Content/ResourceLink.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp\Server\Content;
 
+use Laravel\Mcp\Server\Annotations\Annotation;
 use Laravel\Mcp\Server\Concerns\HasAnnotations;
 use Laravel\Mcp\Server\Concerns\HasMeta;
 use Laravel\Mcp\Server\Contracts\Content;
@@ -91,7 +92,7 @@ class ResourceLink implements Content
     protected function allowedAnnotations(): array
     {
         return [
-            \Laravel\Mcp\Server\Annotations\Annotation::class,
+            Annotation::class,
         ];
     }
 }

--- a/tests/Unit/Content/ResourceLinkTest.php
+++ b/tests/Unit/Content/ResourceLinkTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Mcp\Server\Annotations\Audience;
+use Laravel\Mcp\Server\Content\ResourceLink;
+use Laravel\Mcp\Enums\Role;
+use Laravel\Mcp\Server\Prompt;
+use Laravel\Mcp\Server\Tool;
+
+it('may be used in tools', function (): void {
+    $link = new ResourceLink(
+        'file:///tmp/report.csv',
+        'report.csv',
+        'text/csv',
+        'Generated report'
+    );
+
+    $payload = $link->toTool(new class extends Tool {});
+
+    expect($payload)->toEqual([
+        'type' => 'resource_link',
+        'uri' => 'file:///tmp/report.csv',
+        'name' => 'report.csv',
+        'description' => 'Generated report',
+        'mimeType' => 'text/csv',
+    ]);
+});
+
+it('may be used in prompts', function (): void {
+    $link = new ResourceLink('file:///tmp/report.csv', 'report.csv');
+
+    $payload = $link->toPrompt(new class extends Prompt {});
+
+    expect($payload)->toEqual([
+        'type' => 'resource_link',
+        'uri' => 'file:///tmp/report.csv',
+        'name' => 'report.csv',
+    ]);
+});
+
+it('supports annotations and meta', function (): void {
+    $link = new #[Audience([Role::User])] class('file:///tmp/report.csv', 'report.csv') extends ResourceLink {};
+    $link->setMeta(['origin' => 'export']);
+
+    $payload = $link->toArray();
+
+    expect($payload)->toMatchArray([
+        'type' => 'resource_link',
+        'uri' => 'file:///tmp/report.csv',
+        'name' => 'report.csv',
+        'annotations' => ['audience' => ['user']],
+        '_meta' => ['origin' => 'export'],
+    ]);
+});

--- a/tests/Unit/Content/ResourceLinkTest.php
+++ b/tests/Unit/Content/ResourceLinkTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
+use Laravel\Mcp\Enums\Role;
 use Laravel\Mcp\Server\Annotations\Audience;
 use Laravel\Mcp\Server\Content\ResourceLink;
-use Laravel\Mcp\Enums\Role;
 use Laravel\Mcp\Server\Prompt;
 use Laravel\Mcp\Server\Tool;
 

--- a/tests/Unit/ResponseTest.php
+++ b/tests/Unit/ResponseTest.php
@@ -9,6 +9,7 @@ use Laravel\Mcp\Server\Content\Audio;
 use Laravel\Mcp\Server\Content\Blob;
 use Laravel\Mcp\Server\Content\Image;
 use Laravel\Mcp\Server\Content\Notification;
+use Laravel\Mcp\Server\Content\ResourceLink;
 use Laravel\Mcp\Server\Content\Text;
 
 it('creates a notification response', function (): void {
@@ -77,6 +78,24 @@ it('creates an audio response with custom mime type', function (): void {
 
     expect($response->content())->toBeInstanceOf(Audio::class)
         ->and($response->content()->toArray()['mimeType'])->toBe('audio/mp3');
+});
+
+it('creates a resource link response', function (): void {
+    $response = Response::resourceLink(
+        'file:///tmp/report.csv',
+        'report.csv',
+        'text/csv',
+        'Generated report'
+    );
+
+    expect($response->content())->toBeInstanceOf(ResourceLink::class)
+        ->and($response->content()->toArray())->toEqual([
+            'type' => 'resource_link',
+            'uri' => 'file:///tmp/report.csv',
+            'name' => 'report.csv',
+            'description' => 'Generated report',
+            'mimeType' => 'text/csv',
+        ]);
 });
 
 it('creates image response with content meta', function (): void {


### PR DESCRIPTION
## Summary
- add a `ResourceLink` content type for tool and prompt responses
- add `Response::resourceLink()` as the public factory API
- cover the new content type with focused unit tests

## Testing
- `php vendor/bin/pest tests/Unit/Content/ResourceLinkTest.php tests/Unit/ResponseTest.php`
- `php vendor/bin/phpstan --no-progress`

## Issue
- fixes #199
