### PR TITLE
Extract protocol versions to shared enum for client reuse

### DIFF
--- a/src/Enums/ProtocolVersion.php
+++ b/src/Enums/ProtocolVersion.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Enums;
+
+enum ProtocolVersion: string
+{
+    case V2025_11_25 = '2025-11-25';
+    case V2025_06_18 = '2025-06-18';
+    case V2025_03_26 = '2025-03-26';
+    case V2024_11_05 = '2024-11-05';
+
+    public const LATEST = self::V2025_11_25;
+
+    /**
+     * @return array<int, string>
+     */
+    public static function supported(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/src/Server.php
+++ b/src/Server.php
@@ -6,6 +6,7 @@ namespace Laravel\Mcp;
 
 use Illuminate\Container\Container;
 use Illuminate\Support\Str;
+use Laravel\Mcp\Enums\ProtocolVersion;
 use Laravel\Mcp\Events\SessionInitialized;
 use Laravel\Mcp\Exceptions\JsonRpcException;
 use Laravel\Mcp\Server\AppResource;
@@ -65,12 +66,7 @@ abstract class Server
     /**
      * @var array<int, string>
      */
-    protected array $supportedProtocolVersion = [
-        '2025-11-25',
-        '2025-06-18',
-        '2025-03-26',
-        '2024-11-05',
-    ];
+    protected array $supportedProtocolVersion = [];
 
     /**
      * @var array<string, array<string, bool>|stdClass|string>
@@ -238,7 +234,7 @@ abstract class Server
         $instructions = $this->resolveAttribute(Instructions::class);
 
         return new ServerContext(
-            supportedProtocolVersions: $this->supportedProtocolVersion,
+            supportedProtocolVersions: $this->supportedProtocolVersion ?: ProtocolVersion::supported(),
             serverCapabilities: $this->capabilities,
             serverName: $name !== null ? $name->value : $this->name,
             serverVersion: $version !== null ? $version->value : $this->version,

--- a/tests/Unit/Enums/ProtocolVersionTest.php
+++ b/tests/Unit/Enums/ProtocolVersionTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Mcp\Enums\ProtocolVersion;
+
+it('exposes a non-empty list of supported versions', function (): void {
+    expect(ProtocolVersion::supported())->not->toBeEmpty();
+});
+
+it('lists the latest version first', function (): void {
+    expect(ProtocolVersion::supported()[0])->toBe(ProtocolVersion::LATEST->value);
+});
+
+it('includes the latest version in supported list', function (): void {
+    expect(ProtocolVersion::supported())->toContain(ProtocolVersion::LATEST->value);
+});
+
+it('returns only string values', function (): void {
+    foreach (ProtocolVersion::supported() as $version) {
+        expect($version)->toBeString();
+    }
+});


### PR DESCRIPTION
Currently the list of MCP protocol versions the package speaks is hardcoded inside `Server.php`:

```php
protected array $supportedProtocolVersion = [
    '2025-11-25',
    '2025-06-18',
    '2025-03-26',
    '2024-11-05',
];
```

The upcoming MCP client (per the shipping plan) needs the same information — both sides need to agree on what versions exist, and the client needs to know which one is "latest" to send during the `initialize` handshake. Duplicating the list in two places will inevitably drift.

This PR moves the list into a shared enum, so server and client read from one place:

```php
use Laravel\Mcp\Enums\ProtocolVersion;

ProtocolVersion::LATEST;        // V2025_11_25 (for the future client)
ProtocolVersion::supported();   // ['2025-11-25', '2025-06-18', '2025-03-26', '2024-11-05']
```

Servers that don't override the property continue to advertise the full supported list — no behavior change. If you want to pin a server to a single version, the override path stays the same as today:

```php
class MyServer extends Server
{
    protected array $supportedProtocolVersion = [
        ProtocolVersion::V2025_11_25->value,
    ];
}
```
