### PR TITLE
Extract caching into RegisteredClient

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Laravel\Mcp;
 
 use Illuminate\Support\Collection;
-use Laravel\Mcp\Client\Cache\PrimitiveCache;
 use Laravel\Mcp\Client\Contracts\Transport;
 use Laravel\Mcp\Client\Methods\Ping;
 use Laravel\Mcp\Client\Methods\Tools\CallTool;
@@ -23,8 +22,6 @@ class Client
     public Implementation $clientInfo;
 
     protected Protocol $protocol;
-
-    protected ?PrimitiveCache $listCache = null;
 
     public function __construct(
         protected Transport $transport,
@@ -54,16 +51,6 @@ class Client
     public function withTimeout(float $seconds): static
     {
         $this->transport->setTimeoutSeconds($seconds);
-
-        return $this;
-    }
-
-    /**
-     * @internal Used by ClientManager when wiring registered clients.
-     */
-    public function withListCache(?PrimitiveCache $cache): static
-    {
-        $this->listCache = $cache;
 
         return $this;
     }
@@ -100,7 +87,17 @@ class Client
      */
     public function tools(?int $limit = null): Collection
     {
-        return (new ListTools($this, $this->listCache, limit: $limit))->handle($this->protocol);
+        return (new ListTools($this, limit: $limit))->handle($this->protocol);
+    }
+
+    /**
+     * @internal Used by RegisteredClient to populate the tools list cache.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function fetchToolPayloads(): array
+    {
+        return (new ListTools($this))->fetch($this->protocol);
     }
 
     /**
@@ -109,11 +106,6 @@ class Client
     public function callTool(string $name, array $arguments = []): ToolResult
     {
         return (new CallTool($name, $arguments))->handle($this->protocol);
-    }
-
-    public function flushCache(): void
-    {
-        $this->listCache?->flushAll();
     }
 
     public function __destruct()

--- a/src/Client/ClientManager.php
+++ b/src/Client/ClientManager.php
@@ -16,10 +16,10 @@ class ClientManager
 {
     use Macroable;
 
-    /** @var array<string, Closure(): Client> */
+    /** @var array<string, Closure(): RegisteredClient> */
     protected array $factories = [];
 
-    /** @var array<string, Client> */
+    /** @var array<string, RegisteredClient> */
     protected array $clients = [];
 
     public function __construct(protected ?Repository $cacheRepository = null)
@@ -48,12 +48,13 @@ class ClientManager
             unset($this->clients[$name]);
         }
 
-        $this->factories[$name] = fn (): Client => $factory()->withListCache(
+        $this->factories[$name] = fn (): RegisteredClient => new RegisteredClient(
+            $factory(),
             $this->buildListCache($name, $cacheTtl, $scope),
         );
     }
 
