### PR TITLE
Resolve URI template variables when testing resources

### DIFF
--- a/src/Server/Testing/PendingTestResponse.php
+++ b/src/Server/Testing/PendingTestResponse.php
@@ -15,8 +15,10 @@ use Laravel\Mcp\Server\Prompt;
 use Laravel\Mcp\Server\Resource;
 use Laravel\Mcp\Server\Tool;
 use Laravel\Mcp\Server\Transport\FakeTransporter;
+use Laravel\Mcp\Support\UriTemplate;
 use Laravel\Mcp\Transport\JsonRpcRequest;
 use Laravel\Mcp\Transport\JsonRpcResponse;
+use Stringable;
 
 class PendingTestResponse
 {
@@ -165,8 +167,8 @@ class PendingTestResponse
             'arguments' => $arguments,
         ];
 
-        if ($primitive instanceof Resource && $primitive instanceof HasUriTemplate) {
-            $params['uri'] = $primitive->uriTemplate()->expand($arguments);
+        if ($primitive instanceof HasUriTemplate) {
+            $params['uri'] = $this->expandUriTemplate($primitive->uriTemplate(), $arguments);
         }
 
         $request = new JsonRpcRequest(uniqid(), $method, $params);
@@ -174,5 +176,37 @@ class PendingTestResponse
         $response = $this->executeRequest($server, $request);
 
         return new TestResponse($primitive, $response);
+    }
+
+    /**
+     * @param  array<string, mixed>  $variables
+     */
+    protected function expandUriTemplate(UriTemplate $template, array $variables): string
+    {
+        $expanded = (string) $template;
+
+        preg_match_all('/\{(\w+)}/', $expanded, $matches);
+
+        foreach (array_unique($matches[1]) as $name) {
+            if (! array_key_exists($name, $variables)) {
+                throw new InvalidArgumentException("Missing value for URI template variable [{$name}].");
+            }
+
+            $value = $variables[$name];
+
+            if (! is_scalar($value) && ! $value instanceof Stringable) {
+                throw new InvalidArgumentException("URI template variable [{$name}] must be a scalar or Stringable value.");
+            }
+
+            $value = (string) $value;
+
+            if (str_contains($value, '/')) {
+                throw new InvalidArgumentException("URI template variable [{$name}] value must not contain '/'.");
+            }
+
+            $expanded = str_replace('{'.$name.'}', $value, $expanded);
+        }
+
+        return $expanded;
     }
 }

--- a/src/Server/Testing/PendingTestResponse.php
+++ b/src/Server/Testing/PendingTestResponse.php
@@ -167,7 +167,7 @@ class PendingTestResponse
             'arguments' => $arguments,
         ];
 
-        if ($primitive instanceof HasUriTemplate) {
+        if ($method === 'resources/read' && $primitive instanceof HasUriTemplate) {
             $params['uri'] = $this->expandUriTemplate($primitive->uriTemplate(), $arguments);
         }
 
@@ -185,9 +185,7 @@ class PendingTestResponse
     {
         $expanded = (string) $template;
 
-        preg_match_all('/\{(\w+)}/', $expanded, $matches);
-
-        foreach (array_unique($matches[1]) as $name) {
+        foreach ($template->variableNames() as $name) {
             if (! array_key_exists($name, $variables)) {
                 throw new InvalidArgumentException("Missing value for URI template variable [{$name}].");
             }

--- a/src/Server/Testing/PendingTestResponse.php
+++ b/src/Server/Testing/PendingTestResponse.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Auth\Authenticatable;
 use InvalidArgumentException;
 use Laravel\Mcp\Exceptions\JsonRpcException;
 use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Contracts\HasUriTemplate;
 use Laravel\Mcp\Server\Primitive;
 use Laravel\Mcp\Server\Prompt;
 use Laravel\Mcp\Server\Resource;
@@ -159,14 +160,16 @@ class PendingTestResponse
         $primitive = $this->resolvePrimitive($primitive);
         $server = $this->initializeServer();
 
-        $request = new JsonRpcRequest(
-            uniqid(),
-            $method,
-            [
-                ...$primitive->toMethodCall(),
-                'arguments' => $arguments,
-            ],
-        );
+        $params = [
+            ...$primitive->toMethodCall(),
+            'arguments' => $arguments,
+        ];
+
+        if ($primitive instanceof Resource && $primitive instanceof HasUriTemplate) {
+            $params['uri'] = $primitive->uriTemplate()->expand($arguments);
+        }
+
+        $request = new JsonRpcRequest(uniqid(), $method, $params);
 
         $response = $this->executeRequest($server, $request);
 

--- a/src/Support/UriTemplate.php
+++ b/src/Support/UriTemplate.php
@@ -58,6 +58,14 @@ class UriTemplate implements Stringable
         return $result;
     }
 
+    /**
+     * @return list<string>
+     */
+    public function variableNames(): array
+    {
+        return array_values(array_unique($this->variableNames));
+    }
+
     public function __toString(): string
     {
         return $this->template;

--- a/src/Support/UriTemplate.php
+++ b/src/Support/UriTemplate.php
@@ -37,6 +37,24 @@ class UriTemplate implements Stringable
     }
 
     /**
+     * @param  array<string, scalar|Stringable>  $variables
+     */
+    public function expand(array $variables): string
+    {
+        $expanded = $this->template;
+
+        foreach ($this->variableNames as $name) {
+            if (! array_key_exists($name, $variables)) {
+                continue;
+            }
+
+            $expanded = str_replace('{'.$name.'}', (string) $variables[$name], $expanded);
+        }
+
+        return $expanded;
+    }
+
+    /**
      * @return array<string, string>|null
      */
     public function match(string $uri): ?array

--- a/src/Support/UriTemplate.php
+++ b/src/Support/UriTemplate.php
@@ -37,24 +37,6 @@ class UriTemplate implements Stringable
     }
 
     /**
-     * @param  array<string, scalar|Stringable>  $variables
-     */
-    public function expand(array $variables): string
-    {
-        $expanded = $this->template;
-
-        foreach ($this->variableNames as $name) {
-            if (! array_key_exists($name, $variables)) {
-                continue;
-            }
-
-            $expanded = str_replace('{'.$name.'}', (string) $variables[$name], $expanded);
-        }
-
-        return $expanded;
-    }
-
-    /**
      * @return array<string, string>|null
      */
     public function match(string $uri): ?array

--- a/tests/Feature/Testing/Resources/UriTemplateTest.php
+++ b/tests/Feature/Testing/Resources/UriTemplateTest.php
@@ -2,58 +2,12 @@
 
 declare(strict_types=1);
 
-use Laravel\Mcp\Request;
-use Laravel\Mcp\Response;
-use Laravel\Mcp\Server;
-use Laravel\Mcp\Server\Contracts\HasUriTemplate;
-use Laravel\Mcp\Server\Resource;
-use Laravel\Mcp\Support\UriTemplate;
-
-class SummaryResource extends Resource implements HasUriTemplate
-{
-    public function uriTemplate(): UriTemplate
-    {
-        return new UriTemplate('file://summary/{id}');
-    }
-
-    public function handle(Request $request): Response
-    {
-        $request->validate(['id' => 'required|string']);
-
-        return Response::json([
-            'id' => $request->get('id'),
-            'uri' => $request->uri(),
-        ]);
-    }
-}
-
-class UserFileResource extends Resource implements HasUriTemplate
-{
-    public function uriTemplate(): UriTemplate
-    {
-        return new UriTemplate('file://users/{userId}/files/{fileId}');
-    }
-
-    public function handle(Request $request): Response
-    {
-        return Response::json([
-            'userId' => $request->get('userId'),
-            'fileId' => $request->get('fileId'),
-            'uri' => $request->uri(),
-        ]);
-    }
-}
-
-class TemplateResourceServer extends Server
-{
-    protected array $resources = [
-        SummaryResource::class,
-        UserFileResource::class,
-    ];
-}
+use Tests\Fixtures\UriTemplateSummaryResource;
+use Tests\Fixtures\UriTemplateTestServer;
+use Tests\Fixtures\UriTemplateUserFileResource;
 
 it('resolves URI template variables from arguments when testing resources', function (): void {
-    $response = TemplateResourceServer::resource(SummaryResource::class, ['id' => 'abc']);
+    $response = UriTemplateTestServer::resource(UriTemplateSummaryResource::class, ['id' => 'abc']);
 
     $response->assertOk()
         ->assertSee('"id":"abc"')
@@ -61,7 +15,7 @@ it('resolves URI template variables from arguments when testing resources', func
 });
 
 it('resolves multiple URI template variables when testing resources', function (): void {
-    $response = TemplateResourceServer::resource(UserFileResource::class, [
+    $response = UriTemplateTestServer::resource(UriTemplateUserFileResource::class, [
         'userId' => '42',
         'fileId' => 'document.pdf',
     ]);
@@ -71,3 +25,47 @@ it('resolves multiple URI template variables when testing resources', function (
         ->assertSee('"fileId":"document.pdf"')
         ->assertSee('"uri":"file://users/42/files/document.pdf"');
 });
+
+it('casts non-string scalar arguments when expanding URI templates', function (): void {
+    $response = UriTemplateTestServer::resource(UriTemplateSummaryResource::class, ['id' => 123]);
+
+    $response->assertOk()
+        ->assertSee('"uri":"file://summary/123"');
+});
+
+it('accepts Stringable arguments when expanding URI templates', function (): void {
+    $stringable = new class implements Stringable
+    {
+        public function __toString(): string
+        {
+            return 'abc';
+        }
+    };
+
+    $response = UriTemplateTestServer::resource(UriTemplateSummaryResource::class, ['id' => $stringable]);
+
+    $response->assertOk()
+        ->assertSee('"uri":"file://summary/abc"');
+});
+
+it('ignores extra arguments that do not appear in the URI template', function (): void {
+    $response = UriTemplateTestServer::resource(UriTemplateSummaryResource::class, [
+        'id' => 'abc',
+        'extra' => 'value',
+    ]);
+
+    $response->assertOk()
+        ->assertSee('"uri":"file://summary/abc"');
+});
+
+it('throws when a required URI template variable is missing', function (): void {
+    UriTemplateTestServer::resource(UriTemplateUserFileResource::class, ['userId' => '42']);
+})->throws(InvalidArgumentException::class, 'Missing value for URI template variable [fileId]');
+
+it('throws when a URI template variable value contains a slash', function (): void {
+    UriTemplateTestServer::resource(UriTemplateSummaryResource::class, ['id' => 'a/b']);
+})->throws(InvalidArgumentException::class, "URI template variable [id] value must not contain '/'");
+
+it('throws when a URI template variable value is not scalar or Stringable', function (): void {
+    UriTemplateTestServer::resource(UriTemplateSummaryResource::class, ['id' => ['array']]);
+})->throws(InvalidArgumentException::class, 'URI template variable [id] must be a scalar or Stringable value');

--- a/tests/Feature/Testing/Resources/UriTemplateTest.php
+++ b/tests/Feature/Testing/Resources/UriTemplateTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Contracts\HasUriTemplate;
+use Laravel\Mcp\Server\Resource;
+use Laravel\Mcp\Support\UriTemplate;
+
+class SummaryResource extends Resource implements HasUriTemplate
+{
+    public function uriTemplate(): UriTemplate
+    {
+        return new UriTemplate('file://summary/{id}');
+    }
+
+    public function handle(Request $request): Response
+    {
+        $request->validate(['id' => 'required|string']);
+
+        return Response::json([
+            'id' => $request->get('id'),
+            'uri' => $request->uri(),
+        ]);
+    }
+}
+
+class UserFileResource extends Resource implements HasUriTemplate
+{
+    public function uriTemplate(): UriTemplate
+    {
+        return new UriTemplate('file://users/{userId}/files/{fileId}');
+    }
+
+    public function handle(Request $request): Response
+    {
+        return Response::json([
+            'userId' => $request->get('userId'),
+            'fileId' => $request->get('fileId'),
+            'uri' => $request->uri(),
+        ]);
+    }
+}
+
+class TemplateResourceServer extends Server
+{
+    protected array $resources = [
+        SummaryResource::class,
+        UserFileResource::class,
+    ];
+}
+
+it('resolves URI template variables from arguments when testing resources', function (): void {
+    $response = TemplateResourceServer::resource(SummaryResource::class, ['id' => 'abc']);
+
+    $response->assertOk()
+        ->assertSee('"id":"abc"')
+        ->assertSee('"uri":"file://summary/abc"');
+});
+
+it('resolves multiple URI template variables when testing resources', function (): void {
+    $response = TemplateResourceServer::resource(UserFileResource::class, [
+        'userId' => '42',
+        'fileId' => 'document.pdf',
+    ]);
+
+    $response->assertOk()
+        ->assertSee('"userId":"42"')
+        ->assertSee('"fileId":"document.pdf"')
+        ->assertSee('"uri":"file://users/42/files/document.pdf"');
+});

--- a/tests/Fixtures/UriTemplateSummaryResource.php
+++ b/tests/Fixtures/UriTemplateSummaryResource.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Contracts\HasUriTemplate;
+use Laravel\Mcp\Server\Resource;
+use Laravel\Mcp\Support\UriTemplate;
+
+class UriTemplateSummaryResource extends Resource implements HasUriTemplate
+{
+    public function uriTemplate(): UriTemplate
+    {
+        return new UriTemplate('file://summary/{id}');
+    }
+
+    public function handle(Request $request): Response
+    {
+        $request->validate(['id' => 'required|string']);
+
+        return Response::json([
+            'id' => $request->get('id'),
+            'uri' => $request->uri(),
+        ]);
+    }
+}

--- a/tests/Fixtures/UriTemplateTestServer.php
+++ b/tests/Fixtures/UriTemplateTestServer.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Laravel\Mcp\Server;
+
+class UriTemplateTestServer extends Server
+{
+    protected array $resources = [
+        UriTemplateSummaryResource::class,
+        UriTemplateUserFileResource::class,
+    ];
+}

--- a/tests/Fixtures/UriTemplateUserFileResource.php
+++ b/tests/Fixtures/UriTemplateUserFileResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Contracts\HasUriTemplate;
+use Laravel\Mcp\Server\Resource;
+use Laravel\Mcp\Support\UriTemplate;
+
+class UriTemplateUserFileResource extends Resource implements HasUriTemplate
+{
+    public function uriTemplate(): UriTemplate
+    {
+        return new UriTemplate('file://users/{userId}/files/{fileId}');
+    }
+
+    public function handle(Request $request): Response
+    {
+        return Response::json([
+            'userId' => $request->get('userId'),
+            'fileId' => $request->get('fileId'),
+            'uri' => $request->uri(),
+        ]);
+    }
+}

--- a/tests/Unit/Support/UriTemplateTest.php
+++ b/tests/Unit/Support/UriTemplateTest.php
@@ -127,33 +127,3 @@ it('casts to string', function (): void {
 
     expect((string) $template)->toBe('file://users/{id}');
 });
-
-it('expands variables into the template', function (): void {
-    $template = new UriTemplate('file://users/{id}');
-
-    expect($template->expand(['id' => 'abc']))->toBe('file://users/abc');
-});
-
-it('expands multiple variables', function (): void {
-    $template = new UriTemplate('file://users/{userId}/posts/{postId}');
-
-    expect($template->expand(['userId' => '42', 'postId' => '7']))->toBe('file://users/42/posts/7');
-});
-
-it('leaves missing variables as literal placeholders when expanding', function (): void {
-    $template = new UriTemplate('file://summary/{id}/files/{fileId}');
-
-    expect($template->expand(['id' => 'abc']))->toBe('file://summary/abc/files/{fileId}');
-});
-
-it('ignores extra variables when expanding', function (): void {
-    $template = new UriTemplate('file://users/{id}');
-
-    expect($template->expand(['id' => 'abc', 'extra' => 'value']))->toBe('file://users/abc');
-});
-
-it('casts stringable values when expanding', function (): void {
-    $template = new UriTemplate('file://users/{id}');
-
-    expect($template->expand(['id' => 123]))->toBe('file://users/123');
-});

--- a/tests/Unit/Support/UriTemplateTest.php
+++ b/tests/Unit/Support/UriTemplateTest.php
@@ -127,3 +127,33 @@ it('casts to string', function (): void {
 
     expect((string) $template)->toBe('file://users/{id}');
 });
+
+it('expands variables into the template', function (): void {
+    $template = new UriTemplate('file://users/{id}');
+
+    expect($template->expand(['id' => 'abc']))->toBe('file://users/abc');
+});
+
+it('expands multiple variables', function (): void {
+    $template = new UriTemplate('file://users/{userId}/posts/{postId}');
+
+    expect($template->expand(['userId' => '42', 'postId' => '7']))->toBe('file://users/42/posts/7');
+});
+
+it('leaves missing variables as literal placeholders when expanding', function (): void {
+    $template = new UriTemplate('file://summary/{id}/files/{fileId}');
+
+    expect($template->expand(['id' => 'abc']))->toBe('file://summary/abc/files/{fileId}');
+});
+
+it('ignores extra variables when expanding', function (): void {
+    $template = new UriTemplate('file://users/{id}');
+
+    expect($template->expand(['id' => 'abc', 'extra' => 'value']))->toBe('file://users/abc');
+});
+
+it('casts stringable values when expanding', function (): void {
+    $template = new UriTemplate('file://users/{id}');
+
+    expect($template->expand(['id' => 123]))->toBe('file://users/123');
+});

--- a/tests/Unit/Support/UriTemplateTest.php
+++ b/tests/Unit/Support/UriTemplateTest.php
@@ -32,6 +32,12 @@ it('extracts multiple variables', function (): void {
     expect($template->match('file://users/fred/posts/123'))->toBe(['username' => 'fred', 'postId' => '123']);
 });
 
+it('exposes variable names', function (): void {
+    $template = new UriTemplate('file://users/{userId}/files/{fileId}/copies/{fileId}');
+
+    expect($template->variableNames())->toBe(['userId', 'fileId']);
+});
+
 it('returns null for non-matching URIs', function (): void {
     $template = new UriTemplate('file://users/{username}');
 


### PR DESCRIPTION
Currently testing a resource with a URI template fails because the test helper passes the raw template (`file://summary/{id}`) as the URI and the arguments are ignored:

```php
McpServer::resource(SummaryResource::class, [
    "id" => "abc",
]);
// > Invalid params: The id field must be a string.
```

The helper now expands template placeholders using the provided arguments before dispatching the request, so the same call resolves to `file://summary/abc` and the handler receives `id => "abc"`.

Missing template variables now throw `InvalidArgumentException`, making incomplete test calls fail before dispatch. Extra arguments still flow through as `arguments` and remain available on the request.

Fixes #221