-    public function client(string $name): Client
+    public function client(string $name): RegisteredClient
     {
         if (! array_key_exists($name, $this->factories)) {
             throw new ClientException("MCP client [{$name}] has not been registered.");

--- a/src/Client/Methods/Tools/ListTools.php
+++ b/src/Client/Methods/Tools/ListTools.php
@@ -7,7 +7,6 @@ namespace Laravel\Mcp\Client\Methods\Tools;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Laravel\Mcp\Client;
-use Laravel\Mcp\Client\Cache\PrimitiveCache;
 use Laravel\Mcp\Client\Contracts\Method;
 use Laravel\Mcp\Client\Primitives\Tool;
 use Laravel\Mcp\Client\Protocol;
@@ -20,7 +19,6 @@ class ListTools implements Method
 {
     public function __construct(
         protected Client $client,
-        protected ?PrimitiveCache $cache = null,
         protected ?string $cursor = null,
         protected ?int $limit = null,
     ) {
@@ -45,26 +43,7 @@ class ListTools implements Method
      */
     public function handle(Protocol $protocol): Collection
     {
-        if (! $this->cache instanceof PrimitiveCache || $this->limit !== null) {
-            return $this->hydrate($this->fetch($protocol));
-        }
-
-        $cached = $this->cache->get('tools');
-
-        if (is_array($cached)) {
-            try {
-                return $this->hydrate($cached);
-            } catch (ClientException) {
-                $this->cache->flush('tools');
-            }
-        }
-
-        $payloads = $this->fetch($protocol);
-        $tools = $this->hydrate($payloads);
-
-        $this->cache->put('tools', $payloads);
-
-        return $tools;
+        return $this->hydrate($this->fetch($protocol));
     }
 
     /**
@@ -87,7 +66,7 @@ class ListTools implements Method
     /**
      * @return array<int, array<string, mixed>>
      */
-    protected function fetch(Protocol $protocol): array
+    public function fetch(Protocol $protocol): array
     {
         if ($this->limit === 0) {
             return [];
@@ -110,7 +89,7 @@ class ListTools implements Method
                 $seenCursors[$cursor] = true;
             }
 
-            $result = $protocol->dispatch(new self($this->client, null, $cursor, $this->limit));
+            $result = $protocol->dispatch(new self($this->client, $cursor, $this->limit));
             $page = Arr::get($result, 'tools');
 
             if (! is_array($page)) {

--- a/src/Client/Methods/Tools/ListTools.php
+++ b/src/Client/Methods/Tools/ListTools.php
@@ -43,21 +43,21 @@ class ListTools implements Method
      */
     public function handle(Protocol $protocol): Collection
     {
-        return $this->hydrate($this->fetch($protocol));
+        return self::hydrate($this->client, $this->fetch($protocol));
     }
 
     /**
      * @param  array<int, mixed>  $payloads
      * @return Collection<string, Tool>
      */
-    protected function hydrate(array $payloads): Collection
+    public static function hydrate(Client $client, array $payloads): Collection
     {
-        return collect($payloads)->mapWithKeys(function (mixed $payload): array {
+        return collect($payloads)->mapWithKeys(function (mixed $payload) use ($client): array {
             if (! is_array($payload)) {
                 throw new ClientException('Invalid tool payload.');
             }
 
-            $tool = Tool::from($this->client, $payload);
+            $tool = Tool::from($client, $payload);
 
             return [$tool->name => $tool];
         });

--- a/src/Client/RegisteredClient.php
+++ b/src/Client/RegisteredClient.php
@@ -7,6 +7,7 @@ namespace Laravel\Mcp\Client;
 use Illuminate\Support\Collection;
 use Laravel\Mcp\Client;
 use Laravel\Mcp\Client\Cache\PrimitiveCache;
+use Laravel\Mcp\Client\Methods\Tools\ListTools;
 use Laravel\Mcp\Client\Primitives\Tool;
 use Laravel\Mcp\Client\Schema\InitializeResult;
 use Laravel\Mcp\Client\Schema\ToolResult;
@@ -22,14 +23,18 @@ class RegisteredClient
     /**
      * @return Collection<string, Tool>
      */
-    public function tools(): Collection
+    public function tools(?int $limit = null): Collection
     {
+        if ($limit !== null) {
+            return $this->client->tools($limit);
+        }
+
         if ($this->cache instanceof PrimitiveCache) {
             $cached = $this->cache->get('tools');
 
             if (is_array($cached)) {
                 try {
-                    return $this->hydrateTools($cached);
+                    return ListTools::hydrate($this->client, $cached);
                 } catch (ClientException) {
                     $this->cache->flush('tools');
                 }
@@ -37,7 +42,7 @@ class RegisteredClient
         }
 
         $payloads = $this->client->fetchToolPayloads();
-        $tools = $this->hydrateTools($payloads);
+        $tools = ListTools::hydrate($this->client, $payloads);
 
         $this->cache?->put('tools', $payloads);
 
@@ -89,22 +94,5 @@ class RegisteredClient
     public function initializeResult(): ?InitializeResult
     {
         return $this->client->initializeResult();
-    }
-
-    /**
-     * @param  array<int, mixed>  $payloads
-     * @return Collection<string, Tool>
-     */
-    private function hydrateTools(array $payloads): Collection
-    {
-        return collect($payloads)->mapWithKeys(function (mixed $payload): array {
-            if (! is_array($payload)) {
-                throw new ClientException('Invalid tool payload.');
-            }
-
-            $tool = Tool::from($this->client, $payload);
-
-            return [$tool->name => $tool];
-        });
     }
 }

--- a/src/Client/RegisteredClient.php
+++ b/src/Client/RegisteredClient.php
@@ -9,10 +9,11 @@ use Laravel\Mcp\Client;
 use Laravel\Mcp\Client\Cache\PrimitiveCache;
 use Laravel\Mcp\Client\Methods\Tools\ListTools;
 use Laravel\Mcp\Client\Primitives\Tool;
-use Laravel\Mcp\Client\Schema\InitializeResult;
-use Laravel\Mcp\Client\Schema\ToolResult;
 use Laravel\Mcp\Exceptions\ClientException;
 
+/**
+ * @mixin Client
+ */
 class RegisteredClient
 {
     public function __construct(
@@ -55,44 +56,12 @@ class RegisteredClient
     }
 
     /**
-     * @param  array<string, mixed>  $arguments
+     * @param  array<int, mixed>  $parameters
      */
-    public function callTool(string $name, array $arguments = []): ToolResult
+    public function __call(string $method, array $parameters): mixed
     {
-        return $this->client->callTool($name, $arguments);
-    }
+        $result = $this->client->{$method}(...$parameters);
 
-    public function ping(): void
-    {
-        $this->client->ping();
-    }
-
-    public function connect(): static
-    {
-        $this->client->connect();
-
-        return $this;
-    }
-
-    public function disconnect(): void
-    {
-        $this->client->disconnect();
-    }
-
-    public function connected(): bool
-    {
-        return $this->client->connected();
-    }
-
-    public function withTimeout(float $seconds): static
-    {
-        $this->client->withTimeout($seconds);
-
-        return $this;
-    }
-
-    public function initializeResult(): ?InitializeResult
-    {
-        return $this->client->initializeResult();
+        return $result === $this->client ? $this : $result;
     }
 }

--- a/src/Client/RegisteredClient.php
+++ b/src/Client/RegisteredClient.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client;
+
+use Illuminate\Support\Collection;
+use Laravel\Mcp\Client;
+use Laravel\Mcp\Client\Cache\PrimitiveCache;
+use Laravel\Mcp\Client\Primitives\Tool;
+use Laravel\Mcp\Client\Schema\InitializeResult;
+use Laravel\Mcp\Client\Schema\ToolResult;
+use Laravel\Mcp\Exceptions\ClientException;
+
+class RegisteredClient
+{
+    public function __construct(
+        private Client $client,
+        private ?PrimitiveCache $cache,
+    ) {}
+
+    /**
+     * @return Collection<string, Tool>
+     */
+    public function tools(): Collection
+    {
+        if ($this->cache instanceof PrimitiveCache) {
+            $cached = $this->cache->get('tools');
+
+            if (is_array($cached)) {
+                try {
+                    return $this->hydrateTools($cached);
+                } catch (ClientException) {
+                    $this->cache->flush('tools');
+                }
+            }
+        }
+
+        $payloads = $this->client->fetchToolPayloads();
+        $tools = $this->hydrateTools($payloads);
+
+        $this->cache?->put('tools', $payloads);
+
+        return $tools;
+    }
+
+    public function flushCache(): void
+    {
+        $this->cache?->flushAll();
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     */
+    public function callTool(string $name, array $arguments = []): ToolResult
+    {
+        return $this->client->callTool($name, $arguments);
+    }
+
+    public function ping(): void
+    {
+        $this->client->ping();
+    }
+
+    public function connect(): static
+    {
+        $this->client->connect();
+
+        return $this;
+    }
+
+    public function disconnect(): void
+    {
+        $this->client->disconnect();
+    }
+
+    public function connected(): bool
+    {
+        return $this->client->connected();
+    }
+
+    public function withTimeout(float $seconds): static
+    {
+        $this->client->withTimeout($seconds);
+
+        return $this;
+    }
+
+    public function initializeResult(): ?InitializeResult
+    {
+        return $this->client->initializeResult();
+    }
+
+    /**
+     * @param  array<int, mixed>  $payloads
+     * @return Collection<string, Tool>
+     */
+    private function hydrateTools(array $payloads): Collection
+    {
+        return collect($payloads)->mapWithKeys(function (mixed $payload): array {
+            if (! is_array($payload)) {
+                throw new ClientException('Invalid tool payload.');
+            }
+
+            $tool = Tool::from($this->client, $payload);
+
+            return [$tool->name => $tool];
+        });
+    }
+}

--- a/src/Facades/Mcp.php
+++ b/src/Facades/Mcp.php
@@ -11,7 +11,7 @@ use Laravel\Mcp\Server\Registrar;
  * @method static \Illuminate\Routing\Route web(string $route, string $serverClass)
  * @method static void local(string $handle, string $serverClass)
  * @method static void registerClient(string $name, \Closure $factory, ?int $cacheTtl = null, ?\Closure $scope = null)
- * @method static \Laravel\Mcp\Client client(string $name)
+ * @method static \Laravel\Mcp\Client\RegisteredClient client(string $name)
  * @method static callable|null getLocalServer(string $handle)
  * @method static \Illuminate\Routing\Route|null getWebServer(string $route)
  * @method static array servers()

--- a/src/Server/Registrar.php
+++ b/src/Server/Registrar.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Laravel\Mcp\Client;
 use Laravel\Mcp\Client\ClientManager;
+use Laravel\Mcp\Client\RegisteredClient;
 use Laravel\Mcp\Server;
 use Laravel\Mcp\Server\Contracts\Transport;
 use Laravel\Mcp\Server\Http\Controllers\OAuthRegisterController;
@@ -85,7 +86,7 @@ class Registrar
         $this->clientManager()->registerClient($name, $factory, $cacheTtl, $scope);
     }
 
-    public function client(string $name): Client
+    public function client(string $name): RegisteredClient
     {
         return $this->clientManager()->client($name);
     }

--- a/tests/Unit/Client/ClientManagerTest.php
+++ b/tests/Unit/Client/ClientManagerTest.php
@@ -7,8 +7,10 @@ use Illuminate\Contracts\Cache\Repository;
 use Laravel\Mcp\Client;
 use Laravel\Mcp\Client\ClientManager;
 use Laravel\Mcp\Client\RegisteredClient;
+use Laravel\Mcp\Client\Transport\HttpTransport;
 use Laravel\Mcp\Exceptions\ClientException;
 use Laravel\Mcp\Facades\Mcp;
+use Laravel\Mcp\WebClient;
 use Tests\Fixtures\Client\FakeTransport;
 use Tests\Fixtures\Client\ThrowingTransport;
 
@@ -128,6 +130,16 @@ it('caches a named client tools list across resolutions', function (): void {
     expect(Mcp::client('everything')->tools()->keys()->all())->toBe(['add']);
     expect($transport->responses)->toBeEmpty();
     expect($transport->sent)->toHaveCount(3);
+});
+
+it('forwards subclass methods of the registered client and preserves fluent chaining', function (): void {
+    $web = new WebClient(new HttpTransport('https://example.test/mcp'));
+
+    Mcp::registerClient('remote', fn (): WebClient => $web);
+
+    $client = Mcp::client('remote');
+
+    expect($client->withToken('secret'))->toBe($client);
 });
 
 it('bypasses the cache when a tools limit is given', function (): void {

--- a/tests/Unit/Client/ClientManagerTest.php
+++ b/tests/Unit/Client/ClientManagerTest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Cache\Repository;
 use Laravel\Mcp\Client;
 use Laravel\Mcp\Client\ClientManager;
+use Laravel\Mcp\Client\RegisteredClient;
 use Laravel\Mcp\Exceptions\ClientException;
 use Laravel\Mcp\Facades\Mcp;
 use Tests\Fixtures\Client\FakeTransport;
@@ -25,7 +26,7 @@ function toolsResponse(int $id): string
 it('registers a named client and resolves it by name', function (): void {
     Mcp::registerClient('everything', fn (): Client => new Client(new FakeTransport));
 
-    expect(Mcp::client('everything'))->toBeInstanceOf(Client::class);
+    expect(Mcp::client('everything'))->toBeInstanceOf(RegisteredClient::class);
 });
 
 it('resolves and memoizes a registered client per request', function (): void {

--- a/tests/Unit/Client/ClientManagerTest.php
+++ b/tests/Unit/Client/ClientManagerTest.php
@@ -130,6 +130,19 @@ it('caches a named client tools list across resolutions', function (): void {
     expect($transport->sent)->toHaveCount(3);
 });
 
+it('bypasses the cache when a tools limit is given', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = toolsResponse(2);
+    $transport->responses[] = toolsResponse(3);
+
+    Mcp::registerClient('everything', fn (): Client => new Client($transport));
+
+    expect(Mcp::client('everything')->tools(1)->keys()->all())->toBe(['add']);
+    expect(Mcp::client('everything')->tools(1)->keys()->all())->toBe(['add']);
+    expect($transport->responses)->toBeEmpty();
+});
+
 it('forwards callTool / ping / connected / initializeResult / withTimeout to the inner client', function (): void {
     $transport = new FakeTransport;
     $transport->responses[] = initializeResponse();


### PR DESCRIPTION
The original implementation of named-client caching (#228) worked by injecting a `PrimitiveCache` into `Client` itself via a public `withListCache()` method. That meant `Client` carried cache state even when used inline (not registered), and the `@internal` tag was the only thing stopping users from calling it directly.

Before:

```php
// ClientManager wired it this way
$factory()->withListCache($cache);   // mutates Client directly

// Client held the cache
public function withListCache(?PrimitiveCache $cache): static { ... }
public function flushCache(): void { ... }
```

After:

```php
// ClientManager wraps the Client in a RegisteredClient
new RegisteredClient($factory(), $cache);

// Mcp::client() now returns RegisteredClient
$client = Mcp::client('notion');   // RegisteredClient, not Client
$client->tools();                  // cached here
$client->flushCache();             // owned by RegisteredClient

// Inline clients are unchanged and completely cache-unaware
$client = new Client($transport);
$client->tools();                  // no cache, as before
```

`Client` loses `listCache`, `withListCache()`, and `flushCache()` entirely. The only internal seam left is `fetchToolPayloads()` on `Client`, which `RegisteredClient` calls on a cache miss to get raw payloads for storage. `ListTools` is simplified back to a plain fetch+hydrate with no `PrimitiveCache` dependency.

`PrimitiveCache::flush()` is also tightened to require an explicit `string $kind` argument, and `flushAll()` is added to clear all known kinds at once.