### PR TITLE
Add OAuth layer for MCP web client

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -6,6 +6,7 @@ namespace Laravel\Mcp;
 
 use Illuminate\Support\Collection;
 use Laravel\Mcp\Client\Contracts\Transport;
+use Laravel\Mcp\Client\Exceptions\AuthorizationRequiredException;
 use Laravel\Mcp\Client\Methods\Ping;
 use Laravel\Mcp\Client\Methods\Tools\CallTool;
 use Laravel\Mcp\Client\Methods\Tools\ListTools;
@@ -22,6 +23,15 @@ class Client
     public Implementation $clientInfo;
 
     protected Protocol $protocol;
+
+    protected ?string $registeredName = null;
+
+    public function setRegisteredName(string $name): static
+    {
+        $this->registeredName = $name;
+
+        return $this;
+    }
 
     public function __construct(
         protected Transport $transport,
@@ -83,11 +93,20 @@ class Client
     }
 
     /**
+     * @param  iterable<string, Tool>|null  $default
      * @return Collection<string, Tool>
      */
-    public function tools(?int $limit = null): Collection
+    public function tools(?int $limit = null, ?iterable $default = null): Collection
     {
-        return (new ListTools(limit: $limit))->handle($this->protocol);
+        try {
+            return (new ListTools(limit: $limit))->handle($this->protocol);
+        } catch (AuthorizationRequiredException $authorizationRequiredException) {
+            if ($default === null) {
+                throw $authorizationRequiredException;
+            }
+
+            return Collection::make($default);
+        }
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,22 +20,13 @@ use Laravel\Mcp\Schema\Implementation;
 
 class Client
 {
-    public Implementation $clientInfo;
-
     protected Protocol $protocol;
 
     protected ?string $registeredName = null;
 
-    public function setRegisteredName(string $name): static
-    {
-        $this->registeredName = $name;
-
-        return $this;
-    }
-
     public function __construct(
         protected Transport $transport,
-        ?Implementation $clientInfo = null,
+        public ?Implementation $clientInfo = null,
     ) {
         $this->clientInfo = $clientInfo ?? new Implementation(
             name: config('app.name', 'Laravel MCP Client'),
@@ -43,6 +34,13 @@ class Client
         );
 
         $this->protocol = new Protocol($this->transport, $this->clientInfo);
+    }
+
+    public function setRegisteredName(string $name): static
+    {
+        $this->registeredName = $name;
+
+        return $this;
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -31,12 +31,17 @@ class Client
         protected Transport $transport,
         public ?Implementation $clientInfo = null,
     ) {
-        $this->clientInfo = $clientInfo ?? new Implementation(
+        $this->clientInfo = $clientInfo ?? $this->defaultClientInfo();
+
+        $this->protocol = new Protocol($this->transport, $this->clientInfo);
+    }
+
+    protected function defaultClientInfo(): Implementation
+    {
+        return new Implementation(
             name: config('app.name', 'Laravel MCP Client'),
             version: '0.0.1',
         );
-
-        $this->protocol = new Protocol($this->transport, $this->clientInfo);
     }
 
     public function setName(?string $name): static
@@ -151,10 +156,7 @@ class Client
             $this->transport = TransportFactory::fromRecipe($data['transport']);
         }
 
-        $this->clientInfo ??= new Implementation(
-            name: config('app.name', 'Laravel MCP Client'),
-            version: '0.0.1',
-        );
+        $this->clientInfo ??= $this->defaultClientInfo();
 
         $this->protocol = new Protocol($this->transport, $this->clientInfo);
     }

--- a/src/Client/ClientManager.php
+++ b/src/Client/ClientManager.php
@@ -25,10 +25,7 @@ class ClientManager
     public function registerClient(string $name, Closure $factory): void
     {
         if (isset($this->clients[$name])) {
-            try {
-                $this->clients[$name]->disconnect();
-            } catch (ClientException) {
-            }
+            $this->disconnect($this->clients[$name]);
 
             unset($this->clients[$name]);
         }
@@ -48,12 +45,17 @@ class ClientManager
     public function disconnectAll(): void
     {
         foreach ($this->clients as $client) {
-            try {
-                $client->disconnect();
-            } catch (ClientException) {
-            }
+            $this->disconnect($client);
         }
 
         $this->clients = [];
+    }
+
+    protected function disconnect(Client $client): void
+    {
+        try {
+            $client->disconnect();
+        } catch (ClientException) {
+        }
     }
 }

--- a/src/Client/ClientManager.php
+++ b/src/Client/ClientManager.php
@@ -33,7 +33,7 @@ class ClientManager
             unset($this->clients[$name]);
         }
 
-        $this->factories[$name] = $factory;
+        $this->factories[$name] = fn (): Client => $factory()->setRegisteredName($name);
     }
 
     public function client(string $name): Client

--- a/src/Client/Exceptions/AuthorizationRequiredException.php
+++ b/src/Client/Exceptions/AuthorizationRequiredException.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\Exceptions;
+
+use Laravel\Mcp\Client\OAuth\WwwAuthenticateChallenge;
+
+class AuthorizationRequiredException extends OAuthException
+{
+    public function __construct(
+        string $message = 'Authorization is required to access the MCP server.',
+        public ?WwwAuthenticateChallenge $challenge = null,
+    ) {
+        parent::__construct($message);
+    }
+
+    public function resourceMetadataUrl(): ?string
+    {
+        return $this->challenge?->resourceMetadataUrl;
+    }
+
+    public function scope(): ?string
+    {
+        return $this->challenge?->scope;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function query(): array
+    {
+        return array_filter([
+            'resource_metadata' => $this->resourceMetadataUrl(),
+            'scope' => $this->scope(),
+        ], static fn (?string $value): bool => $value !== null && $value !== '');
+    }
+}

--- a/src/Client/Exceptions/OAuthException.php
+++ b/src/Client/Exceptions/OAuthException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\Exceptions;
+
+use Laravel\Mcp\Exceptions\ClientException;
+
+class OAuthException extends ClientException
+{
+    //
+}

--- a/src/Client/OAuth/AuthServerDiscovery.php
+++ b/src/Client/OAuth/AuthServerDiscovery.php
@@ -15,7 +15,7 @@ class AuthServerDiscovery
 
         $this->requireFetchable($metadataUrl, $resourceUrl);
 
-        $resourceMetadata = $this->fetchResourceMetadata($metadataUrl);
+        $resourceMetadata = $this->fetchResourceMetadata($metadataUrl, explicit: $resourceMetadataUrl !== null);
 
         $this->requireResourceMatches($resourceMetadata, $resourceUrl);
 
@@ -48,7 +48,7 @@ class AuthServerDiscovery
     /**
      * @return array<string, mixed>
      */
-    protected function fetchResourceMetadata(string $metadataUrl): array
+    protected function fetchResourceMetadata(string $metadataUrl, bool $explicit = false): array
     {
         $response = Http::acceptJson()
             ->timeout(5)
@@ -57,12 +57,24 @@ class AuthServerDiscovery
             ->get($metadataUrl);
 
         if (! $response->successful()) {
+            if ($explicit) {
+                throw new OAuthException("Protected resource metadata request to [{$metadataUrl}] failed with status [{$response->status()}].");
+            }
+
             return [];
         }
 
         $data = $response->json();
 
-        return is_array($data) ? $data : [];
+        if (is_array($data)) {
+            return $data;
+        }
+
+        if ($explicit) {
+            throw new OAuthException("Protected resource metadata at [{$metadataUrl}] did not return a valid JSON object.");
+        }
+
+        return [];
     }
 
     /**

--- a/src/Client/OAuth/AuthServerDiscovery.php
+++ b/src/Client/OAuth/AuthServerDiscovery.php
@@ -13,6 +13,8 @@ class AuthServerDiscovery
     {
         $metadataUrl = $resourceMetadataUrl ?? $this->wellKnown($resourceUrl, 'oauth-protected-resource');
 
+        $this->requireFetchable($metadataUrl, $resourceUrl);
+
         $resourceMetadata = $this->fetchResourceMetadata($metadataUrl);
 
         $this->requireResourceMatches($resourceMetadata, $resourceUrl);
@@ -20,6 +22,7 @@ class AuthServerDiscovery
         $issuer = $this->issuerFrom($resourceMetadata) ?? $this->origin($resourceUrl);
 
         $this->requireSecure($issuer);
+        $this->requireNotInternal($issuer, $resourceUrl);
 
         $serverMetadata = $this->fetchMetadata($issuer);
 
@@ -29,6 +32,13 @@ class AuthServerDiscovery
 
         $this->requireSecure($serverMetadata->authorizationEndpoint);
         $this->requireSecure($serverMetadata->tokenEndpoint);
+        $this->requireNotInternal($serverMetadata->authorizationEndpoint, $resourceUrl);
+        $this->requireNotInternal($serverMetadata->tokenEndpoint, $resourceUrl);
+
+        if ($serverMetadata->registrationEndpoint !== null) {
+            $this->requireSecure($serverMetadata->registrationEndpoint);
+            $this->requireNotInternal($serverMetadata->registrationEndpoint, $resourceUrl);
+        }
 
         $scopesSupported = array_values(array_map(strval(...), (array) ($resourceMetadata['scopes_supported'] ?? [])));
 
@@ -40,7 +50,11 @@ class AuthServerDiscovery
      */
     protected function fetchResourceMetadata(string $metadataUrl): array
     {
-        $response = Http::acceptJson()->get($metadataUrl);
+        $response = Http::acceptJson()
+            ->timeout(5)
+            ->connectTimeout(2)
+            ->withOptions(['allow_redirects' => false])
+            ->get($metadataUrl);
 
         if (! $response->successful()) {
             return [];
@@ -80,7 +94,11 @@ class AuthServerDiscovery
     protected function fetchMetadata(string $issuer): AuthServerMetadata
     {
         foreach ($this->metadataUrls($issuer) as $metadataUrl) {
-            $response = Http::acceptJson()->get($metadataUrl);
+            $response = Http::acceptJson()
+                ->timeout(5)
+                ->connectTimeout(2)
+                ->withOptions(['allow_redirects' => false])
+                ->get($metadataUrl);
 
             if (! $response->successful()) {
                 continue;
@@ -105,7 +123,7 @@ class AuthServerDiscovery
 
         $origin = $this->originFromParts($parts);
 
-        $path = rtrim($parts['path'] ?? '', '/');
+        $path = $parts['path'] ?? '';
 
         if ($path === '') {
             return [
@@ -125,7 +143,7 @@ class AuthServerDiscovery
     {
         $parts = $this->parse($url);
 
-        $path = rtrim($parts['path'] ?? '', '/');
+        $path = $parts['path'] ?? '';
 
         return $this->originFromParts($parts).'/.well-known/'.$type.$path;
     }
@@ -143,11 +161,52 @@ class AuthServerDiscovery
             return;
         }
 
-        if (in_array($parts['host'], ['localhost', '127.0.0.1', '::1'], true)) {
+        if ($this->isLocalhost($this->normalizedHost($parts['host']))) {
             return;
         }
 
         throw new OAuthException("OAuth endpoint [{$url}] must be served over HTTPS.");
+    }
+
+    protected function requireFetchable(string $url, string $resourceUrl): void
+    {
+        $this->requireSecure($url);
+        $this->requireNotInternal($url, $resourceUrl);
+    }
+
+    protected function requireNotInternal(string $url, string $resourceUrl): void
+    {
+        $parts = $this->parse($url);
+        $resourceParts = $this->parse($resourceUrl);
+        $host = $this->normalizedHost($parts['host']);
+        $resourceHost = $this->normalizedHost($resourceParts['host']);
+
+        if ($this->isInternalHost($host) && ! ($this->isLocalhost($host) && $this->isLocalhost($resourceHost))) {
+            throw new OAuthException("OAuth endpoint [{$url}] cannot use a private or internal host.");
+        }
+    }
+
+    protected function isInternalHost(string $host): bool
+    {
+        if ($this->isLocalhost($host)) {
+            return true;
+        }
+
+        if (filter_var($host, FILTER_VALIDATE_IP) === false) {
+            return false;
+        }
+
+        return filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false;
+    }
+
+    protected function isLocalhost(string $host): bool
+    {
+        return in_array($host, ['localhost', '127.0.0.1', '::1'], true);
+    }
+
+    protected function normalizedHost(string $host): string
+    {
+        return strtolower(trim($host, '[]'));
     }
 
     /**

--- a/src/Client/OAuth/AuthServerDiscovery.php
+++ b/src/Client/OAuth/AuthServerDiscovery.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp\Client\OAuth;
 
-use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Arr;
 use Laravel\Mcp\Client\Exceptions\OAuthException;
+use Laravel\Mcp\Client\OAuth\Concerns\InteractsWithOAuthEndpoints;
 
 class AuthServerDiscovery
 {
+    use InteractsWithOAuthEndpoints;
+
     public function discover(string $resourceUrl, ?string $resourceMetadataUrl = null): DiscoveryResult
     {
         $metadataUrl = $resourceMetadataUrl ?? $this->wellKnown($resourceUrl, 'oauth-protected-resource');
@@ -50,11 +53,7 @@ class AuthServerDiscovery
      */
     protected function fetchResourceMetadata(string $metadataUrl, bool $explicit = false): array
     {
-        $response = Http::acceptJson()
-            ->timeout(5)
-            ->connectTimeout(2)
-            ->withOptions(['allow_redirects' => false])
-            ->get($metadataUrl);
+        $response = $this->oAuthRequest()->get($metadataUrl);
 
         if (! $response->successful()) {
             if ($explicit) {
@@ -82,7 +81,7 @@ class AuthServerDiscovery
      */
     protected function requireResourceMatches(array $resourceMetadata, string $resourceUrl): void
     {
-        $resource = $resourceMetadata['resource'] ?? null;
+        $resource = Arr::get($resourceMetadata, 'resource');
 
         if (is_string($resource) && ! hash_equals($resourceUrl, $resource)) {
             throw new OAuthException("Protected resource metadata resource [{$resource}] did not match the expected resource [{$resourceUrl}].");
@@ -94,7 +93,7 @@ class AuthServerDiscovery
      */
     protected function issuerFrom(array $resourceMetadata): ?string
     {
-        $servers = $resourceMetadata['authorization_servers'] ?? null;
+        $servers = Arr::get($resourceMetadata, 'authorization_servers');
 
         if (is_array($servers) && $servers !== []) {
             return (string) $servers[0];
@@ -106,11 +105,7 @@ class AuthServerDiscovery
     protected function fetchMetadata(string $issuer): AuthServerMetadata
     {
         foreach ($this->metadataUrls($issuer) as $metadataUrl) {
-            $response = Http::acceptJson()
-                ->timeout(5)
-                ->connectTimeout(2)
-                ->withOptions(['allow_redirects' => false])
-                ->get($metadataUrl);
+            $response = $this->oAuthRequest()->get($metadataUrl);
 
             if (! $response->successful()) {
                 continue;

--- a/src/Client/OAuth/AuthServerDiscovery.php
+++ b/src/Client/OAuth/AuthServerDiscovery.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\OAuth;
+
+use Illuminate\Support\Facades\Http;
+use Laravel\Mcp\Client\Exceptions\OAuthException;
+
+class AuthServerDiscovery
+{
+    public function discover(string $resourceUrl, ?string $resourceMetadataUrl = null): DiscoveryResult
+    {
+        $metadataUrl = $resourceMetadataUrl ?? $this->wellKnown($resourceUrl, 'oauth-protected-resource');
+
+        $resourceMetadata = $this->fetchResourceMetadata($metadataUrl);
+
+        $this->requireResourceMatches($resourceMetadata, $resourceUrl);
+
+        $issuer = $this->issuerFrom($resourceMetadata) ?? $this->origin($resourceUrl);
+
+        $this->requireSecure($issuer);
+
+        $serverMetadata = $this->fetchMetadata($issuer);
+
+        if (! hash_equals($issuer, $serverMetadata->issuer)) {
+            throw new OAuthException("Authorization server issuer [{$serverMetadata->issuer}] did not match the expected issuer [{$issuer}].");
+        }
+
+        $this->requireSecure($serverMetadata->authorizationEndpoint);
+        $this->requireSecure($serverMetadata->tokenEndpoint);
+
+        $scopesSupported = array_values(array_map(strval(...), (array) ($resourceMetadata['scopes_supported'] ?? [])));
+
+        return new DiscoveryResult($serverMetadata, $scopesSupported);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function fetchResourceMetadata(string $metadataUrl): array
+    {
+        $response = Http::acceptJson()->get($metadataUrl);
+
+        if (! $response->successful()) {
+            return [];
+        }
+
+        $data = $response->json();
+
+        return is_array($data) ? $data : [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $resourceMetadata
+     */
+    protected function requireResourceMatches(array $resourceMetadata, string $resourceUrl): void
+    {
+        $resource = $resourceMetadata['resource'] ?? null;
+
+        if (is_string($resource) && ! hash_equals($resourceUrl, $resource)) {
+            throw new OAuthException("Protected resource metadata resource [{$resource}] did not match the expected resource [{$resourceUrl}].");
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $resourceMetadata
+     */
+    protected function issuerFrom(array $resourceMetadata): ?string
+    {
+        $servers = $resourceMetadata['authorization_servers'] ?? null;
+
+        if (is_array($servers) && $servers !== []) {
+            return (string) $servers[0];
+        }
+
+        return null;
+    }
+
+    protected function fetchMetadata(string $issuer): AuthServerMetadata
+    {
+        foreach ($this->metadataUrls($issuer) as $metadataUrl) {
+            $response = Http::acceptJson()->get($metadataUrl);
+
+            if (! $response->successful()) {
+                continue;
+            }
+
+            $metadata = $response->json();
+
+            if (is_array($metadata)) {
+                return AuthServerMetadata::fromArray($metadata);
+            }
+        }
+
+        throw new OAuthException("Unable to discover authorization server metadata from [{$issuer}].");
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function metadataUrls(string $issuer): array
+    {
+        $parts = $this->parse($issuer);
+
+        $origin = $this->originFromParts($parts);
+
+        $path = rtrim($parts['path'] ?? '', '/');
+
+        if ($path === '') {
+            return [
+                $origin.'/.well-known/oauth-authorization-server',
+                $origin.'/.well-known/openid-configuration',
+            ];
+        }
+
+        return [
+            $origin.'/.well-known/oauth-authorization-server'.$path,
+            $origin.'/.well-known/openid-configuration'.$path,
+            $origin.$path.'/.well-known/openid-configuration',
+        ];
+    }
+
+    protected function wellKnown(string $url, string $type): string
+    {
+        $parts = $this->parse($url);
+
+        $path = rtrim($parts['path'] ?? '', '/');
+
+        return $this->originFromParts($parts).'/.well-known/'.$type.$path;
+    }
+
+    protected function origin(string $url): string
+    {
+        return $this->originFromParts($this->parse($url));
+    }
+
+    protected function requireSecure(string $url): void
+    {
+        $parts = $this->parse($url);
+
+        if ($parts['scheme'] === 'https') {
+            return;
+        }
+
+        if (in_array($parts['host'], ['localhost', '127.0.0.1', '::1'], true)) {
+            return;
+        }
+
+        throw new OAuthException("OAuth endpoint [{$url}] must be served over HTTPS.");
+    }
+
+    /**
+     * @param  array{scheme: string, host: string, port?: int, path?: string}  $parts
+     */
+    protected function originFromParts(array $parts): string
+    {
+        return $parts['scheme'].'://'.$parts['host'].(isset($parts['port']) ? ':'.$parts['port'] : '');
+    }
+
+    /**
+     * @return array{scheme: string, host: string, port?: int, path?: string}
+     */
+    protected function parse(string $url): array
+    {
+        $parts = parse_url($url);
+
+        if (! is_array($parts) || ! isset($parts['scheme'], $parts['host'])) {
+            throw new OAuthException("Unable to parse URL [{$url}] during OAuth discovery.");
+        }
+
+        /** @var array{scheme: string, host: string, port?: int, path?: string} $parts */
+        return $parts;
+    }
+}

--- a/src/Client/OAuth/AuthServerMetadata.php
+++ b/src/Client/OAuth/AuthServerMetadata.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\OAuth;
+
+use Laravel\Mcp\Client\Exceptions\OAuthException;
+
+class AuthServerMetadata
+{
+    /**
+     * @param  array<int, string>  $codeChallengeMethodsSupported
+     * @param  array<int, string>  $tokenEndpointAuthMethodsSupported
+     */
+    public function __construct(
+        public string $issuer,
+        public string $authorizationEndpoint,
+        public string $tokenEndpoint,
+        public ?string $registrationEndpoint = null,
+        public array $codeChallengeMethodsSupported = [],
+        public bool $authorizationResponseIssParameterSupported = false,
+        public array $tokenEndpointAuthMethodsSupported = [],
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        if (empty($data['authorization_endpoint']) || empty($data['token_endpoint'])) {
+            throw new OAuthException('Authorization server metadata is missing required endpoints.');
+        }
+
+        return new self(
+            issuer: (string) ($data['issuer'] ?? ''),
+            authorizationEndpoint: (string) $data['authorization_endpoint'],
+            tokenEndpoint: (string) $data['token_endpoint'],
+            registrationEndpoint: isset($data['registration_endpoint']) ? (string) $data['registration_endpoint'] : null,
+            codeChallengeMethodsSupported: array_values(array_map(strval(...), (array) ($data['code_challenge_methods_supported'] ?? []))),
+            authorizationResponseIssParameterSupported: (bool) ($data['authorization_response_iss_parameter_supported'] ?? false),
+            tokenEndpointAuthMethodsSupported: array_values(array_map(strval(...), (array) ($data['token_endpoint_auth_methods_supported'] ?? []))),
+        );
+    }
+}

--- a/src/Client/OAuth/ClientRegistration.php
+++ b/src/Client/OAuth/ClientRegistration.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\OAuth;
+
+class ClientRegistration
+{
+    public function __construct(
+        public string $clientId,
+        public ?string $clientSecret = null,
+    ) {}
+}

--- a/src/Client/OAuth/Concerns/InteractsWithOAuthEndpoints.php
+++ b/src/Client/OAuth/Concerns/InteractsWithOAuthEndpoints.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\OAuth\Concerns;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+
+trait InteractsWithOAuthEndpoints
+{
+    protected function oAuthRequest(): PendingRequest
+    {
+        return Http::acceptJson()
+            ->timeout(5)
+            ->connectTimeout(2)
+            ->withOptions(['allow_redirects' => false]);
+    }
+}

--- a/src/Client/OAuth/DiscoveryResult.php
+++ b/src/Client/OAuth/DiscoveryResult.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\OAuth;
+
+class DiscoveryResult
+{
+    /**
+     * @param  array<int, string>  $scopesSupported
+     */
+    public function __construct(
+        public AuthServerMetadata $server,
+        public array $scopesSupported = [],
+    ) {}
+}

--- a/src/Client/OAuth/DynamicClientRegistration.php
+++ b/src/Client/OAuth/DynamicClientRegistration.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\OAuth;
+
+use Illuminate\Support\Facades\Http;
+use Laravel\Mcp\Client\Exceptions\OAuthException;
+
+class DynamicClientRegistration
+{
+    public function register(
+        string $registrationEndpoint,
+        string $redirectUri,
+        ?string $scope = null,
+        string $clientName = 'Laravel MCP Client',
+        string $applicationType = 'web',
+        string $tokenEndpointAuthMethod = 'client_secret_post',
+    ): ClientRegistration {
+        $response = Http::acceptJson()->asJson()->post($registrationEndpoint, array_filter([
+            'client_name' => $clientName,
+            'redirect_uris' => [$redirectUri],
+            'grant_types' => ['authorization_code', 'refresh_token'],
+            'response_types' => ['code'],
+            'token_endpoint_auth_method' => $tokenEndpointAuthMethod,
+            'application_type' => $applicationType,
+            'scope' => $scope,
+        ], static fn (mixed $value): bool => $value !== null));
+
+        if (! $response->successful()) {
+            throw new OAuthException("Dynamic client registration failed with status [{$response->status()}].");
+        }
+
+        $data = $response->json();
+
+        if (! is_array($data) || empty($data['client_id'])) {
+            throw new OAuthException('Dynamic client registration response did not include a client_id.');
+        }
+
+        return new ClientRegistration(
+            clientId: (string) $data['client_id'],
+            clientSecret: isset($data['client_secret']) ? (string) $data['client_secret'] : null,
+        );
+    }
+}

--- a/src/Client/OAuth/DynamicClientRegistration.php
+++ b/src/Client/OAuth/DynamicClientRegistration.php
@@ -17,15 +17,20 @@ class DynamicClientRegistration
         string $applicationType = 'web',
         TokenEndpointAuthMethod $tokenEndpointAuthMethod = TokenEndpointAuthMethod::ClientSecretPost,
     ): ClientRegistration {
-        $response = Http::acceptJson()->asJson()->post($registrationEndpoint, array_filter([
-            'client_name' => $clientName,
-            'redirect_uris' => [$redirectUri],
-            'grant_types' => ['authorization_code', 'refresh_token'],
-            'response_types' => ['code'],
-            'token_endpoint_auth_method' => $tokenEndpointAuthMethod->value,
-            'application_type' => $applicationType,
-            'scope' => $scope,
-        ], static fn (mixed $value): bool => $value !== null));
+        $response = Http::acceptJson()
+            ->asJson()
+            ->timeout(5)
+            ->connectTimeout(2)
+            ->withOptions(['allow_redirects' => false])
+            ->post($registrationEndpoint, array_filter([
+                'client_name' => $clientName,
+                'redirect_uris' => [$redirectUri],
+                'grant_types' => ['authorization_code', 'refresh_token'],
+                'response_types' => ['code'],
+                'token_endpoint_auth_method' => $tokenEndpointAuthMethod->value,
+                'application_type' => $applicationType,
+                'scope' => $scope,
+            ], static fn (mixed $value): bool => $value !== null));
 
         if (! $response->successful()) {
             throw new OAuthException("Dynamic client registration failed with status [{$response->status()}].");

--- a/src/Client/OAuth/DynamicClientRegistration.php
+++ b/src/Client/OAuth/DynamicClientRegistration.php
@@ -15,14 +15,14 @@ class DynamicClientRegistration
         ?string $scope = null,
         string $clientName = 'Laravel MCP Client',
         string $applicationType = 'web',
-        string $tokenEndpointAuthMethod = 'client_secret_post',
+        TokenEndpointAuthMethod $tokenEndpointAuthMethod = TokenEndpointAuthMethod::ClientSecretPost,
     ): ClientRegistration {
         $response = Http::acceptJson()->asJson()->post($registrationEndpoint, array_filter([
             'client_name' => $clientName,
             'redirect_uris' => [$redirectUri],
             'grant_types' => ['authorization_code', 'refresh_token'],
             'response_types' => ['code'],
-            'token_endpoint_auth_method' => $tokenEndpointAuthMethod,
+            'token_endpoint_auth_method' => $tokenEndpointAuthMethod->value,
             'application_type' => $applicationType,
             'scope' => $scope,
         ], static fn (mixed $value): bool => $value !== null));

--- a/src/Client/OAuth/DynamicClientRegistration.php
+++ b/src/Client/OAuth/DynamicClientRegistration.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp\Client\OAuth;
 
-use Illuminate\Support\Facades\Http;
 use Laravel\Mcp\Client\Exceptions\OAuthException;
+use Laravel\Mcp\Client\OAuth\Concerns\InteractsWithOAuthEndpoints;
 use Laravel\Mcp\Client\OAuth\Enums\TokenEndpointAuthMethod;
 
 class DynamicClientRegistration
 {
+    use InteractsWithOAuthEndpoints;
+
     public function register(
         string $registrationEndpoint,
         string $redirectUri,
@@ -18,11 +20,8 @@ class DynamicClientRegistration
         string $applicationType = 'web',
         TokenEndpointAuthMethod $tokenEndpointAuthMethod = TokenEndpointAuthMethod::ClientSecretPost,
     ): ClientRegistration {
-        $response = Http::acceptJson()
+        $response = $this->oAuthRequest()
             ->asJson()
-            ->timeout(5)
-            ->connectTimeout(2)
-            ->withOptions(['allow_redirects' => false])
             ->post($registrationEndpoint, array_filter([
                 'client_name' => $clientName,
                 'redirect_uris' => [$redirectUri],

--- a/src/Client/OAuth/DynamicClientRegistration.php
+++ b/src/Client/OAuth/DynamicClientRegistration.php
@@ -6,6 +6,7 @@ namespace Laravel\Mcp\Client\OAuth;
 
 use Illuminate\Support\Facades\Http;
 use Laravel\Mcp\Client\Exceptions\OAuthException;
+use Laravel\Mcp\Client\OAuth\Enums\TokenEndpointAuthMethod;
 
 class DynamicClientRegistration
 {

--- a/src/Client/OAuth/Enums/TokenEndpointAuthMethod.php
+++ b/src/Client/OAuth/Enums/TokenEndpointAuthMethod.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Laravel\Mcp\Client\OAuth;
+namespace Laravel\Mcp\Client\OAuth\Enums;
 
 enum TokenEndpointAuthMethod: string
 {

--- a/src/Client/OAuth/OAuthClient.php
+++ b/src/Client/OAuth/OAuthClient.php
@@ -18,6 +18,8 @@ class OAuthClient
 
     protected ?DiscoveryResult $discovered = null;
 
+    protected ?string $returnTo = null;
+
     public function __construct(
         string $resourceUrl,
         protected OAuthConfig $config,
@@ -25,7 +27,7 @@ class OAuthClient
         protected ?string $challengeScope = null,
         protected AuthServerDiscovery $discovery = new AuthServerDiscovery,
     ) {
-        $this->resourceUrl = $this->canonical($resourceUrl);
+        $this->resourceUrl = $this->resourceIdentifier($resourceUrl);
     }
 
     public function redirect(?string $returnTo = null): RedirectResponse
@@ -71,38 +73,15 @@ class OAuthClient
             'state' => $state,
             'code_challenge' => $pkce->challenge,
             'code_challenge_method' => 'S256',
-            'scope' => $this->resolveScope($discovered),
+            'scope' => $this->resolveScope(),
             'resource' => $this->resourceUrl,
         ], static fn (mixed $value): bool => $value !== null && $value !== ''));
 
         return new RedirectResponse((string) $authorizeUrl);
     }
 
-    public function token(): TokenSet
+    public function clientCredentials(): TokenSet
     {
-        $error = Request::query('error');
-
-        if (is_string($error) && $error !== '') {
-            $description = Request::query('error_description');
-
-            throw new OAuthException(is_string($description) && $description !== ''
-                ? "The authorization server returned an error [{$error}]: {$description}"
-                : "The authorization server returned an error [{$error}].");
-        }
-
-        $code = Request::query('code');
-
-        if (is_string($code) && $code !== '') {
-            $state = Request::query('state');
-            $iss = Request::query('iss');
-
-            return $this->exchangeAuthorizationCode(
-                $code,
-                is_string($state) ? $state : '',
-                is_string($iss) ? $iss : null,
-            );
-        }
-
         if ($this->config->clientId === null) {
             throw new OAuthException('A client_id is required for the client_credentials grant.');
         }
@@ -113,13 +92,38 @@ class OAuthClient
             $discovered->server->tokenEndpoint,
             [
                 'grant_type' => 'client_credentials',
-                'scope' => $this->resolveScope($discovered),
+                'scope' => $this->resolveScope(),
                 'resource' => $this->resourceUrl,
             ],
             $this->config->clientId,
             $this->config->clientSecret,
             $this->resolveTokenAuthMethod($discovered->server, $this->config->clientSecret),
         );
+    }
+
+    public function exchangeCallback(): TokenSet
+    {
+        $this->throwOnServerError();
+
+        $code = $this->query('code');
+
+        if ($code === null) {
+            throw new OAuthException('The OAuth callback did not include an authorization code.');
+        }
+
+        $state = Request::query('state');
+        $iss = Request::query('iss');
+
+        return $this->exchangeAuthorizationCode(
+            $code,
+            is_string($state) ? $state : '',
+            is_string($iss) ? $iss : null,
+        );
+    }
+
+    public function returnTo(): ?string
+    {
+        return $this->returnTo;
     }
 
     public function refresh(string $refreshToken, ?string $clientId = null, ?string $clientSecret = null): TokenSet
@@ -134,7 +138,7 @@ class OAuthClient
             [
                 'grant_type' => 'refresh_token',
                 'refresh_token' => $refreshToken,
-                'scope' => $this->resolveScope($discovered),
+                'scope' => $this->resolveScope(),
                 'resource' => $this->resourceUrl,
             ],
             $clientId,
@@ -162,6 +166,10 @@ class OAuthClient
         }
 
         $this->validateIssuer($stored, $iss);
+
+        $this->returnTo = is_string($stored['return_to'] ?? null) && $stored['return_to'] !== ''
+            ? $stored['return_to']
+            : null;
 
         Session::forget($this->sessionKey());
 
@@ -197,7 +205,7 @@ class OAuthClient
         return (new DynamicClientRegistration)->register(
             $metadata->registrationEndpoint,
             $redirectUri,
-            $this->resolveScope($this->discover()),
+            $this->resolveScope(),
             applicationType: $this->applicationType($redirectUri),
             tokenEndpointAuthMethod: $this->resolveTokenAuthMethod($metadata, 'confidential'),
         );
@@ -208,21 +216,23 @@ class OAuthClient
      */
     protected function requestToken(string $tokenEndpoint, array $params, ?string $clientId, ?string $clientSecret, TokenEndpointAuthMethod $authMethod): TokenSet
     {
-        $request = Http::asForm()->acceptJson();
+        $request = Http::asForm()
+            ->acceptJson()
+            ->timeout(5)
+            ->connectTimeout(2)
+            ->withOptions(['allow_redirects' => false]);
+
+        $credentials = match ($authMethod) {
+            TokenEndpointAuthMethod::ClientSecretBasic => [],
+            TokenEndpointAuthMethod::ClientSecretPost => ['client_id' => $clientId, 'client_secret' => $clientSecret],
+            TokenEndpointAuthMethod::None => ['client_id' => $clientId],
+        };
 
         if ($authMethod === TokenEndpointAuthMethod::ClientSecretBasic) {
             $request = $request->withBasicAuth((string) $clientId, (string) $clientSecret);
-        } else {
-            if ($clientId !== null) {
-                $params['client_id'] = $clientId;
-            }
-
-            if ($authMethod === TokenEndpointAuthMethod::ClientSecretPost && $clientSecret !== null) {
-                $params['client_secret'] = $clientSecret;
-            }
         }
 
-        $response = $request->post($tokenEndpoint, $this->withoutNulls($params));
+        $response = $request->post($tokenEndpoint, $this->withoutNulls([...$params, ...$credentials]));
 
         if (! $response->successful()) {
             throw new OAuthException("Token request to [{$tokenEndpoint}] failed with status [{$response->status()}].");
@@ -246,26 +256,38 @@ class OAuthClient
         return array_filter($params, static fn (mixed $value): bool => $value !== null);
     }
 
+    protected function throwOnServerError(): void
+    {
+        if (($error = $this->query('error')) === null) {
+            return;
+        }
+
+        $description = $this->query('error_description');
+
+        throw new OAuthException($description === null
+            ? "The authorization server returned an error [{$error}]."
+            : "The authorization server returned an error [{$error}]: {$description}");
+    }
+
+    protected function query(string $key): ?string
+    {
+        $value = Request::query($key);
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+
     protected function discover(): DiscoveryResult
     {
         return $this->discovered ??= $this->discovery->discover($this->resourceUrl, $this->resourceMetadataUrl);
     }
 
-    protected function resolveScope(DiscoveryResult $discovered): ?string
+    protected function resolveScope(): ?string
     {
-        if ($this->config->scope !== null) {
-            return $this->config->scope;
-        }
-
-        if ($this->challengeScope !== null && $this->challengeScope !== '') {
+        if (filled($this->challengeScope)) {
             return $this->challengeScope;
         }
 
-        if ($discovered->scopesSupported !== []) {
-            return implode(' ', $discovered->scopesSupported);
-        }
-
-        return null;
+        return $this->config->scope ?? 'mcp:use';
     }
 
     protected function resolveTokenAuthMethod(AuthServerMetadata $metadata, ?string $clientSecret): TokenEndpointAuthMethod
@@ -274,7 +296,7 @@ class OAuthClient
             return $this->config->tokenEndpointAuthMethod;
         }
 
-        if ($clientSecret === null || $clientSecret === '') {
+        if (blank($clientSecret)) {
             return TokenEndpointAuthMethod::None;
         }
 
@@ -293,14 +315,12 @@ class OAuthClient
     {
         $host = parse_url($redirectUri, PHP_URL_HOST);
 
-        if (is_string($host) && in_array($host, ['localhost', '127.0.0.1', '::1'], true)) {
-            return 'native';
-        }
-
-        return 'web';
+        return is_string($host) && in_array($host, ['localhost', '127.0.0.1', '::1'], true)
+            ? 'native'
+            : 'web';
     }
 
-    protected function canonical(string $url): string
+    protected function resourceIdentifier(string $url): string
     {
         $parts = parse_url($url);
 
@@ -310,7 +330,7 @@ class OAuthClient
 
         $origin = $parts['scheme'].'://'.$parts['host'].(isset($parts['port']) ? ':'.$parts['port'] : '');
 
-        $path = rtrim($parts['path'] ?? '', '/');
+        $path = $parts['path'] ?? '';
 
         $query = isset($parts['query']) ? '?'.$parts['query'] : '';
 

--- a/src/Client/OAuth/OAuthClient.php
+++ b/src/Client/OAuth/OAuthClient.php
@@ -5,16 +5,18 @@ declare(strict_types=1);
 namespace Laravel\Mcp\Client\OAuth;
 
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Str;
 use Illuminate\Support\Uri;
 use Laravel\Mcp\Client\Exceptions\OAuthException;
+use Laravel\Mcp\Client\OAuth\Concerns\InteractsWithOAuthEndpoints;
 use Laravel\Mcp\Client\OAuth\Enums\TokenEndpointAuthMethod;
 
 class OAuthClient
 {
+    use InteractsWithOAuthEndpoints;
+
     protected ?DiscoveryResult $discovered = null;
 
     protected ?string $returnTo = null;
@@ -215,11 +217,7 @@ class OAuthClient
      */
     protected function requestToken(string $tokenEndpoint, array $params, ?string $clientId, ?string $clientSecret, TokenEndpointAuthMethod $authMethod): TokenSet
     {
-        $request = Http::asForm()
-            ->acceptJson()
-            ->timeout(5)
-            ->connectTimeout(2)
-            ->withOptions(['allow_redirects' => false]);
+        $request = $this->oAuthRequest()->asForm();
 
         $credentials = match ($authMethod) {
             TokenEndpointAuthMethod::ClientSecretBasic => [],

--- a/src/Client/OAuth/OAuthClient.php
+++ b/src/Client/OAuth/OAuthClient.php
@@ -1,0 +1,356 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\OAuth;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Request;
+use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Str;
+use Illuminate\Support\Uri;
+use Laravel\Mcp\Client\Exceptions\OAuthException;
+
+class OAuthClient
+{
+    protected string $resourceUrl;
+
+    protected ?DiscoveryResult $discovered = null;
+
+    public function __construct(
+        string $resourceUrl,
+        protected OAuthConfig $config,
+        protected ?string $resourceMetadataUrl = null,
+        protected ?string $challengeScope = null,
+        protected AuthServerDiscovery $discovery = new AuthServerDiscovery,
+    ) {
+        $this->resourceUrl = $this->canonical($resourceUrl);
+    }
+
+    public function redirect(?string $returnTo = null): RedirectResponse
+    {
+        $discovered = $this->discover();
+        $metadata = $discovered->server;
+
+        if ($metadata->codeChallengeMethodsSupported !== [] && ! in_array('S256', $metadata->codeChallengeMethodsSupported, true)) {
+            throw new OAuthException('The authorization server does not support the required S256 PKCE method.');
+        }
+
+        $clientId = $this->config->clientId;
+        $clientSecret = $this->config->clientSecret;
+        $redirectUri = $this->redirectUri();
+
+        if ($clientId === null) {
+            $registration = $this->register($metadata, $redirectUri);
+
+            $clientId = $registration->clientId;
+            $clientSecret = $registration->clientSecret;
+        }
+
+        $pkce = Pkce::generate();
+        $state = Str::random(40);
+
+        Session::put($this->sessionKey(), [
+            'state' => $state,
+            'verifier' => $pkce->verifier,
+            'client_id' => $clientId,
+            'client_secret' => $clientSecret,
+            'token_endpoint' => $metadata->tokenEndpoint,
+            'token_auth_method' => $this->resolveTokenAuthMethod($metadata, $clientSecret),
+            'redirect_uri' => $redirectUri,
+            'return_to' => $returnTo,
+            'issuer' => $metadata->issuer,
+            'iss_supported' => $metadata->authorizationResponseIssParameterSupported,
+        ]);
+
+        $authorizeUrl = Uri::of($metadata->authorizationEndpoint)->withQuery(array_filter([
+            'response_type' => 'code',
+            'client_id' => $clientId,
+            'redirect_uri' => $redirectUri,
+            'state' => $state,
+            'code_challenge' => $pkce->challenge,
+            'code_challenge_method' => 'S256',
+            'scope' => $this->resolveScope($discovered),
+            'resource' => $this->resourceUrl,
+        ], static fn (mixed $value): bool => $value !== null && $value !== ''));
+
+        return new RedirectResponse((string) $authorizeUrl);
+    }
+
+    public function callbackToken(): TokenSet
+    {
+        $error = Request::query('error');
+
+        if (is_string($error) && $error !== '') {
+            $description = Request::query('error_description');
+
+            throw new OAuthException(is_string($description) && $description !== ''
+                ? "The authorization server returned an error [{$error}]: {$description}"
+                : "The authorization server returned an error [{$error}].");
+        }
+
+        $code = Request::query('code');
+
+        if (! is_string($code)) {
+            throw new OAuthException('The authorization response did not include an authorization code.');
+        }
+
+        $state = Request::query('state');
+        $iss = Request::query('iss');
+
+        return $this->exchangeAuthorizationCode(
+            $code,
+            is_string($state) ? $state : '',
+            is_string($iss) ? $iss : null,
+        );
+    }
+
+    public function clientCredentialsToken(): TokenSet
+    {
+        if ($this->config->clientId === null) {
+            throw new OAuthException('A client_id is required for the client_credentials grant.');
+        }
+
+        $discovered = $this->discover();
+
+        return $this->requestToken(
+            $discovered->server->tokenEndpoint,
+            [
+                'grant_type' => 'client_credentials',
+                'scope' => $this->resolveScope($discovered),
+                'resource' => $this->resourceUrl,
+            ],
+            $this->config->clientId,
+            $this->config->clientSecret,
+            $this->resolveTokenAuthMethod($discovered->server, $this->config->clientSecret),
+        );
+    }
+
+    public function refresh(string $refreshToken, ?string $clientId = null, ?string $clientSecret = null): TokenSet
+    {
+        $discovered = $this->discover();
+
+        $clientId ??= $this->config->clientId;
+        $clientSecret ??= $this->config->clientSecret;
+
+        $token = $this->requestToken(
+            $discovered->server->tokenEndpoint,
+            [
+                'grant_type' => 'refresh_token',
+                'refresh_token' => $refreshToken,
+                'scope' => $this->resolveScope($discovered),
+                'resource' => $this->resourceUrl,
+            ],
+            $clientId,
+            $clientSecret,
+            $this->resolveTokenAuthMethod($discovered->server, $clientSecret),
+        );
+
+        $token->clientId = $clientId;
+        $token->clientSecret = $clientSecret;
+
+        return $token;
+    }
+
+    protected function exchangeAuthorizationCode(string $code, string $state, ?string $iss): TokenSet
+    {
+        /** @var array<string, mixed>|null $stored */
+        $stored = Session::get($this->sessionKey());
+
+        if (! is_array($stored)) {
+            throw new OAuthException('No pending OAuth authorization was found in the session.');
+        }
+
+        if (! is_string($stored['state'] ?? null) || ! hash_equals($stored['state'], $state)) {
+            throw new OAuthException('The OAuth state parameter did not match. Possible CSRF attempt.');
+        }
+
+        $this->validateIssuer($stored, $iss);
+
+        Session::forget($this->sessionKey());
+
+        $clientId = (string) $stored['client_id'];
+        $clientSecret = isset($stored['client_secret']) ? (string) $stored['client_secret'] : null;
+
+        $token = $this->requestToken(
+            (string) $stored['token_endpoint'],
+            [
+                'grant_type' => 'authorization_code',
+                'code' => $code,
+                'redirect_uri' => (string) $stored['redirect_uri'],
+                'code_verifier' => (string) $stored['verifier'],
+                'resource' => $this->resourceUrl,
+            ],
+            $clientId,
+            $clientSecret,
+            (string) ($stored['token_auth_method'] ?? 'client_secret_post'),
+        );
+
+        $token->clientId = $clientId;
+        $token->clientSecret = $clientSecret;
+
+        return $token;
+    }
+
+    protected function register(AuthServerMetadata $metadata, string $redirectUri): ClientRegistration
+    {
+        if ($metadata->registrationEndpoint === null) {
+            throw new OAuthException('No client_id was configured and the authorization server does not support dynamic client registration.');
+        }
+
+        return (new DynamicClientRegistration)->register(
+            $metadata->registrationEndpoint,
+            $redirectUri,
+            $this->resolveScope($this->discover()),
+            applicationType: $this->applicationType($redirectUri),
+            tokenEndpointAuthMethod: $this->resolveTokenAuthMethod($metadata, 'confidential'),
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $params
+     */
+    protected function requestToken(string $tokenEndpoint, array $params, ?string $clientId, ?string $clientSecret, string $authMethod): TokenSet
+    {
+        $request = Http::asForm()->acceptJson();
+
+        if ($authMethod === 'client_secret_basic') {
+            $request = $request->withBasicAuth((string) $clientId, (string) $clientSecret);
+        } else {
+            if ($clientId !== null) {
+                $params['client_id'] = $clientId;
+            }
+
+            if ($authMethod === 'client_secret_post' && $clientSecret !== null) {
+                $params['client_secret'] = $clientSecret;
+            }
+        }
+
+        $response = $request->post($tokenEndpoint, $this->withoutNulls($params));
+
+        if (! $response->successful()) {
+            throw new OAuthException("Token request to [{$tokenEndpoint}] failed with status [{$response->status()}].");
+        }
+
+        $data = $response->json();
+
+        if (! is_array($data) || empty($data['access_token'])) {
+            throw new OAuthException('The token response did not include an access_token.');
+        }
+
+        return TokenSet::fromResponse($data);
+    }
+
+    /**
+     * @param  array<string, mixed>  $params
+     * @return array<string, mixed>
+     */
+    protected function withoutNulls(array $params): array
+    {
+        return array_filter($params, static fn (mixed $value): bool => $value !== null);
+    }
+
+    protected function discover(): DiscoveryResult
+    {
+        return $this->discovered ??= $this->discovery->discover($this->resourceUrl, $this->resourceMetadataUrl);
+    }
+
+    protected function resolveScope(DiscoveryResult $discovered): ?string
+    {
+        if ($this->config->scope !== null) {
+            return $this->config->scope;
+        }
+
+        if ($this->challengeScope !== null && $this->challengeScope !== '') {
+            return $this->challengeScope;
+        }
+
+        if ($discovered->scopesSupported !== []) {
+            return implode(' ', $discovered->scopesSupported);
+        }
+
+        return null;
+    }
+
+    protected function resolveTokenAuthMethod(AuthServerMetadata $metadata, ?string $clientSecret): string
+    {
+        if ($this->config->tokenEndpointAuthMethod !== null) {
+            return $this->config->tokenEndpointAuthMethod;
+        }
+
+        if ($clientSecret === null || $clientSecret === '') {
+            return 'none';
+        }
+
+        $supported = $metadata->tokenEndpointAuthMethodsSupported;
+
+        if ($supported !== [] && ! in_array('client_secret_post', $supported, true) && in_array('client_secret_basic', $supported, true)) {
+            return 'client_secret_basic';
+        }
+
+        return 'client_secret_post';
+    }
+
+    protected function applicationType(string $redirectUri): string
+    {
+        $host = parse_url($redirectUri, PHP_URL_HOST);
+
+        if (is_string($host) && in_array($host, ['localhost', '127.0.0.1', '::1'], true)) {
+            return 'native';
+        }
+
+        return 'web';
+    }
+
+    protected function canonical(string $url): string
+    {
+        $parts = parse_url($url);
+
+        if (! is_array($parts) || ! isset($parts['scheme'], $parts['host'])) {
+            return $url;
+        }
+
+        $origin = $parts['scheme'].'://'.$parts['host'].(isset($parts['port']) ? ':'.$parts['port'] : '');
+
+        $path = rtrim($parts['path'] ?? '', '/');
+
+        $query = isset($parts['query']) ? '?'.$parts['query'] : '';
+
+        return $origin.$path.$query;
+    }
+
+    /**
+     * @param  array<string, mixed>  $stored
+     */
+    protected function validateIssuer(array $stored, ?string $iss): void
+    {
+        $expectedIssuer = is_string($stored['issuer'] ?? null) ? $stored['issuer'] : '';
+
+        if ($iss !== null) {
+            if ($expectedIssuer === '' || ! hash_equals($expectedIssuer, $iss)) {
+                throw new OAuthException('The OAuth issuer (iss) parameter did not match the expected issuer. Possible mix-up attack.');
+            }
+
+            return;
+        }
+
+        if ($stored['iss_supported'] ?? false) {
+            throw new OAuthException('The authorization response is missing the required iss parameter.');
+        }
+    }
+
+    protected function redirectUri(): string
+    {
+        if ($this->config->redirectUri === null) {
+            throw new OAuthException('A redirect URI is required. Pass redirectUri to withOauth().');
+        }
+
+        return $this->config->redirectUri;
+    }
+
+    protected function sessionKey(): string
+    {
+        return 'mcp.oauth.'.sha1($this->resourceUrl);
+    }
+}

--- a/src/Client/OAuth/OAuthClient.php
+++ b/src/Client/OAuth/OAuthClient.php
@@ -57,7 +57,7 @@ class OAuthClient
             'client_id' => $clientId,
             'client_secret' => $clientSecret,
             'token_endpoint' => $metadata->tokenEndpoint,
-            'token_auth_method' => $this->resolveTokenAuthMethod($metadata, $clientSecret),
+            'token_auth_method' => $this->resolveTokenAuthMethod($metadata, $clientSecret)->value,
             'redirect_uri' => $redirectUri,
             'return_to' => $returnTo,
             'issuer' => $metadata->issuer,
@@ -179,7 +179,7 @@ class OAuthClient
             ],
             $clientId,
             $clientSecret,
-            (string) ($stored['token_auth_method'] ?? 'client_secret_post'),
+            TokenEndpointAuthMethod::tryFrom((string) ($stored['token_auth_method'] ?? '')) ?? TokenEndpointAuthMethod::ClientSecretPost,
         );
 
         $token->clientId = $clientId;
@@ -206,18 +206,18 @@ class OAuthClient
     /**
      * @param  array<string, mixed>  $params
      */
-    protected function requestToken(string $tokenEndpoint, array $params, ?string $clientId, ?string $clientSecret, string $authMethod): TokenSet
+    protected function requestToken(string $tokenEndpoint, array $params, ?string $clientId, ?string $clientSecret, TokenEndpointAuthMethod $authMethod): TokenSet
     {
         $request = Http::asForm()->acceptJson();
 
-        if ($authMethod === 'client_secret_basic') {
+        if ($authMethod === TokenEndpointAuthMethod::ClientSecretBasic) {
             $request = $request->withBasicAuth((string) $clientId, (string) $clientSecret);
         } else {
             if ($clientId !== null) {
                 $params['client_id'] = $clientId;
             }
 
-            if ($authMethod === 'client_secret_post' && $clientSecret !== null) {
+            if ($authMethod === TokenEndpointAuthMethod::ClientSecretPost && $clientSecret !== null) {
                 $params['client_secret'] = $clientSecret;
             }
         }
@@ -268,23 +268,25 @@ class OAuthClient
         return null;
     }
 
-    protected function resolveTokenAuthMethod(AuthServerMetadata $metadata, ?string $clientSecret): string
+    protected function resolveTokenAuthMethod(AuthServerMetadata $metadata, ?string $clientSecret): TokenEndpointAuthMethod
     {
-        if ($this->config->tokenEndpointAuthMethod !== null) {
+        if ($this->config->tokenEndpointAuthMethod instanceof TokenEndpointAuthMethod) {
             return $this->config->tokenEndpointAuthMethod;
         }
 
         if ($clientSecret === null || $clientSecret === '') {
-            return 'none';
+            return TokenEndpointAuthMethod::None;
         }
 
         $supported = $metadata->tokenEndpointAuthMethodsSupported;
 
-        if ($supported !== [] && ! in_array('client_secret_post', $supported, true) && in_array('client_secret_basic', $supported, true)) {
-            return 'client_secret_basic';
+        if ($supported !== []
+            && ! in_array(TokenEndpointAuthMethod::ClientSecretPost->value, $supported, true)
+            && in_array(TokenEndpointAuthMethod::ClientSecretBasic->value, $supported, true)) {
+            return TokenEndpointAuthMethod::ClientSecretBasic;
         }
 
-        return 'client_secret_post';
+        return TokenEndpointAuthMethod::ClientSecretPost;
     }
 
     protected function applicationType(string $redirectUri): string

--- a/src/Client/OAuth/OAuthClient.php
+++ b/src/Client/OAuth/OAuthClient.php
@@ -11,23 +11,22 @@ use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Str;
 use Illuminate\Support\Uri;
 use Laravel\Mcp\Client\Exceptions\OAuthException;
+use Laravel\Mcp\Client\OAuth\Enums\TokenEndpointAuthMethod;
 
 class OAuthClient
 {
-    protected string $resourceUrl;
-
     protected ?DiscoveryResult $discovered = null;
 
     protected ?string $returnTo = null;
 
     public function __construct(
-        string $resourceUrl,
         protected OAuthConfig $config,
+        protected string $resourceUrl,
         protected ?string $resourceMetadataUrl = null,
         protected ?string $challengeScope = null,
         protected AuthServerDiscovery $discovery = new AuthServerDiscovery,
     ) {
-        $this->resourceUrl = $this->resourceIdentifier($resourceUrl);
+        $this->resourceUrl = (string) Uri::of($this->resourceUrl)->withoutFragment();
     }
 
     public function redirect(?string $returnTo = null): RedirectResponse
@@ -41,7 +40,7 @@ class OAuthClient
 
         $clientId = $this->config->clientId;
         $clientSecret = $this->config->clientSecret;
-        $redirectUri = $this->redirectUri();
+        $redirectUri = $this->config->redirectUri ?? throw new OAuthException('A redirect URI is required.');
 
         if ($clientId === null) {
             $registration = $this->register($metadata, $redirectUri);
@@ -126,7 +125,7 @@ class OAuthClient
         return $this->returnTo;
     }
 
-    public function refresh(string $refreshToken, ?string $clientId = null, ?string $clientSecret = null): TokenSet
+    public function refreshCredentials(string $refreshToken, ?string $clientId = null, ?string $clientSecret = null): TokenSet
     {
         $discovered = $this->discover();
 
@@ -232,7 +231,7 @@ class OAuthClient
             $request = $request->withBasicAuth((string) $clientId, (string) $clientSecret);
         }
 
-        $response = $request->post($tokenEndpoint, $this->withoutNulls([...$params, ...$credentials]));
+        $response = $request->post($tokenEndpoint, array_filter([...$params, ...$credentials], static fn (mixed $value): bool => $value !== null));
 
         if (! $response->successful()) {
             throw new OAuthException("Token request to [{$tokenEndpoint}] failed with status [{$response->status()}].");
@@ -245,15 +244,6 @@ class OAuthClient
         }
 
         return TokenSet::fromResponse($data);
-    }
-
-    /**
-     * @param  array<string, mixed>  $params
-     * @return array<string, mixed>
-     */
-    protected function withoutNulls(array $params): array
-    {
-        return array_filter($params, static fn (mixed $value): bool => $value !== null);
     }
 
     protected function throwOnServerError(): void
@@ -316,23 +306,6 @@ class OAuthClient
             : 'web';
     }
 
-    protected function resourceIdentifier(string $url): string
-    {
-        $parts = parse_url($url);
-
-        if (! is_array($parts) || ! isset($parts['scheme'], $parts['host'])) {
-            return $url;
-        }
-
-        $origin = $parts['scheme'].'://'.$parts['host'].(isset($parts['port']) ? ':'.$parts['port'] : '');
-
-        $path = $parts['path'] ?? '';
-
-        $query = isset($parts['query']) ? '?'.$parts['query'] : '';
-
-        return $origin.$path.$query;
-    }
-
     /**
      * @param  array<string, mixed>  $stored
      */
@@ -351,15 +324,6 @@ class OAuthClient
         if ($stored['iss_supported'] ?? false) {
             throw new OAuthException('The authorization response is missing the required iss parameter.');
         }
-    }
-
-    protected function redirectUri(): string
-    {
-        if ($this->config->redirectUri === null) {
-            throw new OAuthException('A redirect URI is required. Pass redirectUri to withOauth().');
-        }
-
-        return $this->config->redirectUri;
     }
 
     protected function sessionKey(): string

--- a/src/Client/OAuth/OAuthClient.php
+++ b/src/Client/OAuth/OAuthClient.php
@@ -292,10 +292,6 @@ class OAuthClient
 
     protected function resolveTokenAuthMethod(AuthServerMetadata $metadata, ?string $clientSecret): TokenEndpointAuthMethod
     {
-        if ($this->config->tokenEndpointAuthMethod instanceof TokenEndpointAuthMethod) {
-            return $this->config->tokenEndpointAuthMethod;
-        }
-
         if (blank($clientSecret)) {
             return TokenEndpointAuthMethod::None;
         }

--- a/src/Client/OAuth/OAuthClient.php
+++ b/src/Client/OAuth/OAuthClient.php
@@ -28,7 +28,7 @@ class OAuthClient
         protected ?string $challengeScope = null,
         protected AuthServerDiscovery $discovery = new AuthServerDiscovery,
     ) {
-        $this->resourceUrl = (string) Uri::of($this->resourceUrl)->withoutFragment();
+        $this->resourceUrl = Str::before($this->resourceUrl, '#');
     }
 
     public function redirect(?string $returnTo = null): RedirectResponse

--- a/src/Client/OAuth/OAuthClient.php
+++ b/src/Client/OAuth/OAuthClient.php
@@ -78,7 +78,7 @@ class OAuthClient
         return new RedirectResponse((string) $authorizeUrl);
     }
 
-    public function callbackToken(): TokenSet
+    public function token(): TokenSet
     {
         $error = Request::query('error');
 
@@ -92,22 +92,17 @@ class OAuthClient
 
         $code = Request::query('code');
 
-        if (! is_string($code)) {
-            throw new OAuthException('The authorization response did not include an authorization code.');
+        if (is_string($code) && $code !== '') {
+            $state = Request::query('state');
+            $iss = Request::query('iss');
+
+            return $this->exchangeAuthorizationCode(
+                $code,
+                is_string($state) ? $state : '',
+                is_string($iss) ? $iss : null,
+            );
         }
 
-        $state = Request::query('state');
-        $iss = Request::query('iss');
-
-        return $this->exchangeAuthorizationCode(
-            $code,
-            is_string($state) ? $state : '',
-            is_string($iss) ? $iss : null,
-        );
-    }
-
-    public function clientCredentialsToken(): TokenSet
-    {
         if ($this->config->clientId === null) {
             throw new OAuthException('A client_id is required for the client_credentials grant.');
         }

--- a/src/Client/OAuth/OAuthConfig.php
+++ b/src/Client/OAuth/OAuthConfig.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\OAuth;
+
+class OAuthConfig
+{
+    public function __construct(
+        public ?string $clientId = null,
+        public ?string $clientSecret = null,
+        public ?string $scope = null,
+        public ?string $redirectUri = null,
+        public ?string $tokenEndpointAuthMethod = null,
+    ) {}
+}

--- a/src/Client/OAuth/OAuthConfig.php
+++ b/src/Client/OAuth/OAuthConfig.php
@@ -11,6 +11,6 @@ class OAuthConfig
         public ?string $clientSecret = null,
         public ?string $scope = null,
         public ?string $redirectUri = null,
-        public ?string $tokenEndpointAuthMethod = null,
+        public ?TokenEndpointAuthMethod $tokenEndpointAuthMethod = null,
     ) {}
 }

--- a/src/Client/OAuth/OAuthConfig.php
+++ b/src/Client/OAuth/OAuthConfig.php
@@ -11,6 +11,5 @@ class OAuthConfig
         public ?string $clientSecret = null,
         public ?string $scope = null,
         public ?string $redirectUri = null,
-        public ?TokenEndpointAuthMethod $tokenEndpointAuthMethod = null,
     ) {}
 }

--- a/src/Client/OAuth/OAuthRouteRegistrar.php
+++ b/src/Client/OAuth/OAuthRouteRegistrar.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\OAuth;
+
+use Closure;
+use Illuminate\Container\Container;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Route as Router;
+use Laravel\Mcp\Client\ClientManager;
+use Laravel\Mcp\Exceptions\ClientException;
+use Laravel\Mcp\WebClient;
+
+class OAuthRouteRegistrar
+{
+    /**
+     * @param  Closure(string, TokenSet): mixed|array{0: class-string, 1: string}  $handler
+     * @param  array<int, string>|string  $middleware
+     */
+    public function register(
+        string $client,
+        Closure|array $handler,
+        array|string $middleware = 'web',
+        ?string $connectUri = null,
+        ?string $callbackUri = null,
+    ): void {
+        if (is_array($handler)) {
+            $handler = $handler[0].'@'.$handler[1];
+        }
+
+        $connect = Router::get($connectUri ?? "mcp/{$client}/connect", function () use ($client): mixed {
+            $resourceMetadata = request()->query('resource_metadata');
+            $scope = request()->query('scope');
+
+            return $this->webClient($client)->oAuthClient(
+                is_string($resourceMetadata) && $resourceMetadata !== '' ? $resourceMetadata : null,
+                is_string($scope) && $scope !== '' ? $scope : null,
+            )->redirect();
+        });
+
+        assert($connect instanceof Route);
+
+        $connect->name("mcp.oauth.{$client}.connect")->middleware($middleware);
+
+        $callback = Router::get($callbackUri ?? "mcp/oauth/{$client}/callback", function () use ($client, $handler): mixed {
+            $oauth = $this->webClient($client)->oAuthClient();
+            $token = $oauth->exchangeCallback();
+
+            $result = Container::getInstance()->call($handler, [
+                'provider' => $client,
+                'client' => $client,
+                'token' => $token,
+                'returnTo' => $oauth->returnTo(),
+            ]);
+
+            return $result ?? redirect($oauth->returnTo() ?? '/');
+        });
+
+        assert($callback instanceof Route);
+
+        $callback->name("mcp.oauth.{$client}.callback")->middleware($middleware);
+
+        Router::getRoutes()->refreshNameLookups();
+    }
+
+    protected function webClient(string $name): WebClient
+    {
+        $client = Container::getInstance()->make(ClientManager::class)->client($name);
+
+        if (! $client instanceof WebClient) {
+            throw new ClientException("MCP client [{$name}] does not support OAuth.");
+        }
+
+        return $client;
+    }
+}

--- a/src/Client/OAuth/Pkce.php
+++ b/src/Client/OAuth/Pkce.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\OAuth;
+
+class Pkce
+{
+    public function __construct(
+        public string $verifier,
+        public string $challenge,
+    ) {}
+
+    public static function generate(): self
+    {
+        $verifier = self::base64Url(random_bytes(64));
+        $challenge = self::base64Url(hash('sha256', $verifier, true));
+
+        return new self($verifier, $challenge);
+    }
+
+    private static function base64Url(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
+    }
+}

--- a/src/Client/OAuth/TokenEndpointAuthMethod.php
+++ b/src/Client/OAuth/TokenEndpointAuthMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\OAuth;
+
+enum TokenEndpointAuthMethod: string
+{
+    case None = 'none';
+    case ClientSecretBasic = 'client_secret_basic';
+    case ClientSecretPost = 'client_secret_post';
+}

--- a/src/Client/OAuth/TokenSet.php
+++ b/src/Client/OAuth/TokenSet.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\OAuth;
+
+class TokenSet
+{
+    public function __construct(
+        public string $accessToken,
+        public ?string $refreshToken = null,
+        public ?int $expiresAt = null,
+        public string $tokenType = 'Bearer',
+        public ?string $scope = null,
+        public ?string $clientId = null,
+        public ?string $clientSecret = null,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromResponse(array $data): self
+    {
+        $expiresIn = isset($data['expires_in']) ? (int) $data['expires_in'] : null;
+
+        return new self(
+            accessToken: (string) ($data['access_token'] ?? ''),
+            refreshToken: isset($data['refresh_token']) ? (string) $data['refresh_token'] : null,
+            expiresAt: $expiresIn !== null ? time() + $expiresIn : null,
+            tokenType: (string) ($data['token_type'] ?? 'Bearer'),
+            scope: isset($data['scope']) ? (string) $data['scope'] : null,
+        );
+    }
+}

--- a/src/Client/OAuth/WwwAuthenticateChallenge.php
+++ b/src/Client/OAuth/WwwAuthenticateChallenge.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\OAuth;
+
+class WwwAuthenticateChallenge
+{
+    public function __construct(
+        public ?string $resourceMetadataUrl = null,
+        public ?string $error = null,
+        public ?string $errorDescription = null,
+        public ?string $scope = null,
+    ) {}
+
+    public static function parse(?string $header): self
+    {
+        if ($header === null || $header === '') {
+            return new self;
+        }
+
+        $params = [];
+
+        preg_match_all('/(\w+)="([^"]*)"/', $header, $matches, PREG_SET_ORDER);
+
+        foreach ($matches as $match) {
+            $params[$match[1]] = $match[2];
+        }
+
+        return new self(
+            resourceMetadataUrl: $params['resource_metadata'] ?? null,
+            error: $params['error'] ?? null,
+            errorDescription: $params['error_description'] ?? null,
+            scope: $params['scope'] ?? null,
+        );
+    }
+}

--- a/src/Client/OAuth/WwwAuthenticateChallenge.php
+++ b/src/Client/OAuth/WwwAuthenticateChallenge.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp\Client\OAuth;
 
+use Symfony\Component\HttpFoundation\HeaderUtils;
+
 class WwwAuthenticateChallenge
 {
     public function __construct(
@@ -21,10 +23,38 @@ class WwwAuthenticateChallenge
 
         $params = [];
 
-        preg_match_all('/(\w+)="([^"]*)"/', $header, $matches, PREG_SET_ORDER);
+        foreach (HeaderUtils::split($header, ',') as $part) {
+            $part = trim((string) $part);
 
-        foreach ($matches as $match) {
-            $params[$match[1]] = $match[2];
+            if ($part === '') {
+                continue;
+            }
+
+            if (str_contains($part, ' ')) {
+                [$scheme, $value] = explode(' ', $part, 2);
+
+                if (! str_contains($scheme, '=')) {
+                    $part = trim($value);
+                }
+            }
+
+            if (! str_contains($part, '=')) {
+                continue;
+            }
+
+            $pair = HeaderUtils::split($part, '=');
+
+            if (count($pair) !== 2) {
+                continue;
+            }
+
+            $key = strtolower(trim((string) $pair[0]));
+
+            if (str_contains($key, ' ')) {
+                $key = substr($key, strrpos($key, ' ') + 1);
+            }
+
+            $params[$key] = HeaderUtils::unquote(trim((string) $pair[1]));
         }
 
         return new self(

--- a/src/Client/OAuth/WwwAuthenticateChallenge.php
+++ b/src/Client/OAuth/WwwAuthenticateChallenge.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp\Client\OAuth;
 
+use Illuminate\Support\Arr;
 use Symfony\Component\HttpFoundation\HeaderUtils;
 
 class WwwAuthenticateChallenge
@@ -21,47 +22,19 @@ class WwwAuthenticateChallenge
             return new self;
         }
 
+        preg_match_all('/([\w-]+)\s*=\s*("[^"]*"|[^,\s]+)/', $header, $matches, PREG_SET_ORDER);
+
         $params = [];
 
-        foreach (HeaderUtils::split($header, ',') as $part) {
-            $part = trim((string) $part);
-
-            if ($part === '') {
-                continue;
-            }
-
-            if (str_contains($part, ' ')) {
-                [$scheme, $value] = explode(' ', $part, 2);
-
-                if (! str_contains($scheme, '=')) {
-                    $part = trim($value);
-                }
-            }
-
-            if (! str_contains($part, '=')) {
-                continue;
-            }
-
-            $pair = HeaderUtils::split($part, '=');
-
-            if (count($pair) !== 2) {
-                continue;
-            }
-
-            $key = strtolower(trim((string) $pair[0]));
-
-            if (str_contains($key, ' ')) {
-                $key = substr($key, strrpos($key, ' ') + 1);
-            }
-
-            $params[$key] = HeaderUtils::unquote(trim((string) $pair[1]));
+        foreach ($matches as $match) {
+            $params[strtolower($match[1])] = HeaderUtils::unquote($match[2]);
         }
 
         return new self(
-            resourceMetadataUrl: $params['resource_metadata'] ?? null,
-            error: $params['error'] ?? null,
-            errorDescription: $params['error_description'] ?? null,
-            scope: $params['scope'] ?? null,
+            resourceMetadataUrl: Arr::get($params, 'resource_metadata'),
+            error: Arr::get($params, 'error'),
+            errorDescription: Arr::get($params, 'error_description'),
+            scope: Arr::get($params, 'scope'),
         );
     }
 }

--- a/src/Client/Transport/HttpTransport.php
+++ b/src/Client/Transport/HttpTransport.php
@@ -75,7 +75,7 @@ class HttpTransport implements Transport
         return [
             'driver' => 'http',
             'url' => $this->url,
-            'token' => $this->token,
+            'token' => $this->token instanceof Closure ? (string) ($this->token)() : $this->token,
             'timeoutSeconds' => $this->timeoutSeconds,
         ];
     }

--- a/src/Client/Transport/HttpTransport.php
+++ b/src/Client/Transport/HttpTransport.php
@@ -20,7 +20,7 @@ use Throwable;
 
 class HttpTransport implements Transport
 {
-    /** @var string|Closure(): string|null */
+    /** @var string|(Closure(): string)|null */
     protected string|Closure|null $token = null;
 
     protected ?string $sessionId = null;

--- a/src/Client/Transport/HttpTransport.php
+++ b/src/Client/Transport/HttpTransport.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp\Client\Transport;
 
+use Closure;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\Response as ClientResponse;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use Laravel\Mcp\Client\Contracts\Transport;
+use Laravel\Mcp\Client\Exceptions\AuthorizationRequiredException;
+use Laravel\Mcp\Client\OAuth\WwwAuthenticateChallenge;
 use Laravel\Mcp\Enums\ProtocolVersion;
 use Laravel\Mcp\Exceptions\ClientException;
 use Laravel\Mcp\Exceptions\SessionExpiredException;
@@ -17,7 +20,8 @@ use Throwable;
 
 class HttpTransport implements Transport
 {
-    protected ?string $token = null;
+    /** @var string|Closure(): string|null */
+    protected string|Closure|null $token = null;
 
     protected ?string $sessionId = null;
 
@@ -50,9 +54,17 @@ class HttpTransport implements Transport
         $this->timeoutSeconds = $seconds;
     }
 
-    public function withToken(string $token): void
+    /**
+     * @param  string|Closure(): string  $token
+     */
+    public function withToken(string|Closure $token): void
     {
         $this->token = $token;
+    }
+
+    public function url(): string
+    {
+        return $this->url;
     }
 
     public function send(string $message): void
@@ -70,6 +82,17 @@ class HttpTransport implements Transport
         }
 
         $this->captureSessionId($response);
+
+        if ($response->status() === 401 || $response->status() === 403) {
+            $challenge = WwwAuthenticateChallenge::parse($response->header('WWW-Authenticate'));
+
+            $this->reset();
+
+            throw new AuthorizationRequiredException(
+                "The server responded with HTTP {$response->status()} for endpoint [{$this->url}]. Authorization is required.",
+                $challenge,
+            );
+        }
 
         if ($response->notFound() && $hadSession) {
             $this->reset();
@@ -131,8 +154,10 @@ class HttpTransport implements Transport
             $headers['MCP-Protocol-Version'] = ProtocolVersion::LATEST->value;
         }
 
-        if ($this->token !== null) {
-            $headers['Authorization'] = "Bearer {$this->token}";
+        $token = $this->token instanceof Closure ? (string) ($this->token)() : $this->token;
+
+        if ($token !== null && $token !== '') {
+            $headers['Authorization'] = "Bearer {$token}";
         }
 
         return $headers;

--- a/src/Facades/Mcp.php
+++ b/src/Facades/Mcp.php
@@ -12,6 +12,7 @@ use Laravel\Mcp\Server\Registrar;
  * @method static void local(string $handle, string $serverClass)
  * @method static void registerClient(string $name, \Closure $factory)
  * @method static \Laravel\Mcp\Client client(string $name)
+ * @method static void oAuthRoutesFor(string $client, \Closure|array $handler, array|string $middleware = 'web', ?string $connectUri = null, ?string $callbackUri = null)
  * @method static callable|null getLocalServer(string $handle)
  * @method static \Illuminate\Routing\Route|null getWebServer(string $route)
  * @method static array servers()

--- a/src/Server/Registrar.php
+++ b/src/Server/Registrar.php
@@ -13,6 +13,8 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Laravel\Mcp\Client;
 use Laravel\Mcp\Client\ClientManager;
+use Laravel\Mcp\Client\OAuth\TokenSet;
+use Laravel\Mcp\Exceptions\ClientException;
 use Laravel\Mcp\Server;
 use Laravel\Mcp\Server\Contracts\Transport;
 use Laravel\Mcp\Server\Http\Controllers\OAuthRegisterController;
@@ -20,6 +22,7 @@ use Laravel\Mcp\Server\Middleware\AddWwwAuthenticateHeader;
 use Laravel\Mcp\Server\Middleware\ReorderJsonAccept;
 use Laravel\Mcp\Server\Transport\HttpTransport;
 use Laravel\Mcp\Server\Transport\StdioTransport;
+use Laravel\Mcp\WebClient;
 use Laravel\Passport\Passport;
 
 class Registrar
@@ -82,6 +85,65 @@ class Registrar
     public function client(string $name): Client
     {
         return $this->clientManager()->client($name);
+    }
+
+    protected function webClient(string $name): WebClient
+    {
+        $client = $this->client($name);
+
+        if (! $client instanceof WebClient) {
+            throw new ClientException("MCP client [{$name}] does not support OAuth.");
+        }
+
+        return $client;
+    }
+
+    /**
+     * @param  Closure(string, TokenSet): mixed|array{0: class-string, 1: string}  $handler
+     * @param  array<int, string>|string  $middleware
+     */
+    public function oAuthRoutesFor(
+        string $client,
+        Closure|array $handler,
+        array|string $middleware = 'web',
+        ?string $connectUri = null,
+        ?string $callbackUri = null,
+    ): void {
+        if (is_array($handler)) {
+            $handler = $handler[0].'@'.$handler[1];
+        }
+
+        $connect = Router::get($connectUri ?? "mcp/{$client}/connect", function () use ($client): mixed {
+            $resourceMetadata = request()->query('resource_metadata');
+            $scope = request()->query('scope');
+
+            return $this->webClient($client)->oAuth(
+                is_string($resourceMetadata) && $resourceMetadata !== '' ? $resourceMetadata : null,
+                is_string($scope) && $scope !== '' ? $scope : null,
+            )->redirect();
+        });
+
+        assert($connect instanceof Route);
+
+        $connect->name("mcp.oauth.{$client}.connect")->middleware($middleware);
+
+        $callback = Router::get($callbackUri ?? "mcp/oauth/{$client}/callback", function () use ($client, $handler): mixed {
+            $token = $this->webClient($client)->oAuth()->callbackToken();
+
+            $result = Container::getInstance()->call($handler, [
+                'provider' => $client,
+                'client' => $client,
+                'token' => $token,
+            ]);
+
+            return $result ?? redirect('/');
+        });
+
+        assert($callback instanceof Route);
+
+        $callback->name("mcp.oauth.{$client}.callback")->middleware($middleware);
+
+        Router::getRoutes()->refreshNameLookups();
     }
 
     public function getLocalServer(string $handle): ?callable

--- a/src/Server/Registrar.php
+++ b/src/Server/Registrar.php
@@ -128,15 +128,17 @@ class Registrar
         $connect->name("mcp.oauth.{$client}.connect")->middleware($middleware);
 
         $callback = Router::get($callbackUri ?? "mcp/oauth/{$client}/callback", function () use ($client, $handler): mixed {
-            $token = $this->webClient($client)->oAuth()->token();
+            $oauth = $this->webClient($client)->oAuth();
+            $token = $oauth->exchangeCallback();
 
             $result = Container::getInstance()->call($handler, [
                 'provider' => $client,
                 'client' => $client,
                 'token' => $token,
+                'returnTo' => $oauth->returnTo(),
             ]);
 
-            return $result ?? redirect('/');
+            return $result ?? redirect($oauth->returnTo() ?? '/');
         });
 
         assert($callback instanceof Route);

--- a/src/Server/Registrar.php
+++ b/src/Server/Registrar.php
@@ -128,7 +128,7 @@ class Registrar
         $connect->name("mcp.oauth.{$client}.connect")->middleware($middleware);
 
         $callback = Router::get($callbackUri ?? "mcp/oauth/{$client}/callback", function () use ($client, $handler): mixed {
-            $token = $this->webClient($client)->oAuth()->callbackToken();
+            $token = $this->webClient($client)->oAuth()->token();
 
             $result = Container::getInstance()->call($handler, [
                 'provider' => $client,

--- a/src/Server/Registrar.php
+++ b/src/Server/Registrar.php
@@ -13,8 +13,8 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Laravel\Mcp\Client;
 use Laravel\Mcp\Client\ClientManager;
+use Laravel\Mcp\Client\OAuth\OAuthRouteRegistrar;
 use Laravel\Mcp\Client\OAuth\TokenSet;
-use Laravel\Mcp\Exceptions\ClientException;
 use Laravel\Mcp\Server;
 use Laravel\Mcp\Server\Contracts\Transport;
 use Laravel\Mcp\Server\Http\Controllers\OAuthRegisterController;
@@ -22,7 +22,6 @@ use Laravel\Mcp\Server\Middleware\AddWwwAuthenticateHeader;
 use Laravel\Mcp\Server\Middleware\ReorderJsonAccept;
 use Laravel\Mcp\Server\Transport\HttpTransport;
 use Laravel\Mcp\Server\Transport\StdioTransport;
-use Laravel\Mcp\WebClient;
 use Laravel\Passport\Passport;
 
 class Registrar
@@ -87,17 +86,6 @@ class Registrar
         return $this->clientManager()->client($name);
     }
 
-    protected function webClient(string $name): WebClient
-    {
-        $client = $this->client($name);
-
-        if (! $client instanceof WebClient) {
-            throw new ClientException("MCP client [{$name}] does not support OAuth.");
-        }
-
-        return $client;
-    }
-
     /**
      * @param  Closure(string, TokenSet): mixed|array{0: class-string, 1: string}  $handler
      * @param  array<int, string>|string  $middleware
@@ -109,43 +97,7 @@ class Registrar
         ?string $connectUri = null,
         ?string $callbackUri = null,
     ): void {
-        if (is_array($handler)) {
-            $handler = $handler[0].'@'.$handler[1];
-        }
-
-        $connect = Router::get($connectUri ?? "mcp/{$client}/connect", function () use ($client): mixed {
-            $resourceMetadata = request()->query('resource_metadata');
-            $scope = request()->query('scope');
-
-            return $this->webClient($client)->oAuth(
-                is_string($resourceMetadata) && $resourceMetadata !== '' ? $resourceMetadata : null,
-                is_string($scope) && $scope !== '' ? $scope : null,
-            )->redirect();
-        });
-
-        assert($connect instanceof Route);
-
-        $connect->name("mcp.oauth.{$client}.connect")->middleware($middleware);
-
-        $callback = Router::get($callbackUri ?? "mcp/oauth/{$client}/callback", function () use ($client, $handler): mixed {
-            $oauth = $this->webClient($client)->oAuth();
-            $token = $oauth->exchangeCallback();
-
-            $result = Container::getInstance()->call($handler, [
-                'provider' => $client,
-                'client' => $client,
-                'token' => $token,
-                'returnTo' => $oauth->returnTo(),
-            ]);
-
-            return $result ?? redirect($oauth->returnTo() ?? '/');
-        });
-
-        assert($callback instanceof Route);
-
-        $callback->name("mcp.oauth.{$client}.callback")->middleware($middleware);
-
-        Router::getRoutes()->refreshNameLookups();
+        (new OAuthRouteRegistrar)->register($client, $handler, $middleware, $connectUri, $callbackUri);
     }
 
     public function getLocalServer(string $handle): ?callable

--- a/src/WebClient.php
+++ b/src/WebClient.php
@@ -4,11 +4,18 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp;
 
+use Closure;
+use Laravel\Mcp\Client\Exceptions\OAuthException;
+use Laravel\Mcp\Client\OAuth\OAuthClient;
+use Laravel\Mcp\Client\OAuth\OAuthConfig;
 use Laravel\Mcp\Client\Transport\HttpTransport;
 use Laravel\Mcp\Schema\Implementation;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 class WebClient extends Client
 {
+    protected ?OAuthConfig $oAuthConfig = null;
+
     public function __construct(
         protected HttpTransport $httpTransport,
         ?Implementation $clientInfo = null,
@@ -16,10 +23,57 @@ class WebClient extends Client
         parent::__construct($httpTransport, $clientInfo);
     }
 
-    public function withToken(string $token): static
+    /**
+     * @param  string|Closure(): string  $token
+     */
+    public function withToken(string|Closure $token): static
     {
         $this->httpTransport->withToken($token);
 
         return $this;
+    }
+
+    public function withOAuth(
+        ?string $clientId = null,
+        ?string $clientSecret = null,
+        ?string $scope = 'mcp:use',
+        ?string $redirectUri = null,
+        ?string $tokenEndpointAuthMethod = null,
+    ): static {
+        $this->oAuthConfig = new OAuthConfig(
+            clientId: $clientId,
+            clientSecret: $clientSecret,
+            scope: $scope,
+            redirectUri: $redirectUri,
+            tokenEndpointAuthMethod: $tokenEndpointAuthMethod,
+        );
+
+        return $this;
+    }
+
+    public function oAuth(?string $resourceMetadataUrl = null, ?string $challengeScope = null): OAuthClient
+    {
+        if (! $this->oAuthConfig instanceof OAuthConfig) {
+            throw new OAuthException('No OAuth configuration found. Call withOAuth() before oAuth().');
+        }
+
+        if ($this->oAuthConfig->redirectUri === null) {
+            $this->oAuthConfig->redirectUri = $this->defaultRedirectUri();
+        }
+
+        return new OAuthClient($this->httpTransport->url(), $this->oAuthConfig, $resourceMetadataUrl, $challengeScope);
+    }
+
+    protected function defaultRedirectUri(): ?string
+    {
+        if ($this->registeredName === null) {
+            return null;
+        }
+
+        try {
+            return route("mcp.oauth.{$this->registeredName}.callback");
+        } catch (RouteNotFoundException) {
+            return null;
+        }
     }
 }

--- a/src/WebClient.php
+++ b/src/WebClient.php
@@ -8,7 +8,6 @@ use Closure;
 use Laravel\Mcp\Client\Exceptions\OAuthException;
 use Laravel\Mcp\Client\OAuth\OAuthClient;
 use Laravel\Mcp\Client\OAuth\OAuthConfig;
-use Laravel\Mcp\Client\OAuth\TokenEndpointAuthMethod;
 use Laravel\Mcp\Client\Transport\HttpTransport;
 use Laravel\Mcp\Schema\Implementation;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
@@ -39,14 +38,12 @@ class WebClient extends Client
         ?string $clientSecret = null,
         ?string $scope = null,
         ?string $redirectUri = null,
-        ?TokenEndpointAuthMethod $tokenEndpointAuthMethod = null,
     ): static {
         $this->oAuthConfig = new OAuthConfig(
             clientId: $clientId,
             clientSecret: $clientSecret,
             scope: $scope,
             redirectUri: $redirectUri,
-            tokenEndpointAuthMethod: $tokenEndpointAuthMethod,
         );
 
         return $this;

--- a/src/WebClient.php
+++ b/src/WebClient.php
@@ -8,6 +8,7 @@ use Closure;
 use Laravel\Mcp\Client\Exceptions\OAuthException;
 use Laravel\Mcp\Client\OAuth\OAuthClient;
 use Laravel\Mcp\Client\OAuth\OAuthConfig;
+use Laravel\Mcp\Client\OAuth\TokenEndpointAuthMethod;
 use Laravel\Mcp\Client\Transport\HttpTransport;
 use Laravel\Mcp\Schema\Implementation;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
@@ -38,7 +39,7 @@ class WebClient extends Client
         ?string $clientSecret = null,
         ?string $scope = 'mcp:use',
         ?string $redirectUri = null,
-        ?string $tokenEndpointAuthMethod = null,
+        ?TokenEndpointAuthMethod $tokenEndpointAuthMethod = null,
     ): static {
         $this->oAuthConfig = new OAuthConfig(
             clientId: $clientId,

--- a/src/WebClient.php
+++ b/src/WebClient.php
@@ -14,11 +14,10 @@ use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 class WebClient extends Client
 {
-    protected ?OAuthConfig $oAuthConfig = null;
-
     public function __construct(
         protected HttpTransport $httpTransport,
-        ?Implementation $clientInfo = null,
+        public ?Implementation $clientInfo = null,
+        protected ?OAuthConfig $oAuthConfig = null,
     ) {
         parent::__construct($httpTransport, $clientInfo);
     }
@@ -49,29 +48,23 @@ class WebClient extends Client
         return $this;
     }
 
-    public function oAuth(?string $resourceMetadataUrl = null, ?string $challengeScope = null): OAuthClient
+    public function oAuthClient(?string $resourceMetadataUrl = null, ?string $challengeScope = null): OAuthClient
     {
         if (! $this->oAuthConfig instanceof OAuthConfig) {
-            throw new OAuthException('No OAuth configuration found. Call withOAuth() before oAuth().');
+            throw new OAuthException('No OAuth configuration found. Call withOAuth() before oAuthClient().');
         }
 
-        if ($this->oAuthConfig->redirectUri === null) {
-            $this->oAuthConfig->redirectUri = $this->defaultRedirectUri();
+        $config = $this->oAuthConfig;
+
+        if ($config->redirectUri === null && $this->registeredName !== null) {
+            $config = clone $config;
+
+            try {
+                $config->redirectUri = route("mcp.oauth.{$this->registeredName}.callback");
+            } catch (RouteNotFoundException) {
+            }
         }
 
-        return new OAuthClient($this->httpTransport->url(), $this->oAuthConfig, $resourceMetadataUrl, $challengeScope);
-    }
-
-    protected function defaultRedirectUri(): ?string
-    {
-        if ($this->registeredName === null) {
-            return null;
-        }
-
-        try {
-            return route("mcp.oauth.{$this->registeredName}.callback");
-        } catch (RouteNotFoundException) {
-            return null;
-        }
+        return new OAuthClient($config, $this->httpTransport->url(), $resourceMetadataUrl, $challengeScope);
     }
 }

--- a/src/WebClient.php
+++ b/src/WebClient.php
@@ -37,7 +37,7 @@ class WebClient extends Client
     public function withOAuth(
         ?string $clientId = null,
         ?string $clientSecret = null,
-        ?string $scope = 'mcp:use',
+        ?string $scope = null,
         ?string $redirectUri = null,
         ?TokenEndpointAuthMethod $tokenEndpointAuthMethod = null,
     ): static {

--- a/src/WebClient.php
+++ b/src/WebClient.php
@@ -75,6 +75,8 @@ class WebClient extends Client
     {
         parent::__unserialize($data);
 
+        $this->oAuthConfig = null;
+
         if ($this->transport instanceof HttpTransport) {
             $this->httpTransport = $this->transport;
         }

--- a/tests/Feature/Client/OAuthCallbackRouteTest.php
+++ b/tests/Feature/Client/OAuthCallbackRouteTest.php
@@ -137,6 +137,29 @@ it('falls back to redirecting home when the handler returns nothing', function (
         ->assertRedirect('/');
 });
 
+it('passes the stored return destination to the handler and fallback redirect', function (): void {
+    Http::fake([
+        'https://auth.test/token' => Http::response(['access_token' => 'access-token']),
+    ]);
+
+    registerGithubClient();
+
+    $capturedReturnTo = null;
+
+    Mcp::oAuthRoutesFor('github', function (string $provider, TokenSet $token, ?string $returnTo) use (&$capturedReturnTo): void {
+        $capturedReturnTo = $returnTo;
+    });
+
+    $session = fakeOAuthSession();
+    $session['mcp.oauth.'.sha1('https://mcp.test/mcp')]['return_to'] = '/connected';
+
+    $this->withSession($session)
+        ->get('/mcp/oauth/github/callback?code=auth-code&state=the-state')
+        ->assertRedirect('/connected');
+
+    expect($capturedReturnTo)->toBe('/connected');
+});
+
 it('forwards challenge metadata and scope from the connect route into discovery', function (): void {
     Http::fake([
         'https://mcp.test/.well-known/custom-resource' => Http::response([
@@ -151,7 +174,6 @@ it('forwards challenge metadata and scope from the connect route into discovery'
 
     Mcp::registerClient('github', fn (): WebClient => Client::web('https://mcp.test/mcp')->withOAuth(
         clientId: 'client-123',
-        scope: null,
         redirectUri: 'https://app.test/callback',
     ));
 

--- a/tests/Feature/Client/OAuthCallbackRouteTest.php
+++ b/tests/Feature/Client/OAuthCallbackRouteTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Route;
+use Laravel\Mcp\Client;
+use Laravel\Mcp\Client\OAuth\TokenSet;
+use Laravel\Mcp\Facades\Mcp;
+use Laravel\Mcp\WebClient;
+use Tests\Fixtures\Client\OAuthCallbackController;
+
+beforeEach(function (): void {
+    config()->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
+});
+
+function fakeOAuthSession(): array
+{
+    return ['mcp.oauth.'.sha1('https://mcp.test/mcp') => [
+        'state' => 'the-state',
+        'verifier' => 'the-verifier',
+        'client_id' => 'client-123',
+        'client_secret' => null,
+        'token_endpoint' => 'https://auth.test/token',
+        'redirect_uri' => 'https://app.test/callback',
+        'return_to' => null,
+    ]];
+}
+
+function registerGithubClient(): void
+{
+    Mcp::registerClient('github', fn (): WebClient => Client::web('https://mcp.test/mcp')->withOAuth(
+        clientId: 'client-123',
+        redirectUri: 'https://app.test/callback',
+    ));
+}
+
+it('exchanges the code and invokes the handler with the client name', function (): void {
+    Http::fake([
+        'https://auth.test/token' => Http::response([
+            'access_token' => 'access-token',
+            'refresh_token' => 'refresh-token',
+            'expires_in' => 3600,
+        ]),
+    ]);
+
+    registerGithubClient();
+
+    $capturedProvider = null;
+    $capturedToken = null;
+
+    Mcp::oAuthRoutesFor('github', function (string $provider, TokenSet $token) use (&$capturedProvider, &$capturedToken): RedirectResponse {
+        $capturedProvider = $provider;
+        $capturedToken = $token;
+
+        return redirect('/dashboard');
+    });
+
+    $this->withSession(fakeOAuthSession())
+        ->get('/mcp/oauth/github/callback?code=auth-code&state=the-state')
+        ->assertRedirect('/dashboard');
+
+    expect($capturedProvider)->toBe('github')
+        ->and($capturedToken)->toBeInstanceOf(TokenSet::class)
+        ->and($capturedToken->accessToken)->toBe('access-token')
+        ->and($capturedToken->refreshToken)->toBe('refresh-token');
+
+    Http::assertSent(fn ($request): bool => $request->url() === 'https://auth.test/token'
+        && ($request['grant_type'] ?? null) === 'authorization_code'
+        && ($request['code'] ?? null) === 'auth-code');
+});
+
+it('registers a connect route that redirects to the authorization server', function (): void {
+    Http::fake([
+        'https://mcp.test/.well-known/oauth-protected-resource/mcp' => Http::response([
+            'resource' => 'https://mcp.test/mcp',
+            'authorization_servers' => ['https://auth.test'],
+        ]),
+        'https://auth.test/.well-known/oauth-authorization-server' => Http::response([
+            'issuer' => 'https://auth.test',
+            'authorization_endpoint' => 'https://auth.test/authorize',
+            'token_endpoint' => 'https://auth.test/token',
+        ]),
+    ]);
+
+    registerGithubClient();
+
+    Mcp::oAuthRoutesFor('github', fn (string $provider, TokenSet $token): RedirectResponse => redirect('/dashboard'));
+
+    $response = $this->withSession([])->get('/mcp/github/connect');
+
+    $response->assertRedirectContains('https://auth.test/authorize');
+});
+
+it('supports controller array syntax for the handler', function (): void {
+    Http::fake([
+        'https://auth.test/token' => Http::response(['access_token' => 'access-token']),
+    ]);
+
+    registerGithubClient();
+
+    Mcp::oAuthRoutesFor('github', [OAuthCallbackController::class, 'callback']);
+
+    $this->withSession(fakeOAuthSession())
+        ->get('/mcp/oauth/github/callback?code=auth-code&state=the-state')
+        ->assertRedirect('/connected/github');
+});
+
+it('applies the web middleware group by default to both routes', function (): void {
+    Mcp::oAuthRoutesFor('github', fn (string $provider, TokenSet $token): null => null);
+
+    expect(Route::getRoutes()->getByName('mcp.oauth.github.connect')->gatherMiddleware())->toContain('web')
+        ->and(Route::getRoutes()->getByName('mcp.oauth.github.callback')->gatherMiddleware())->toContain('web');
+});
+
+it('allows the middleware to be overridden on both routes', function (): void {
+    Mcp::oAuthRoutesFor('github', fn (string $provider, TokenSet $token): null => null, middleware: ['web', 'auth']);
+
+    expect(Route::getRoutes()->getByName('mcp.oauth.github.connect')->gatherMiddleware())->toContain('web')->toContain('auth')
+        ->and(Route::getRoutes()->getByName('mcp.oauth.github.callback')->gatherMiddleware())->toContain('web')->toContain('auth');
+});
+
+it('falls back to redirecting home when the handler returns nothing', function (): void {
+    Http::fake([
+        'https://auth.test/token' => Http::response(['access_token' => 'access-token']),
+    ]);
+
+    registerGithubClient();
+
+    Mcp::oAuthRoutesFor('github', function (string $provider, TokenSet $token): void {
+        //
+    });
+
+    $this->withSession(fakeOAuthSession())
+        ->get('/mcp/oauth/github/callback?code=auth-code&state=the-state')
+        ->assertRedirect('/');
+});
+
+it('forwards challenge metadata and scope from the connect route into discovery', function (): void {
+    Http::fake([
+        'https://mcp.test/.well-known/custom-resource' => Http::response([
+            'authorization_servers' => ['https://auth.test'],
+        ]),
+        'https://auth.test/.well-known/oauth-authorization-server' => Http::response([
+            'issuer' => 'https://auth.test',
+            'authorization_endpoint' => 'https://auth.test/authorize',
+            'token_endpoint' => 'https://auth.test/token',
+        ]),
+    ]);
+
+    Mcp::registerClient('github', fn (): WebClient => Client::web('https://mcp.test/mcp')->withOAuth(
+        clientId: 'client-123',
+        scope: null,
+        redirectUri: 'https://app.test/callback',
+    ));
+
+    Mcp::oAuthRoutesFor('github', fn (string $provider, TokenSet $token): null => null);
+
+    $this->withSession([])
+        ->get('/mcp/github/connect?resource_metadata=https://mcp.test/.well-known/custom-resource&scope=files:read')
+        ->assertRedirectContains('https://auth.test/authorize')
+        ->assertRedirectContains('scope=files%3Aread');
+
+    Http::assertSent(fn ($request): bool => $request->url() === 'https://mcp.test/.well-known/custom-resource');
+});

--- a/tests/Fixtures/Client/OAuthCallbackController.php
+++ b/tests/Fixtures/Client/OAuthCallbackController.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Client;
+
+use Illuminate\Http\RedirectResponse;
+use Laravel\Mcp\Client\OAuth\TokenSet;
+
+class OAuthCallbackController
+{
+    public function callback(string $provider, TokenSet $token): RedirectResponse
+    {
+        return redirect("/connected/{$provider}");
+    }
+}

--- a/tests/Unit/Client/ClientManagerTest.php
+++ b/tests/Unit/Client/ClientManagerTest.php
@@ -2,8 +2,11 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
 use Laravel\Mcp\Client;
 use Laravel\Mcp\Client\ClientManager;
+use Laravel\Mcp\Client\Exceptions\AuthorizationRequiredException;
 use Laravel\Mcp\Client\Transport\HttpTransport;
 use Laravel\Mcp\Exceptions\ClientException;
 use Laravel\Mcp\Facades\Mcp;
@@ -127,6 +130,29 @@ it('fetches a fresh tools list on every resolution', function (): void {
     expect(Mcp::client('everything')->tools()->keys()->all())->toBe(['add']);
     expect(Mcp::client('everything')->tools()->keys()->all())->toBe(['add']);
     expect($transport->responses)->toBeEmpty();
+});
+
+it('returns the given default from a named client when authorization is required', function (): void {
+    Http::fake([
+        'https://mcp.test/mcp' => Http::response('', 401),
+    ]);
+
+    Mcp::registerClient('nightwatch', fn (): Client => new Client(new HttpTransport('https://mcp.test/mcp')));
+
+    $tools = Mcp::client('nightwatch')->tools(default: []);
+
+    expect($tools)->toBeInstanceOf(Collection::class)->toBeEmpty();
+});
+
+it('rethrows the authorization exception from a named client when no default is given', function (): void {
+    Http::fake([
+        'https://mcp.test/mcp' => Http::response('', 401),
+    ]);
+
+    Mcp::registerClient('nightwatch', fn (): Client => new Client(new HttpTransport('https://mcp.test/mcp')));
+
+    expect(fn () => Mcp::client('nightwatch')->tools())
+        ->toThrow(AuthorizationRequiredException::class);
 });
 
 it('resolves a subclassed client and preserves fluent chaining', function (): void {

--- a/tests/Unit/Client/OAuth/OAuthClientTest.php
+++ b/tests/Unit/Client/OAuth/OAuthClientTest.php
@@ -10,7 +10,6 @@ use Illuminate\Support\Facades\Session;
 use Laravel\Mcp\Client;
 use Laravel\Mcp\Client\Exceptions\OAuthException;
 use Laravel\Mcp\Client\OAuth\OAuthClient;
-use Laravel\Mcp\Client\OAuth\TokenEndpointAuthMethod;
 use Laravel\Mcp\Client\OAuth\TokenSet;
 
 function fakeDiscovery(): void
@@ -867,19 +866,4 @@ it('uses client_secret_basic when the server only supports it', function (): voi
             && $authorization === 'Basic '.base64_encode('svc:secret')
             && ! array_key_exists('client_secret', $request->data());
     });
-});
-
-it('honors an explicitly configured token endpoint auth method', function (): void {
-    fakeDiscovery();
-
-    Http::fake([
-        'https://auth.test/token' => Http::response(['access_token' => 'machine-token']),
-    ]);
-
-    Client::web('https://mcp.test/mcp')
-        ->withOAuth(clientId: 'svc', clientSecret: 'secret', scope: 'mcp:use', tokenEndpointAuthMethod: TokenEndpointAuthMethod::ClientSecretBasic)
-        ->oAuth()
-        ->clientCredentials();
-
-    Http::assertSent(fn ($request): bool => ($request->header('Authorization')[0] ?? '') === 'Basic '.base64_encode('svc:secret'));
 });

--- a/tests/Unit/Client/OAuth/OAuthClientTest.php
+++ b/tests/Unit/Client/OAuth/OAuthClientTest.php
@@ -38,7 +38,7 @@ it('builds an authorization redirect with PKCE and stashes session state', funct
             scope: 'mcp:use',
             redirectUri: 'https://app.test/callback',
         )
-        ->oAuth()
+        ->oAuthClient()
         ->redirect('/dashboard');
 
     $target = $response->getTargetUrl();
@@ -76,7 +76,7 @@ it('merges query params onto an authorization endpoint that already has a query 
 
     $target = Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oAuth()
+        ->oAuthClient()
         ->redirect()
         ->getTargetUrl();
 
@@ -98,7 +98,7 @@ it('dynamically registers a client when no client id is configured', function ()
 
     Client::web('https://mcp.test/mcp')
         ->withOAuth(redirectUri: 'https://app.test/callback')
-        ->oAuth()
+        ->oAuthClient()
         ->redirect();
 
     $stored = Session::get('mcp.oauth.'.sha1('https://mcp.test/mcp'));
@@ -142,7 +142,7 @@ it('exchanges an authorization code for a token set', function (): void {
 
     $token = Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123')
-        ->oAuth()
+        ->oAuthClient()
         ->exchangeCallback();
 
     expect($token)->toBeInstanceOf(TokenSet::class)
@@ -181,7 +181,7 @@ it('rejects a mismatched state parameter', function (): void {
 
     expect(fn (): TokenSet => Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123')
-        ->oAuth()
+        ->oAuthClient()
         ->exchangeCallback())
         ->toThrow(OAuthException::class, 'state parameter did not match');
 });
@@ -198,7 +198,7 @@ it('runs the client credentials grant', function (): void {
 
     $token = Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'svc', clientSecret: 'secret', scope: 'mcp:use')
-        ->oAuth()
+        ->oAuthClient()
         ->clientCredentials();
 
     expect($token->accessToken)->toBe('machine-token');
@@ -217,7 +217,7 @@ it('throws when the authorization server redirects back with an error', function
 
     Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123')
-        ->oAuth()
+        ->oAuthClient()
         ->exchangeCallback();
 })->throws(OAuthException::class, 'The authorization server returned an error [access_denied]: The user denied the request');
 
@@ -226,7 +226,7 @@ it('requires an authorization code when exchanging a callback', function (): voi
 
     expect(fn (): TokenSet => Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'svc', clientSecret: 'secret', scope: 'mcp:use')
-        ->oAuth()
+        ->oAuthClient()
         ->exchangeCallback())
         ->toThrow(OAuthException::class, 'did not include an authorization code');
 });
@@ -244,8 +244,8 @@ it('refreshes a token using the refresh grant', function (): void {
 
     $token = Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123', scope: 'mcp:use')
-        ->oAuth()
-        ->refresh('old-refresh');
+        ->oAuthClient()
+        ->refreshCredentials('old-refresh');
 
     expect($token->accessToken)->toBe('fresh-token')
         ->and($token->refreshToken)->toBe('new-refresh');
@@ -267,7 +267,7 @@ it('falls back to the resource origin when protected resource metadata is unavai
 
     $response = Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oAuth()
+        ->oAuthClient()
         ->redirect();
 
     expect($response->getTargetUrl())->toStartWith('https://mcp.test/authorize?');
@@ -282,8 +282,8 @@ it('throws when the token request fails', function (): void {
 
     expect(fn (): TokenSet => Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123', scope: 'mcp:use')
-        ->oAuth()
-        ->refresh('bad-token'))
+        ->oAuthClient()
+        ->refreshCredentials('bad-token'))
         ->toThrow(OAuthException::class, 'failed with status [400]');
 });
 
@@ -298,7 +298,7 @@ it('throws when the authorization server metadata cannot be discovered', functio
 
     expect(fn (): TokenSet => Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123', clientSecret: 'secret')
-        ->oAuth()
+        ->oAuthClient()
         ->clientCredentials())
         ->toThrow(OAuthException::class, 'Unable to discover authorization server metadata');
 });
@@ -317,13 +317,13 @@ it('throws when dynamic registration is needed but unsupported', function (): vo
 
     expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
         ->withOAuth(redirectUri: 'https://app.test/callback')
-        ->oAuth()
+        ->oAuthClient()
         ->redirect())
         ->toThrow(OAuthException::class, 'does not support dynamic client registration');
 });
 
 it('throws when oauth is used without configuration', function (): void {
-    expect(fn (): OAuthClient => Client::web('https://mcp.test/mcp')->oAuth())
+    expect(fn (): OAuthClient => Client::web('https://mcp.test/mcp')->oAuthClient())
         ->toThrow(OAuthException::class, 'No OAuth configuration');
 });
 
@@ -332,7 +332,7 @@ it('requires a redirect uri before redirecting', function (): void {
 
     expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123')
-        ->oAuth()
+        ->oAuthClient()
         ->redirect())
         ->toThrow(OAuthException::class, 'redirect URI is required');
 });
@@ -351,7 +351,7 @@ it('uses the server advertised resource metadata url when provided', function ()
 
     $target = Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oAuth('https://mcp.test/.well-known/custom-resource')
+        ->oAuthClient('https://mcp.test/.well-known/custom-resource')
         ->redirect()
         ->getTargetUrl();
 
@@ -360,10 +360,41 @@ it('uses the server advertised resource metadata url when provided', function ()
     Http::assertSent(fn ($request): bool => $request->url() === 'https://mcp.test/.well-known/custom-resource');
 });
 
+it('throws instead of falling back to the origin when an explicit resource metadata url fails', function (): void {
+    Http::fake([
+        'https://mcp.test/.well-known/custom-resource' => Http::response('', 404),
+        'https://mcp.test/.well-known/oauth-authorization-server' => Http::response([
+            'issuer' => 'https://mcp.test',
+            'authorization_endpoint' => 'https://mcp.test/authorize',
+            'token_endpoint' => 'https://mcp.test/token',
+        ]),
+    ]);
+
+    expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
+        ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oAuthClient('https://mcp.test/.well-known/custom-resource')
+        ->redirect())
+        ->toThrow(OAuthException::class, 'Protected resource metadata request to [https://mcp.test/.well-known/custom-resource] failed with status [404]');
+
+    Http::assertNotSent(fn ($request): bool => $request->url() === 'https://mcp.test/.well-known/oauth-authorization-server');
+});
+
+it('throws when an explicit resource metadata url returns invalid json', function (): void {
+    Http::fake([
+        'https://mcp.test/.well-known/custom-resource' => Http::response('not json', 200, ['Content-Type' => 'text/plain']),
+    ]);
+
+    expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
+        ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oAuthClient('https://mcp.test/.well-known/custom-resource')
+        ->redirect())
+        ->toThrow(OAuthException::class, 'did not return a valid JSON object');
+});
+
 it('rejects protected resource metadata urls on internal hosts', function (): void {
     expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oAuth('https://127.0.0.1/.well-known/oauth-protected-resource')
+        ->oAuthClient('https://127.0.0.1/.well-known/oauth-protected-resource')
         ->redirect())
         ->toThrow(OAuthException::class, 'private or internal host');
 });
@@ -371,7 +402,7 @@ it('rejects protected resource metadata urls on internal hosts', function (): vo
 it('rejects protected resource metadata urls served over plain http', function (): void {
     expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oAuth('http://mcp.test/.well-known/oauth-protected-resource')
+        ->oAuthClient('http://mcp.test/.well-known/oauth-protected-resource')
         ->redirect())
         ->toThrow(OAuthException::class, 'must be served over HTTPS');
 });
@@ -390,7 +421,7 @@ it('rejects an authorization server whose issuer does not match', function (): v
 
     expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oAuth()
+        ->oAuthClient()
         ->redirect())
         ->toThrow(OAuthException::class, 'did not match the expected issuer');
 });
@@ -405,7 +436,7 @@ it('rejects protected resource metadata whose resource does not match', function
 
     expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oAuth()
+        ->oAuthClient()
         ->redirect())
         ->toThrow(OAuthException::class, 'did not match the expected resource');
 });
@@ -423,7 +454,7 @@ it('rejects authorization server metadata that omits the issuer', function (): v
 
     expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oAuth()
+        ->oAuthClient()
         ->redirect())
         ->toThrow(OAuthException::class, 'did not match the expected issuer');
 });
@@ -443,7 +474,7 @@ it('rejects an authorization server that does not advertise the S256 PKCE method
 
     expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oAuth()
+        ->oAuthClient()
         ->redirect())
         ->toThrow(OAuthException::class, 'does not support the required S256');
 });
@@ -457,7 +488,7 @@ it('rejects an authorization server served over plain http', function (): void {
 
     expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oAuth()
+        ->oAuthClient()
         ->redirect())
         ->toThrow(OAuthException::class, 'must be served over HTTPS');
 });
@@ -477,7 +508,7 @@ it('falls back to openid connect discovery when oauth metadata is absent', funct
 
     $target = Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oAuth()
+        ->oAuthClient()
         ->redirect()
         ->getTargetUrl();
 
@@ -513,7 +544,7 @@ it('validates a matching iss parameter on the authorization callback', function 
 
     $token = Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123')
-        ->oAuth()
+        ->oAuthClient()
         ->exchangeCallback();
 
     expect($token->accessToken)->toBe('access-token');
@@ -544,7 +575,7 @@ it('rejects a mismatched iss parameter on the authorization callback', function 
 
     expect(fn (): TokenSet => Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123')
-        ->oAuth()
+        ->oAuthClient()
         ->exchangeCallback())
         ->toThrow(OAuthException::class, 'iss) parameter did not match');
 });
@@ -573,7 +604,7 @@ it('rejects a missing iss parameter when the server advertises support', functio
 
     expect(fn (): TokenSet => Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123')
-        ->oAuth()
+        ->oAuthClient()
         ->exchangeCallback())
         ->toThrow(OAuthException::class, 'missing the required iss parameter');
 });
@@ -593,7 +624,7 @@ it('records the issuer in the session for callback validation', function (): voi
 
     Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oAuth()
+        ->oAuthClient()
         ->redirect();
 
     $stored = Session::get('mcp.oauth.'.sha1('https://mcp.test/mcp'));
@@ -607,7 +638,7 @@ it('defaults the scope to mcp:use', function (): void {
 
     $target = Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oAuth()
+        ->oAuthClient()
         ->redirect()
         ->getTargetUrl();
 
@@ -631,7 +662,7 @@ it('does not request every supported scope from protected resource metadata', fu
 
     $target = Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oAuth()
+        ->oAuthClient()
         ->redirect()
         ->getTargetUrl();
 
@@ -655,7 +686,7 @@ it('prefers the challenge scope over the configured scope', function (): void {
 
     $target = Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123', scope: 'mcp:use', redirectUri: 'https://app.test/callback')
-        ->oAuth(challengeScope: 'files:read files:write')
+        ->oAuthClient(challengeScope: 'files:read files:write')
         ->redirect()
         ->getTargetUrl();
 
@@ -673,7 +704,7 @@ it('sends a native application_type when registering a localhost client', functi
 
     Client::web('https://mcp.test/mcp')
         ->withOAuth(redirectUri: 'http://localhost:3000/callback')
-        ->oAuth()
+        ->oAuthClient()
         ->redirect();
 
     Http::assertSent(fn ($request): bool => $request->url() === 'https://auth.test/register'
@@ -689,7 +720,7 @@ it('sends a web application_type when registering a remote client', function ():
 
     Client::web('https://mcp.test/mcp')
         ->withOAuth(redirectUri: 'https://app.test/callback')
-        ->oAuth()
+        ->oAuthClient()
         ->redirect();
 
     Http::assertSent(fn ($request): bool => $request->url() === 'https://auth.test/register'
@@ -710,7 +741,7 @@ it('strips fragments but preserves trailing slashes in the resource identifier',
 
     $target = Client::web('https://mcp.test/mcp/#fragment')
         ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oAuth()
+        ->oAuthClient()
         ->redirect()
         ->getTargetUrl();
 
@@ -729,7 +760,7 @@ it('rejects protected resource metadata when a trailing slash differs', function
 
     expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp/')
         ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oAuth()
+        ->oAuthClient()
         ->redirect())
         ->toThrow(OAuthException::class, 'did not match the expected resource [https://mcp.test/mcp/]');
 });
@@ -743,8 +774,8 @@ it('includes the resource parameter on a refresh token request', function (): vo
 
     Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123')
-        ->oAuth()
-        ->refresh('old-refresh');
+        ->oAuthClient()
+        ->refreshCredentials('old-refresh');
 
     Http::assertSent(fn ($request): bool => $request->url() === 'https://auth.test/token'
         && ($request['grant_type'] ?? null) === 'refresh_token'
@@ -760,7 +791,7 @@ it('defaults the redirect uri to the package callback route for a registered cli
     $target = Client::web('https://mcp.test/mcp')
         ->setRegisteredName('github')
         ->withOAuth(clientId: 'client-123', scope: 'mcp:use')
-        ->oAuth()
+        ->oAuthClient()
         ->redirect()
         ->getTargetUrl();
 
@@ -778,7 +809,7 @@ it('lets an explicit redirect uri override the default callback route', function
     $target = Client::web('https://mcp.test/mcp')
         ->setRegisteredName('github')
         ->withOAuth(clientId: 'client-123', scope: 'mcp:use', redirectUri: 'https://app.test/custom')
-        ->oAuth()
+        ->oAuthClient()
         ->redirect()
         ->getTargetUrl();
 
@@ -814,7 +845,7 @@ it('surfaces the dynamically registered credentials on the token set', function 
 
     $token = Client::web('https://mcp.test/mcp')
         ->withOAuth()
-        ->oAuth()
+        ->oAuthClient()
         ->exchangeCallback();
 
     expect($token->clientId)->toBe('dcr-999')
@@ -830,8 +861,8 @@ it('refreshes using explicitly passed client credentials', function (): void {
 
     $token = Client::web('https://mcp.test/mcp')
         ->withOAuth(scope: 'mcp:use')
-        ->oAuth()
-        ->refresh('old-refresh', clientId: 'dcr-999', clientSecret: 'dcr-secret');
+        ->oAuthClient()
+        ->refreshCredentials('old-refresh', clientId: 'dcr-999', clientSecret: 'dcr-secret');
 
     expect($token->clientId)->toBe('dcr-999');
 
@@ -856,7 +887,7 @@ it('uses client_secret_basic when the server only supports it', function (): voi
 
     Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'svc', clientSecret: 'secret', scope: 'mcp:use')
-        ->oAuth()
+        ->oAuthClient()
         ->clientCredentials();
 
     Http::assertSent(function ($request): bool {

--- a/tests/Unit/Client/OAuth/OAuthClientTest.php
+++ b/tests/Unit/Client/OAuth/OAuthClientTest.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Session;
 use Laravel\Mcp\Client;
 use Laravel\Mcp\Client\Exceptions\OAuthException;
 use Laravel\Mcp\Client\OAuth\OAuthClient;
+use Laravel\Mcp\Client\OAuth\TokenEndpointAuthMethod;
 use Laravel\Mcp\Client\OAuth\TokenSet;
 
 function fakeDiscovery(): void
@@ -858,7 +859,7 @@ it('honors an explicitly configured token endpoint auth method', function (): vo
     ]);
 
     Client::web('https://mcp.test/mcp')
-        ->withOAuth(clientId: 'svc', clientSecret: 'secret', scope: 'mcp:use', tokenEndpointAuthMethod: 'client_secret_basic')
+        ->withOAuth(clientId: 'svc', clientSecret: 'secret', scope: 'mcp:use', tokenEndpointAuthMethod: TokenEndpointAuthMethod::ClientSecretBasic)
         ->oAuth()
         ->token();
 

--- a/tests/Unit/Client/OAuth/OAuthClientTest.php
+++ b/tests/Unit/Client/OAuth/OAuthClientTest.php
@@ -143,7 +143,7 @@ it('exchanges an authorization code for a token set', function (): void {
     $token = Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123')
         ->oAuth()
-        ->callbackToken();
+        ->token();
 
     expect($token)->toBeInstanceOf(TokenSet::class)
         ->and($token->accessToken)->toBe('access-token')
@@ -182,7 +182,7 @@ it('rejects a mismatched state parameter', function (): void {
     expect(fn (): TokenSet => Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123')
         ->oAuth()
-        ->callbackToken())
+        ->token())
         ->toThrow(OAuthException::class, 'state parameter did not match');
 });
 
@@ -199,7 +199,7 @@ it('runs the client credentials grant', function (): void {
     $token = Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'svc', clientSecret: 'secret', scope: 'mcp:use')
         ->oAuth()
-        ->clientCredentialsToken();
+        ->token();
 
     expect($token->accessToken)->toBe('machine-token');
 
@@ -218,17 +218,31 @@ it('throws when the authorization server redirects back with an error', function
     Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123')
         ->oAuth()
-        ->callbackToken();
+        ->token();
 })->throws(OAuthException::class, 'The authorization server returned an error [access_denied]: The user denied the request');
 
-it('throws when the authorization callback has no code', function (): void {
+it('falls back to the client credentials grant when no authorization code is present', function (): void {
+    fakeDiscovery();
+
+    Http::fake([
+        'https://auth.test/token' => Http::response([
+            'access_token' => 'machine-token',
+            'expires_in' => 7200,
+        ]),
+    ]);
+
     app()->instance('request', Request::create('https://app.test/callback', 'GET'));
 
-    Client::web('https://mcp.test/mcp')
-        ->withOAuth(clientId: 'client-123')
+    $token = Client::web('https://mcp.test/mcp')
+        ->withOAuth(clientId: 'svc', clientSecret: 'secret', scope: 'mcp:use')
         ->oAuth()
-        ->callbackToken();
-})->throws(OAuthException::class, 'The authorization response did not include an authorization code.');
+        ->token();
+
+    expect($token->accessToken)->toBe('machine-token');
+
+    Http::assertSent(fn ($request): bool => $request->url() === 'https://auth.test/token'
+        && ($request->data()['grant_type'] ?? null) === 'client_credentials');
+});
 
 it('refreshes a token using the refresh grant', function (): void {
     fakeDiscovery();
@@ -298,7 +312,7 @@ it('throws when the authorization server metadata cannot be discovered', functio
     expect(fn (): TokenSet => Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123', clientSecret: 'secret')
         ->oAuth()
-        ->clientCredentialsToken())
+        ->token())
         ->toThrow(OAuthException::class, 'Unable to discover authorization server metadata');
 });
 
@@ -497,7 +511,7 @@ it('validates a matching iss parameter on the authorization callback', function 
     $token = Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123')
         ->oAuth()
-        ->callbackToken();
+        ->token();
 
     expect($token->accessToken)->toBe('access-token');
 });
@@ -528,7 +542,7 @@ it('rejects a mismatched iss parameter on the authorization callback', function 
     expect(fn (): TokenSet => Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123')
         ->oAuth()
-        ->callbackToken())
+        ->token())
         ->toThrow(OAuthException::class, 'iss) parameter did not match');
 });
 
@@ -557,7 +571,7 @@ it('rejects a missing iss parameter when the server advertises support', functio
     expect(fn (): TokenSet => Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123')
         ->oAuth()
-        ->callbackToken())
+        ->token())
         ->toThrow(OAuthException::class, 'missing the required iss parameter');
 });
 
@@ -783,7 +797,7 @@ it('surfaces the dynamically registered credentials on the token set', function 
     $token = Client::web('https://mcp.test/mcp')
         ->withOAuth()
         ->oAuth()
-        ->callbackToken();
+        ->token();
 
     expect($token->clientId)->toBe('dcr-999')
         ->and($token->clientSecret)->toBe('dcr-secret');
@@ -825,7 +839,7 @@ it('uses client_secret_basic when the server only supports it', function (): voi
     Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'svc', clientSecret: 'secret', scope: 'mcp:use')
         ->oAuth()
-        ->clientCredentialsToken();
+        ->token();
 
     Http::assertSent(function ($request): bool {
         $authorization = $request->header('Authorization')[0] ?? '';
@@ -846,7 +860,7 @@ it('honors an explicitly configured token endpoint auth method', function (): vo
     Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'svc', clientSecret: 'secret', scope: 'mcp:use', tokenEndpointAuthMethod: 'client_secret_basic')
         ->oAuth()
-        ->clientCredentialsToken();
+        ->token();
 
     Http::assertSent(fn ($request): bool => ($request->header('Authorization')[0] ?? '') === 'Basic '.base64_encode('svc:secret'));
 });

--- a/tests/Unit/Client/OAuth/OAuthClientTest.php
+++ b/tests/Unit/Client/OAuth/OAuthClientTest.php
@@ -33,12 +33,12 @@ it('builds an authorization redirect with PKCE and stashes session state', funct
     fakeDiscovery();
 
     $response = Client::web('https://mcp.test/mcp')
-        ->withOauth(
+        ->withOAuth(
             clientId: 'client-123',
             scope: 'mcp:use',
             redirectUri: 'https://app.test/callback',
         )
-        ->oauth()
+        ->oAuth()
         ->redirect('/dashboard');
 
     $target = $response->getTargetUrl();
@@ -75,8 +75,8 @@ it('merges query params onto an authorization endpoint that already has a query 
     ]);
 
     $target = Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oAuth()
         ->redirect()
         ->getTargetUrl();
 
@@ -97,8 +97,8 @@ it('dynamically registers a client when no client id is configured', function ()
     ]);
 
     Client::web('https://mcp.test/mcp')
-        ->withOauth(redirectUri: 'https://app.test/callback')
-        ->oauth()
+        ->withOAuth(redirectUri: 'https://app.test/callback')
+        ->oAuth()
         ->redirect();
 
     $stored = Session::get('mcp.oauth.'.sha1('https://mcp.test/mcp'));
@@ -141,8 +141,8 @@ it('exchanges an authorization code for a token set', function (): void {
     ]));
 
     $token = Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'client-123')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123')
+        ->oAuth()
         ->callbackToken();
 
     expect($token)->toBeInstanceOf(TokenSet::class)
@@ -180,8 +180,8 @@ it('rejects a mismatched state parameter', function (): void {
     ]));
 
     expect(fn (): TokenSet => Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'client-123')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123')
+        ->oAuth()
         ->callbackToken())
         ->toThrow(OAuthException::class, 'state parameter did not match');
 });
@@ -197,8 +197,8 @@ it('runs the client credentials grant', function (): void {
     ]);
 
     $token = Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'svc', clientSecret: 'secret', scope: 'mcp:use')
-        ->oauth()
+        ->withOAuth(clientId: 'svc', clientSecret: 'secret', scope: 'mcp:use')
+        ->oAuth()
         ->clientCredentialsToken();
 
     expect($token->accessToken)->toBe('machine-token');
@@ -216,8 +216,8 @@ it('throws when the authorization server redirects back with an error', function
     ]));
 
     Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'client-123')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123')
+        ->oAuth()
         ->callbackToken();
 })->throws(OAuthException::class, 'The authorization server returned an error [access_denied]: The user denied the request');
 
@@ -225,8 +225,8 @@ it('throws when the authorization callback has no code', function (): void {
     app()->instance('request', Request::create('https://app.test/callback', 'GET'));
 
     Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'client-123')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123')
+        ->oAuth()
         ->callbackToken();
 })->throws(OAuthException::class, 'The authorization response did not include an authorization code.');
 
@@ -242,8 +242,8 @@ it('refreshes a token using the refresh grant', function (): void {
     ]);
 
     $token = Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'client-123', scope: 'mcp:use')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123', scope: 'mcp:use')
+        ->oAuth()
         ->refresh('old-refresh');
 
     expect($token->accessToken)->toBe('fresh-token')
@@ -265,8 +265,8 @@ it('falls back to the resource origin when protected resource metadata is unavai
     ]);
 
     $response = Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oAuth()
         ->redirect();
 
     expect($response->getTargetUrl())->toStartWith('https://mcp.test/authorize?');
@@ -280,8 +280,8 @@ it('throws when the token request fails', function (): void {
     ]);
 
     expect(fn (): TokenSet => Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'client-123', scope: 'mcp:use')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123', scope: 'mcp:use')
+        ->oAuth()
         ->refresh('bad-token'))
         ->toThrow(OAuthException::class, 'failed with status [400]');
 });
@@ -296,8 +296,8 @@ it('throws when the authorization server metadata cannot be discovered', functio
     ]);
 
     expect(fn (): TokenSet => Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'client-123', clientSecret: 'secret')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123', clientSecret: 'secret')
+        ->oAuth()
         ->clientCredentialsToken())
         ->toThrow(OAuthException::class, 'Unable to discover authorization server metadata');
 });
@@ -315,14 +315,14 @@ it('throws when dynamic registration is needed but unsupported', function (): vo
     ]);
 
     expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
-        ->withOauth(redirectUri: 'https://app.test/callback')
-        ->oauth()
+        ->withOAuth(redirectUri: 'https://app.test/callback')
+        ->oAuth()
         ->redirect())
         ->toThrow(OAuthException::class, 'does not support dynamic client registration');
 });
 
 it('throws when oauth is used without configuration', function (): void {
-    expect(fn (): OAuthClient => Client::web('https://mcp.test/mcp')->oauth())
+    expect(fn (): OAuthClient => Client::web('https://mcp.test/mcp')->oAuth())
         ->toThrow(OAuthException::class, 'No OAuth configuration');
 });
 
@@ -330,8 +330,8 @@ it('requires a redirect uri before redirecting', function (): void {
     fakeDiscovery();
 
     expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'client-123')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123')
+        ->oAuth()
         ->redirect())
         ->toThrow(OAuthException::class, 'redirect URI is required');
 });
@@ -349,8 +349,8 @@ it('uses the server advertised resource metadata url when provided', function ()
     ]);
 
     $target = Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oauth('https://mcp.test/.well-known/custom-resource')
+        ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oAuth('https://mcp.test/.well-known/custom-resource')
         ->redirect()
         ->getTargetUrl();
 
@@ -372,8 +372,8 @@ it('rejects an authorization server whose issuer does not match', function (): v
     ]);
 
     expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oAuth()
         ->redirect())
         ->toThrow(OAuthException::class, 'did not match the expected issuer');
 });
@@ -387,8 +387,8 @@ it('rejects protected resource metadata whose resource does not match', function
     ]);
 
     expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oAuth()
         ->redirect())
         ->toThrow(OAuthException::class, 'did not match the expected resource');
 });
@@ -405,8 +405,8 @@ it('rejects authorization server metadata that omits the issuer', function (): v
     ]);
 
     expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oAuth()
         ->redirect())
         ->toThrow(OAuthException::class, 'did not match the expected issuer');
 });
@@ -425,8 +425,8 @@ it('rejects an authorization server that does not advertise the S256 PKCE method
     ]);
 
     expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oAuth()
         ->redirect())
         ->toThrow(OAuthException::class, 'does not support the required S256');
 });
@@ -439,8 +439,8 @@ it('rejects an authorization server served over plain http', function (): void {
     ]);
 
     expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oAuth()
         ->redirect())
         ->toThrow(OAuthException::class, 'must be served over HTTPS');
 });
@@ -459,8 +459,8 @@ it('falls back to openid connect discovery when oauth metadata is absent', funct
     ]);
 
     $target = Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oAuth()
         ->redirect()
         ->getTargetUrl();
 
@@ -495,8 +495,8 @@ it('validates a matching iss parameter on the authorization callback', function 
     ]));
 
     $token = Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'client-123')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123')
+        ->oAuth()
         ->callbackToken();
 
     expect($token->accessToken)->toBe('access-token');
@@ -526,8 +526,8 @@ it('rejects a mismatched iss parameter on the authorization callback', function 
     ]));
 
     expect(fn (): TokenSet => Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'client-123')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123')
+        ->oAuth()
         ->callbackToken())
         ->toThrow(OAuthException::class, 'iss) parameter did not match');
 });
@@ -555,8 +555,8 @@ it('rejects a missing iss parameter when the server advertises support', functio
     ]));
 
     expect(fn (): TokenSet => Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'client-123')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123')
+        ->oAuth()
         ->callbackToken())
         ->toThrow(OAuthException::class, 'missing the required iss parameter');
 });
@@ -575,8 +575,8 @@ it('records the issuer in the session for callback validation', function (): voi
     ]);
 
     Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oAuth()
         ->redirect();
 
     $stored = Session::get('mcp.oauth.'.sha1('https://mcp.test/mcp'));
@@ -589,8 +589,8 @@ it('defaults the scope to mcp:use', function (): void {
     fakeDiscovery();
 
     $target = Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oAuth()
         ->redirect()
         ->getTargetUrl();
 
@@ -613,8 +613,8 @@ it('falls back to scopes_supported from the protected resource metadata', functi
     ]);
 
     $target = Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'client-123', scope: null, redirectUri: 'https://app.test/callback')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123', scope: null, redirectUri: 'https://app.test/callback')
+        ->oAuth()
         ->redirect()
         ->getTargetUrl();
 
@@ -637,8 +637,8 @@ it('prefers the challenge scope over scopes_supported', function (): void {
     ]);
 
     $target = Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'client-123', scope: null, redirectUri: 'https://app.test/callback')
-        ->oauth(challengeScope: 'files:read files:write')
+        ->withOAuth(clientId: 'client-123', scope: null, redirectUri: 'https://app.test/callback')
+        ->oAuth(challengeScope: 'files:read files:write')
         ->redirect()
         ->getTargetUrl();
 
@@ -655,8 +655,8 @@ it('sends a native application_type when registering a localhost client', functi
     ]);
 
     Client::web('https://mcp.test/mcp')
-        ->withOauth(redirectUri: 'http://localhost:3000/callback')
-        ->oauth()
+        ->withOAuth(redirectUri: 'http://localhost:3000/callback')
+        ->oAuth()
         ->redirect();
 
     Http::assertSent(fn ($request): bool => $request->url() === 'https://auth.test/register'
@@ -671,8 +671,8 @@ it('sends a web application_type when registering a remote client', function ():
     ]);
 
     Client::web('https://mcp.test/mcp')
-        ->withOauth(redirectUri: 'https://app.test/callback')
-        ->oauth()
+        ->withOAuth(redirectUri: 'https://app.test/callback')
+        ->oAuth()
         ->redirect();
 
     Http::assertSent(fn ($request): bool => $request->url() === 'https://auth.test/register'
@@ -692,8 +692,8 @@ it('normalizes the resource to its canonical form without a trailing slash', fun
     ]);
 
     $target = Client::web('https://mcp.test/mcp/#fragment')
-        ->withOauth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oAuth()
         ->redirect()
         ->getTargetUrl();
 
@@ -710,8 +710,8 @@ it('includes the resource parameter on a refresh token request', function (): vo
     ]);
 
     Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'client-123')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123')
+        ->oAuth()
         ->refresh('old-refresh');
 
     Http::assertSent(fn ($request): bool => $request->url() === 'https://auth.test/token'
@@ -727,8 +727,8 @@ it('defaults the redirect uri to the package callback route for a registered cli
 
     $target = Client::web('https://mcp.test/mcp')
         ->setRegisteredName('github')
-        ->withOauth(clientId: 'client-123', scope: 'mcp:use')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123', scope: 'mcp:use')
+        ->oAuth()
         ->redirect()
         ->getTargetUrl();
 
@@ -745,8 +745,8 @@ it('lets an explicit redirect uri override the default callback route', function
 
     $target = Client::web('https://mcp.test/mcp')
         ->setRegisteredName('github')
-        ->withOauth(clientId: 'client-123', scope: 'mcp:use', redirectUri: 'https://app.test/custom')
-        ->oauth()
+        ->withOAuth(clientId: 'client-123', scope: 'mcp:use', redirectUri: 'https://app.test/custom')
+        ->oAuth()
         ->redirect()
         ->getTargetUrl();
 
@@ -781,8 +781,8 @@ it('surfaces the dynamically registered credentials on the token set', function 
     ]));
 
     $token = Client::web('https://mcp.test/mcp')
-        ->withOauth()
-        ->oauth()
+        ->withOAuth()
+        ->oAuth()
         ->callbackToken();
 
     expect($token->clientId)->toBe('dcr-999')
@@ -797,8 +797,8 @@ it('refreshes using explicitly passed client credentials', function (): void {
     ]);
 
     $token = Client::web('https://mcp.test/mcp')
-        ->withOauth(scope: 'mcp:use')
-        ->oauth()
+        ->withOAuth(scope: 'mcp:use')
+        ->oAuth()
         ->refresh('old-refresh', clientId: 'dcr-999', clientSecret: 'dcr-secret');
 
     expect($token->clientId)->toBe('dcr-999');
@@ -823,8 +823,8 @@ it('uses client_secret_basic when the server only supports it', function (): voi
     ]);
 
     Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'svc', clientSecret: 'secret', scope: 'mcp:use')
-        ->oauth()
+        ->withOAuth(clientId: 'svc', clientSecret: 'secret', scope: 'mcp:use')
+        ->oAuth()
         ->clientCredentialsToken();
 
     Http::assertSent(function ($request): bool {
@@ -844,8 +844,8 @@ it('honors an explicitly configured token endpoint auth method', function (): vo
     ]);
 
     Client::web('https://mcp.test/mcp')
-        ->withOauth(clientId: 'svc', clientSecret: 'secret', scope: 'mcp:use', tokenEndpointAuthMethod: 'client_secret_basic')
-        ->oauth()
+        ->withOAuth(clientId: 'svc', clientSecret: 'secret', scope: 'mcp:use', tokenEndpointAuthMethod: 'client_secret_basic')
+        ->oAuth()
         ->clientCredentialsToken();
 
     Http::assertSent(fn ($request): bool => ($request->header('Authorization')[0] ?? '') === 'Basic '.base64_encode('svc:secret'));

--- a/tests/Unit/Client/OAuth/OAuthClientTest.php
+++ b/tests/Unit/Client/OAuth/OAuthClientTest.php
@@ -1,0 +1,852 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Session;
+use Laravel\Mcp\Client;
+use Laravel\Mcp\Client\Exceptions\OAuthException;
+use Laravel\Mcp\Client\OAuth\OAuthClient;
+use Laravel\Mcp\Client\OAuth\TokenSet;
+
+function fakeDiscovery(): void
+{
+    Http::fake([
+        'https://mcp.test/.well-known/oauth-protected-resource/mcp' => Http::response([
+            'resource' => 'https://mcp.test/mcp',
+            'authorization_servers' => ['https://auth.test'],
+        ]),
+        'https://auth.test/.well-known/oauth-authorization-server' => Http::response([
+            'issuer' => 'https://auth.test',
+            'authorization_endpoint' => 'https://auth.test/authorize',
+            'token_endpoint' => 'https://auth.test/token',
+            'registration_endpoint' => 'https://auth.test/register',
+            'code_challenge_methods_supported' => ['S256'],
+        ]),
+    ]);
+}
+
+it('builds an authorization redirect with PKCE and stashes session state', function (): void {
+    fakeDiscovery();
+
+    $response = Client::web('https://mcp.test/mcp')
+        ->withOauth(
+            clientId: 'client-123',
+            scope: 'mcp:use',
+            redirectUri: 'https://app.test/callback',
+        )
+        ->oauth()
+        ->redirect('/dashboard');
+
+    $target = $response->getTargetUrl();
+    parse_str((string) parse_url($target, PHP_URL_QUERY), $query);
+
+    expect($target)->toStartWith('https://auth.test/authorize?')
+        ->and($query['response_type'])->toBe('code')
+        ->and($query['client_id'])->toBe('client-123')
+        ->and($query['redirect_uri'])->toBe('https://app.test/callback')
+        ->and($query['code_challenge_method'])->toBe('S256')
+        ->and($query['scope'])->toBe('mcp:use')
+        ->and($query['resource'])->toBe('https://mcp.test/mcp')
+        ->and($query)->toHaveKey('code_challenge')
+        ->and($query)->toHaveKey('state');
+
+    $stored = Session::get('mcp.oauth.'.sha1('https://mcp.test/mcp'));
+
+    expect($stored['state'])->toBe($query['state'])
+        ->and($stored['client_id'])->toBe('client-123')
+        ->and($stored['return_to'])->toBe('/dashboard')
+        ->and($stored['verifier'])->toBeString();
+});
+
+it('merges query params onto an authorization endpoint that already has a query string', function (): void {
+    Http::fake([
+        'https://mcp.test/.well-known/oauth-protected-resource/mcp' => Http::response([
+            'authorization_servers' => ['https://auth.test'],
+        ]),
+        'https://auth.test/.well-known/oauth-authorization-server' => Http::response([
+            'issuer' => 'https://auth.test',
+            'authorization_endpoint' => 'https://auth.test/authorize?audience=api',
+            'token_endpoint' => 'https://auth.test/token',
+        ]),
+    ]);
+
+    $target = Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oauth()
+        ->redirect()
+        ->getTargetUrl();
+
+    expect(substr_count($target, '?'))->toBe(1);
+
+    parse_str((string) parse_url($target, PHP_URL_QUERY), $query);
+
+    expect($query['audience'])->toBe('api')
+        ->and($query['response_type'])->toBe('code')
+        ->and($query['client_id'])->toBe('client-123');
+});
+
+it('dynamically registers a client when no client id is configured', function (): void {
+    fakeDiscovery();
+
+    Http::fake([
+        'https://auth.test/register' => Http::response(['client_id' => 'dcr-999', 'client_secret' => 'shh']),
+    ]);
+
+    Client::web('https://mcp.test/mcp')
+        ->withOauth(redirectUri: 'https://app.test/callback')
+        ->oauth()
+        ->redirect();
+
+    $stored = Session::get('mcp.oauth.'.sha1('https://mcp.test/mcp'));
+
+    expect($stored['client_id'])->toBe('dcr-999')
+        ->and($stored['client_secret'])->toBe('shh');
+
+    Http::assertSent(fn ($request): bool => $request->url() === 'https://auth.test/register'
+        && ($request['redirect_uris'] ?? null) === ['https://app.test/callback']);
+});
+
+it('exchanges an authorization code for a token set', function (): void {
+    fakeDiscovery();
+
+    Http::fake([
+        'https://auth.test/token' => Http::response([
+            'access_token' => 'access-token',
+            'refresh_token' => 'refresh-token',
+            'expires_in' => 3600,
+            'token_type' => 'Bearer',
+            'scope' => 'mcp:use',
+        ]),
+    ]);
+
+    $key = 'mcp.oauth.'.sha1('https://mcp.test/mcp');
+
+    Session::put($key, [
+        'state' => 'the-state',
+        'verifier' => 'the-verifier',
+        'client_id' => 'client-123',
+        'client_secret' => null,
+        'token_endpoint' => 'https://auth.test/token',
+        'redirect_uri' => 'https://app.test/callback',
+        'return_to' => null,
+    ]);
+
+    app()->instance('request', Request::create('https://app.test/callback', 'GET', [
+        'code' => 'auth-code',
+        'state' => 'the-state',
+    ]));
+
+    $token = Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'client-123')
+        ->oauth()
+        ->callbackToken();
+
+    expect($token)->toBeInstanceOf(TokenSet::class)
+        ->and($token->accessToken)->toBe('access-token')
+        ->and($token->refreshToken)->toBe('refresh-token')
+        ->and($token->expiresAt)->toBeGreaterThan(time());
+
+    expect(Session::has($key))->toBeFalse();
+
+    Http::assertSent(fn ($request): bool => $request->url() === 'https://auth.test/token'
+        && ($request['grant_type'] ?? null) === 'authorization_code'
+        && ($request['code'] ?? null) === 'auth-code'
+        && ($request['code_verifier'] ?? null) === 'the-verifier'
+        && ($request['resource'] ?? null) === 'https://mcp.test/mcp');
+});
+
+it('rejects a mismatched state parameter', function (): void {
+    fakeDiscovery();
+
+    $key = 'mcp.oauth.'.sha1('https://mcp.test/mcp');
+
+    Session::put($key, [
+        'state' => 'expected-state',
+        'verifier' => 'verifier',
+        'client_id' => 'client-123',
+        'client_secret' => null,
+        'token_endpoint' => 'https://auth.test/token',
+        'redirect_uri' => 'https://app.test/callback',
+        'return_to' => null,
+    ]);
+
+    app()->instance('request', Request::create('https://app.test/callback', 'GET', [
+        'code' => 'auth-code',
+        'state' => 'tampered-state',
+    ]));
+
+    expect(fn (): TokenSet => Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'client-123')
+        ->oauth()
+        ->callbackToken())
+        ->toThrow(OAuthException::class, 'state parameter did not match');
+});
+
+it('runs the client credentials grant', function (): void {
+    fakeDiscovery();
+
+    Http::fake([
+        'https://auth.test/token' => Http::response([
+            'access_token' => 'machine-token',
+            'expires_in' => 7200,
+        ]),
+    ]);
+
+    $token = Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'svc', clientSecret: 'secret', scope: 'mcp:use')
+        ->oauth()
+        ->clientCredentialsToken();
+
+    expect($token->accessToken)->toBe('machine-token');
+
+    Http::assertSent(fn ($request): bool => $request->url() === 'https://auth.test/token'
+        && ($request['grant_type'] ?? null) === 'client_credentials'
+        && ($request['client_id'] ?? null) === 'svc'
+        && ($request['client_secret'] ?? null) === 'secret');
+});
+
+it('throws when the authorization server redirects back with an error', function (): void {
+    app()->instance('request', Request::create('https://app.test/callback', 'GET', [
+        'error' => 'access_denied',
+        'error_description' => 'The user denied the request',
+    ]));
+
+    Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'client-123')
+        ->oauth()
+        ->callbackToken();
+})->throws(OAuthException::class, 'The authorization server returned an error [access_denied]: The user denied the request');
+
+it('throws when the authorization callback has no code', function (): void {
+    app()->instance('request', Request::create('https://app.test/callback', 'GET'));
+
+    Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'client-123')
+        ->oauth()
+        ->callbackToken();
+})->throws(OAuthException::class, 'The authorization response did not include an authorization code.');
+
+it('refreshes a token using the refresh grant', function (): void {
+    fakeDiscovery();
+
+    Http::fake([
+        'https://auth.test/token' => Http::response([
+            'access_token' => 'fresh-token',
+            'refresh_token' => 'new-refresh',
+            'expires_in' => 3600,
+        ]),
+    ]);
+
+    $token = Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'client-123', scope: 'mcp:use')
+        ->oauth()
+        ->refresh('old-refresh');
+
+    expect($token->accessToken)->toBe('fresh-token')
+        ->and($token->refreshToken)->toBe('new-refresh');
+
+    Http::assertSent(fn ($request): bool => ($request['grant_type'] ?? null) === 'refresh_token'
+        && ($request['refresh_token'] ?? null) === 'old-refresh'
+        && ($request['client_id'] ?? null) === 'client-123');
+});
+
+it('falls back to the resource origin when protected resource metadata is unavailable', function (): void {
+    Http::fake([
+        'https://mcp.test/.well-known/oauth-protected-resource/mcp' => Http::response('', 404),
+        'https://mcp.test/.well-known/oauth-authorization-server' => Http::response([
+            'issuer' => 'https://mcp.test',
+            'authorization_endpoint' => 'https://mcp.test/authorize',
+            'token_endpoint' => 'https://mcp.test/token',
+        ]),
+    ]);
+
+    $response = Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oauth()
+        ->redirect();
+
+    expect($response->getTargetUrl())->toStartWith('https://mcp.test/authorize?');
+});
+
+it('throws when the token request fails', function (): void {
+    fakeDiscovery();
+
+    Http::fake([
+        'https://auth.test/token' => Http::response(['error' => 'invalid_grant'], 400),
+    ]);
+
+    expect(fn (): TokenSet => Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'client-123', scope: 'mcp:use')
+        ->oauth()
+        ->refresh('bad-token'))
+        ->toThrow(OAuthException::class, 'failed with status [400]');
+});
+
+it('throws when the authorization server metadata cannot be discovered', function (): void {
+    Http::fake([
+        'https://mcp.test/.well-known/oauth-protected-resource/mcp' => Http::response([
+            'authorization_servers' => ['https://auth.test'],
+        ]),
+        'https://auth.test/.well-known/oauth-authorization-server' => Http::response('', 500),
+        'https://auth.test/.well-known/openid-configuration' => Http::response('', 500),
+    ]);
+
+    expect(fn (): TokenSet => Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'client-123', clientSecret: 'secret')
+        ->oauth()
+        ->clientCredentialsToken())
+        ->toThrow(OAuthException::class, 'Unable to discover authorization server metadata');
+});
+
+it('throws when dynamic registration is needed but unsupported', function (): void {
+    Http::fake([
+        'https://mcp.test/.well-known/oauth-protected-resource/mcp' => Http::response([
+            'authorization_servers' => ['https://auth.test'],
+        ]),
+        'https://auth.test/.well-known/oauth-authorization-server' => Http::response([
+            'issuer' => 'https://auth.test',
+            'authorization_endpoint' => 'https://auth.test/authorize',
+            'token_endpoint' => 'https://auth.test/token',
+        ]),
+    ]);
+
+    expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
+        ->withOauth(redirectUri: 'https://app.test/callback')
+        ->oauth()
+        ->redirect())
+        ->toThrow(OAuthException::class, 'does not support dynamic client registration');
+});
+
+it('throws when oauth is used without configuration', function (): void {
+    expect(fn (): OAuthClient => Client::web('https://mcp.test/mcp')->oauth())
+        ->toThrow(OAuthException::class, 'No OAuth configuration');
+});
+
+it('requires a redirect uri before redirecting', function (): void {
+    fakeDiscovery();
+
+    expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'client-123')
+        ->oauth()
+        ->redirect())
+        ->toThrow(OAuthException::class, 'redirect URI is required');
+});
+
+it('uses the server advertised resource metadata url when provided', function (): void {
+    Http::fake([
+        'https://mcp.test/.well-known/custom-resource' => Http::response([
+            'authorization_servers' => ['https://auth.test'],
+        ]),
+        'https://auth.test/.well-known/oauth-authorization-server' => Http::response([
+            'issuer' => 'https://auth.test',
+            'authorization_endpoint' => 'https://auth.test/authorize',
+            'token_endpoint' => 'https://auth.test/token',
+        ]),
+    ]);
+
+    $target = Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oauth('https://mcp.test/.well-known/custom-resource')
+        ->redirect()
+        ->getTargetUrl();
+
+    expect($target)->toStartWith('https://auth.test/authorize?');
+
+    Http::assertSent(fn ($request): bool => $request->url() === 'https://mcp.test/.well-known/custom-resource');
+});
+
+it('rejects an authorization server whose issuer does not match', function (): void {
+    Http::fake([
+        'https://mcp.test/.well-known/oauth-protected-resource/mcp' => Http::response([
+            'authorization_servers' => ['https://auth.test'],
+        ]),
+        'https://auth.test/.well-known/oauth-authorization-server' => Http::response([
+            'issuer' => 'https://evil.test',
+            'authorization_endpoint' => 'https://auth.test/authorize',
+            'token_endpoint' => 'https://auth.test/token',
+        ]),
+    ]);
+
+    expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oauth()
+        ->redirect())
+        ->toThrow(OAuthException::class, 'did not match the expected issuer');
+});
+
+it('rejects protected resource metadata whose resource does not match', function (): void {
+    Http::fake([
+        'https://mcp.test/.well-known/oauth-protected-resource/mcp' => Http::response([
+            'resource' => 'https://other.test/mcp',
+            'authorization_servers' => ['https://auth.test'],
+        ]),
+    ]);
+
+    expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oauth()
+        ->redirect())
+        ->toThrow(OAuthException::class, 'did not match the expected resource');
+});
+
+it('rejects authorization server metadata that omits the issuer', function (): void {
+    Http::fake([
+        'https://mcp.test/.well-known/oauth-protected-resource/mcp' => Http::response([
+            'authorization_servers' => ['https://auth.test'],
+        ]),
+        'https://auth.test/.well-known/oauth-authorization-server' => Http::response([
+            'authorization_endpoint' => 'https://auth.test/authorize',
+            'token_endpoint' => 'https://auth.test/token',
+        ]),
+    ]);
+
+    expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oauth()
+        ->redirect())
+        ->toThrow(OAuthException::class, 'did not match the expected issuer');
+});
+
+it('rejects an authorization server that does not advertise the S256 PKCE method', function (): void {
+    Http::fake([
+        'https://mcp.test/.well-known/oauth-protected-resource/mcp' => Http::response([
+            'authorization_servers' => ['https://auth.test'],
+        ]),
+        'https://auth.test/.well-known/oauth-authorization-server' => Http::response([
+            'issuer' => 'https://auth.test',
+            'authorization_endpoint' => 'https://auth.test/authorize',
+            'token_endpoint' => 'https://auth.test/token',
+            'code_challenge_methods_supported' => ['plain'],
+        ]),
+    ]);
+
+    expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oauth()
+        ->redirect())
+        ->toThrow(OAuthException::class, 'does not support the required S256');
+});
+
+it('rejects an authorization server served over plain http', function (): void {
+    Http::fake([
+        'https://mcp.test/.well-known/oauth-protected-resource/mcp' => Http::response([
+            'authorization_servers' => ['http://auth.test'],
+        ]),
+    ]);
+
+    expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oauth()
+        ->redirect())
+        ->toThrow(OAuthException::class, 'must be served over HTTPS');
+});
+
+it('falls back to openid connect discovery when oauth metadata is absent', function (): void {
+    Http::fake([
+        'https://mcp.test/.well-known/oauth-protected-resource/mcp' => Http::response([
+            'authorization_servers' => ['https://auth.test'],
+        ]),
+        'https://auth.test/.well-known/oauth-authorization-server' => Http::response('', 404),
+        'https://auth.test/.well-known/openid-configuration' => Http::response([
+            'issuer' => 'https://auth.test',
+            'authorization_endpoint' => 'https://auth.test/authorize',
+            'token_endpoint' => 'https://auth.test/token',
+        ]),
+    ]);
+
+    $target = Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oauth()
+        ->redirect()
+        ->getTargetUrl();
+
+    expect($target)->toStartWith('https://auth.test/authorize?');
+});
+
+it('validates a matching iss parameter on the authorization callback', function (): void {
+    fakeDiscovery();
+
+    Http::fake([
+        'https://auth.test/token' => Http::response(['access_token' => 'access-token']),
+    ]);
+
+    $key = 'mcp.oauth.'.sha1('https://mcp.test/mcp');
+
+    Session::put($key, [
+        'state' => 'the-state',
+        'verifier' => 'the-verifier',
+        'client_id' => 'client-123',
+        'client_secret' => null,
+        'token_endpoint' => 'https://auth.test/token',
+        'redirect_uri' => 'https://app.test/callback',
+        'return_to' => null,
+        'issuer' => 'https://auth.test',
+        'iss_supported' => true,
+    ]);
+
+    app()->instance('request', Request::create('https://app.test/callback', 'GET', [
+        'code' => 'auth-code',
+        'state' => 'the-state',
+        'iss' => 'https://auth.test',
+    ]));
+
+    $token = Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'client-123')
+        ->oauth()
+        ->callbackToken();
+
+    expect($token->accessToken)->toBe('access-token');
+});
+
+it('rejects a mismatched iss parameter on the authorization callback', function (): void {
+    fakeDiscovery();
+
+    $key = 'mcp.oauth.'.sha1('https://mcp.test/mcp');
+
+    Session::put($key, [
+        'state' => 'the-state',
+        'verifier' => 'the-verifier',
+        'client_id' => 'client-123',
+        'client_secret' => null,
+        'token_endpoint' => 'https://auth.test/token',
+        'redirect_uri' => 'https://app.test/callback',
+        'return_to' => null,
+        'issuer' => 'https://auth.test',
+        'iss_supported' => true,
+    ]);
+
+    app()->instance('request', Request::create('https://app.test/callback', 'GET', [
+        'code' => 'auth-code',
+        'state' => 'the-state',
+        'iss' => 'https://evil.test',
+    ]));
+
+    expect(fn (): TokenSet => Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'client-123')
+        ->oauth()
+        ->callbackToken())
+        ->toThrow(OAuthException::class, 'iss) parameter did not match');
+});
+
+it('rejects a missing iss parameter when the server advertises support', function (): void {
+    fakeDiscovery();
+
+    $key = 'mcp.oauth.'.sha1('https://mcp.test/mcp');
+
+    Session::put($key, [
+        'state' => 'the-state',
+        'verifier' => 'the-verifier',
+        'client_id' => 'client-123',
+        'client_secret' => null,
+        'token_endpoint' => 'https://auth.test/token',
+        'redirect_uri' => 'https://app.test/callback',
+        'return_to' => null,
+        'issuer' => 'https://auth.test',
+        'iss_supported' => true,
+    ]);
+
+    app()->instance('request', Request::create('https://app.test/callback', 'GET', [
+        'code' => 'auth-code',
+        'state' => 'the-state',
+    ]));
+
+    expect(fn (): TokenSet => Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'client-123')
+        ->oauth()
+        ->callbackToken())
+        ->toThrow(OAuthException::class, 'missing the required iss parameter');
+});
+
+it('records the issuer in the session for callback validation', function (): void {
+    Http::fake([
+        'https://mcp.test/.well-known/oauth-protected-resource/mcp' => Http::response([
+            'authorization_servers' => ['https://auth.test'],
+        ]),
+        'https://auth.test/.well-known/oauth-authorization-server' => Http::response([
+            'issuer' => 'https://auth.test',
+            'authorization_endpoint' => 'https://auth.test/authorize',
+            'token_endpoint' => 'https://auth.test/token',
+            'authorization_response_iss_parameter_supported' => true,
+        ]),
+    ]);
+
+    Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oauth()
+        ->redirect();
+
+    $stored = Session::get('mcp.oauth.'.sha1('https://mcp.test/mcp'));
+
+    expect($stored['issuer'])->toBe('https://auth.test')
+        ->and($stored['iss_supported'])->toBeTrue();
+});
+
+it('defaults the scope to mcp:use', function (): void {
+    fakeDiscovery();
+
+    $target = Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oauth()
+        ->redirect()
+        ->getTargetUrl();
+
+    parse_str((string) parse_url($target, PHP_URL_QUERY), $query);
+
+    expect($query['scope'])->toBe('mcp:use');
+});
+
+it('falls back to scopes_supported from the protected resource metadata', function (): void {
+    Http::fake([
+        'https://mcp.test/.well-known/oauth-protected-resource/mcp' => Http::response([
+            'authorization_servers' => ['https://auth.test'],
+            'scopes_supported' => ['mcp:read', 'mcp:write'],
+        ]),
+        'https://auth.test/.well-known/oauth-authorization-server' => Http::response([
+            'issuer' => 'https://auth.test',
+            'authorization_endpoint' => 'https://auth.test/authorize',
+            'token_endpoint' => 'https://auth.test/token',
+        ]),
+    ]);
+
+    $target = Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'client-123', scope: null, redirectUri: 'https://app.test/callback')
+        ->oauth()
+        ->redirect()
+        ->getTargetUrl();
+
+    parse_str((string) parse_url($target, PHP_URL_QUERY), $query);
+
+    expect($query['scope'])->toBe('mcp:read mcp:write');
+});
+
+it('prefers the challenge scope over scopes_supported', function (): void {
+    Http::fake([
+        'https://mcp.test/.well-known/oauth-protected-resource/mcp' => Http::response([
+            'authorization_servers' => ['https://auth.test'],
+            'scopes_supported' => ['mcp:read'],
+        ]),
+        'https://auth.test/.well-known/oauth-authorization-server' => Http::response([
+            'issuer' => 'https://auth.test',
+            'authorization_endpoint' => 'https://auth.test/authorize',
+            'token_endpoint' => 'https://auth.test/token',
+        ]),
+    ]);
+
+    $target = Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'client-123', scope: null, redirectUri: 'https://app.test/callback')
+        ->oauth(challengeScope: 'files:read files:write')
+        ->redirect()
+        ->getTargetUrl();
+
+    parse_str((string) parse_url($target, PHP_URL_QUERY), $query);
+
+    expect($query['scope'])->toBe('files:read files:write');
+});
+
+it('sends a native application_type when registering a localhost client', function (): void {
+    fakeDiscovery();
+
+    Http::fake([
+        'https://auth.test/register' => Http::response(['client_id' => 'dcr-1']),
+    ]);
+
+    Client::web('https://mcp.test/mcp')
+        ->withOauth(redirectUri: 'http://localhost:3000/callback')
+        ->oauth()
+        ->redirect();
+
+    Http::assertSent(fn ($request): bool => $request->url() === 'https://auth.test/register'
+        && ($request['application_type'] ?? null) === 'native');
+});
+
+it('sends a web application_type when registering a remote client', function (): void {
+    fakeDiscovery();
+
+    Http::fake([
+        'https://auth.test/register' => Http::response(['client_id' => 'dcr-1']),
+    ]);
+
+    Client::web('https://mcp.test/mcp')
+        ->withOauth(redirectUri: 'https://app.test/callback')
+        ->oauth()
+        ->redirect();
+
+    Http::assertSent(fn ($request): bool => $request->url() === 'https://auth.test/register'
+        && ($request['application_type'] ?? null) === 'web');
+});
+
+it('normalizes the resource to its canonical form without a trailing slash', function (): void {
+    Http::fake([
+        'https://mcp.test/.well-known/oauth-protected-resource/mcp' => Http::response([
+            'authorization_servers' => ['https://auth.test'],
+        ]),
+        'https://auth.test/.well-known/oauth-authorization-server' => Http::response([
+            'issuer' => 'https://auth.test',
+            'authorization_endpoint' => 'https://auth.test/authorize',
+            'token_endpoint' => 'https://auth.test/token',
+        ]),
+    ]);
+
+    $target = Client::web('https://mcp.test/mcp/#fragment')
+        ->withOauth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oauth()
+        ->redirect()
+        ->getTargetUrl();
+
+    parse_str((string) parse_url($target, PHP_URL_QUERY), $query);
+
+    expect($query['resource'])->toBe('https://mcp.test/mcp');
+});
+
+it('includes the resource parameter on a refresh token request', function (): void {
+    fakeDiscovery();
+
+    Http::fake([
+        'https://auth.test/token' => Http::response(['access_token' => 'fresh-token']),
+    ]);
+
+    Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'client-123')
+        ->oauth()
+        ->refresh('old-refresh');
+
+    Http::assertSent(fn ($request): bool => $request->url() === 'https://auth.test/token'
+        && ($request['grant_type'] ?? null) === 'refresh_token'
+        && ($request['resource'] ?? null) === 'https://mcp.test/mcp');
+});
+
+it('defaults the redirect uri to the package callback route for a registered client', function (): void {
+    fakeDiscovery();
+
+    Route::get('mcp/oauth/github/callback', fn (): string => '')
+        ->name('mcp.oauth.github.callback');
+
+    $target = Client::web('https://mcp.test/mcp')
+        ->setRegisteredName('github')
+        ->withOauth(clientId: 'client-123', scope: 'mcp:use')
+        ->oauth()
+        ->redirect()
+        ->getTargetUrl();
+
+    parse_str((string) parse_url($target, PHP_URL_QUERY), $query);
+
+    expect($query['redirect_uri'])->toBe(url('mcp/oauth/github/callback'));
+});
+
+it('lets an explicit redirect uri override the default callback route', function (): void {
+    fakeDiscovery();
+
+    Route::get('mcp/oauth/github/callback', fn (): string => '')
+        ->name('mcp.oauth.github.callback');
+
+    $target = Client::web('https://mcp.test/mcp')
+        ->setRegisteredName('github')
+        ->withOauth(clientId: 'client-123', scope: 'mcp:use', redirectUri: 'https://app.test/custom')
+        ->oauth()
+        ->redirect()
+        ->getTargetUrl();
+
+    parse_str((string) parse_url($target, PHP_URL_QUERY), $query);
+
+    expect($query['redirect_uri'])->toBe('https://app.test/custom');
+});
+
+it('surfaces the dynamically registered credentials on the token set', function (): void {
+    fakeDiscovery();
+
+    Http::fake([
+        'https://auth.test/token' => Http::response(['access_token' => 'access-token', 'refresh_token' => 'refresh-token']),
+    ]);
+
+    $key = 'mcp.oauth.'.sha1('https://mcp.test/mcp');
+
+    Session::put($key, [
+        'state' => 'the-state',
+        'verifier' => 'the-verifier',
+        'client_id' => 'dcr-999',
+        'client_secret' => 'dcr-secret',
+        'token_endpoint' => 'https://auth.test/token',
+        'token_auth_method' => 'client_secret_post',
+        'redirect_uri' => 'https://app.test/callback',
+        'return_to' => null,
+    ]);
+
+    app()->instance('request', Request::create('https://app.test/callback', 'GET', [
+        'code' => 'auth-code',
+        'state' => 'the-state',
+    ]));
+
+    $token = Client::web('https://mcp.test/mcp')
+        ->withOauth()
+        ->oauth()
+        ->callbackToken();
+
+    expect($token->clientId)->toBe('dcr-999')
+        ->and($token->clientSecret)->toBe('dcr-secret');
+});
+
+it('refreshes using explicitly passed client credentials', function (): void {
+    fakeDiscovery();
+
+    Http::fake([
+        'https://auth.test/token' => Http::response(['access_token' => 'fresh-token']),
+    ]);
+
+    $token = Client::web('https://mcp.test/mcp')
+        ->withOauth(scope: 'mcp:use')
+        ->oauth()
+        ->refresh('old-refresh', clientId: 'dcr-999', clientSecret: 'dcr-secret');
+
+    expect($token->clientId)->toBe('dcr-999');
+
+    Http::assertSent(fn ($request): bool => ($request['grant_type'] ?? null) === 'refresh_token'
+        && ($request['client_id'] ?? null) === 'dcr-999'
+        && ($request['client_secret'] ?? null) === 'dcr-secret');
+});
+
+it('uses client_secret_basic when the server only supports it', function (): void {
+    Http::fake([
+        'https://mcp.test/.well-known/oauth-protected-resource/mcp' => Http::response([
+            'authorization_servers' => ['https://auth.test'],
+        ]),
+        'https://auth.test/.well-known/oauth-authorization-server' => Http::response([
+            'issuer' => 'https://auth.test',
+            'authorization_endpoint' => 'https://auth.test/authorize',
+            'token_endpoint' => 'https://auth.test/token',
+            'token_endpoint_auth_methods_supported' => ['client_secret_basic'],
+        ]),
+        'https://auth.test/token' => Http::response(['access_token' => 'machine-token']),
+    ]);
+
+    Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'svc', clientSecret: 'secret', scope: 'mcp:use')
+        ->oauth()
+        ->clientCredentialsToken();
+
+    Http::assertSent(function ($request): bool {
+        $authorization = $request->header('Authorization')[0] ?? '';
+
+        return $request->url() === 'https://auth.test/token'
+            && $authorization === 'Basic '.base64_encode('svc:secret')
+            && ! array_key_exists('client_secret', $request->data());
+    });
+});
+
+it('honors an explicitly configured token endpoint auth method', function (): void {
+    fakeDiscovery();
+
+    Http::fake([
+        'https://auth.test/token' => Http::response(['access_token' => 'machine-token']),
+    ]);
+
+    Client::web('https://mcp.test/mcp')
+        ->withOauth(clientId: 'svc', clientSecret: 'secret', scope: 'mcp:use', tokenEndpointAuthMethod: 'client_secret_basic')
+        ->oauth()
+        ->clientCredentialsToken();
+
+    Http::assertSent(fn ($request): bool => ($request->header('Authorization')[0] ?? '') === 'Basic '.base64_encode('svc:secret'));
+});

--- a/tests/Unit/Client/OAuth/OAuthClientTest.php
+++ b/tests/Unit/Client/OAuth/OAuthClientTest.php
@@ -750,6 +750,52 @@ it('strips fragments but preserves trailing slashes in the resource identifier',
     expect($query['resource'])->toBe('https://mcp.test/mcp/');
 });
 
+it('strips the fragment but preserves the query string in the resource identifier', function (): void {
+    Http::fake([
+        'https://mcp.test/.well-known/oauth-protected-resource/mcp' => Http::response([
+            'authorization_servers' => ['https://auth.test'],
+        ]),
+        'https://auth.test/.well-known/oauth-authorization-server' => Http::response([
+            'issuer' => 'https://auth.test',
+            'authorization_endpoint' => 'https://auth.test/authorize',
+            'token_endpoint' => 'https://auth.test/token',
+        ]),
+    ]);
+
+    $target = Client::web('https://mcp.test/mcp?tenant=acme#section')
+        ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oAuthClient()
+        ->redirect()
+        ->getTargetUrl();
+
+    parse_str((string) parse_url($target, PHP_URL_QUERY), $query);
+
+    expect($query['resource'])->toBe('https://mcp.test/mcp?tenant=acme');
+});
+
+it('leaves a resource identifier without a fragment unchanged', function (): void {
+    Http::fake([
+        'https://mcp.test/.well-known/oauth-protected-resource/mcp' => Http::response([
+            'authorization_servers' => ['https://auth.test'],
+        ]),
+        'https://auth.test/.well-known/oauth-authorization-server' => Http::response([
+            'issuer' => 'https://auth.test',
+            'authorization_endpoint' => 'https://auth.test/authorize',
+            'token_endpoint' => 'https://auth.test/token',
+        ]),
+    ]);
+
+    $target = Client::web('https://mcp.test/mcp')
+        ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oAuthClient()
+        ->redirect()
+        ->getTargetUrl();
+
+    parse_str((string) parse_url($target, PHP_URL_QUERY), $query);
+
+    expect($query['resource'])->toBe('https://mcp.test/mcp');
+});
+
 it('rejects protected resource metadata when a trailing slash differs', function (): void {
     Http::fake([
         'https://mcp.test/.well-known/oauth-protected-resource/mcp/' => Http::response([

--- a/tests/Unit/Client/OAuth/OAuthClientTest.php
+++ b/tests/Unit/Client/OAuth/OAuthClientTest.php
@@ -144,7 +144,7 @@ it('exchanges an authorization code for a token set', function (): void {
     $token = Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123')
         ->oAuth()
-        ->token();
+        ->exchangeCallback();
 
     expect($token)->toBeInstanceOf(TokenSet::class)
         ->and($token->accessToken)->toBe('access-token')
@@ -183,7 +183,7 @@ it('rejects a mismatched state parameter', function (): void {
     expect(fn (): TokenSet => Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123')
         ->oAuth()
-        ->token())
+        ->exchangeCallback())
         ->toThrow(OAuthException::class, 'state parameter did not match');
 });
 
@@ -200,7 +200,7 @@ it('runs the client credentials grant', function (): void {
     $token = Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'svc', clientSecret: 'secret', scope: 'mcp:use')
         ->oAuth()
-        ->token();
+        ->clientCredentials();
 
     expect($token->accessToken)->toBe('machine-token');
 
@@ -219,30 +219,17 @@ it('throws when the authorization server redirects back with an error', function
     Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123')
         ->oAuth()
-        ->token();
+        ->exchangeCallback();
 })->throws(OAuthException::class, 'The authorization server returned an error [access_denied]: The user denied the request');
 
-it('falls back to the client credentials grant when no authorization code is present', function (): void {
-    fakeDiscovery();
-
-    Http::fake([
-        'https://auth.test/token' => Http::response([
-            'access_token' => 'machine-token',
-            'expires_in' => 7200,
-        ]),
-    ]);
-
+it('requires an authorization code when exchanging a callback', function (): void {
     app()->instance('request', Request::create('https://app.test/callback', 'GET'));
 
-    $token = Client::web('https://mcp.test/mcp')
+    expect(fn (): TokenSet => Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'svc', clientSecret: 'secret', scope: 'mcp:use')
         ->oAuth()
-        ->token();
-
-    expect($token->accessToken)->toBe('machine-token');
-
-    Http::assertSent(fn ($request): bool => $request->url() === 'https://auth.test/token'
-        && ($request->data()['grant_type'] ?? null) === 'client_credentials');
+        ->exchangeCallback())
+        ->toThrow(OAuthException::class, 'did not include an authorization code');
 });
 
 it('refreshes a token using the refresh grant', function (): void {
@@ -313,7 +300,7 @@ it('throws when the authorization server metadata cannot be discovered', functio
     expect(fn (): TokenSet => Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123', clientSecret: 'secret')
         ->oAuth()
-        ->token())
+        ->clientCredentials())
         ->toThrow(OAuthException::class, 'Unable to discover authorization server metadata');
 });
 
@@ -372,6 +359,22 @@ it('uses the server advertised resource metadata url when provided', function ()
     expect($target)->toStartWith('https://auth.test/authorize?');
 
     Http::assertSent(fn ($request): bool => $request->url() === 'https://mcp.test/.well-known/custom-resource');
+});
+
+it('rejects protected resource metadata urls on internal hosts', function (): void {
+    expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
+        ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oAuth('https://127.0.0.1/.well-known/oauth-protected-resource')
+        ->redirect())
+        ->toThrow(OAuthException::class, 'private or internal host');
+});
+
+it('rejects protected resource metadata urls served over plain http', function (): void {
+    expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp')
+        ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oAuth('http://mcp.test/.well-known/oauth-protected-resource')
+        ->redirect())
+        ->toThrow(OAuthException::class, 'must be served over HTTPS');
 });
 
 it('rejects an authorization server whose issuer does not match', function (): void {
@@ -512,7 +515,7 @@ it('validates a matching iss parameter on the authorization callback', function 
     $token = Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123')
         ->oAuth()
-        ->token();
+        ->exchangeCallback();
 
     expect($token->accessToken)->toBe('access-token');
 });
@@ -543,7 +546,7 @@ it('rejects a mismatched iss parameter on the authorization callback', function 
     expect(fn (): TokenSet => Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123')
         ->oAuth()
-        ->token())
+        ->exchangeCallback())
         ->toThrow(OAuthException::class, 'iss) parameter did not match');
 });
 
@@ -572,7 +575,7 @@ it('rejects a missing iss parameter when the server advertises support', functio
     expect(fn (): TokenSet => Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'client-123')
         ->oAuth()
-        ->token())
+        ->exchangeCallback())
         ->toThrow(OAuthException::class, 'missing the required iss parameter');
 });
 
@@ -614,7 +617,7 @@ it('defaults the scope to mcp:use', function (): void {
     expect($query['scope'])->toBe('mcp:use');
 });
 
-it('falls back to scopes_supported from the protected resource metadata', function (): void {
+it('does not request every supported scope from protected resource metadata', function (): void {
     Http::fake([
         'https://mcp.test/.well-known/oauth-protected-resource/mcp' => Http::response([
             'authorization_servers' => ['https://auth.test'],
@@ -628,17 +631,17 @@ it('falls back to scopes_supported from the protected resource metadata', functi
     ]);
 
     $target = Client::web('https://mcp.test/mcp')
-        ->withOAuth(clientId: 'client-123', scope: null, redirectUri: 'https://app.test/callback')
+        ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
         ->oAuth()
         ->redirect()
         ->getTargetUrl();
 
     parse_str((string) parse_url($target, PHP_URL_QUERY), $query);
 
-    expect($query['scope'])->toBe('mcp:read mcp:write');
+    expect($query['scope'])->toBe('mcp:use');
 });
 
-it('prefers the challenge scope over scopes_supported', function (): void {
+it('prefers the challenge scope over the configured scope', function (): void {
     Http::fake([
         'https://mcp.test/.well-known/oauth-protected-resource/mcp' => Http::response([
             'authorization_servers' => ['https://auth.test'],
@@ -652,7 +655,7 @@ it('prefers the challenge scope over scopes_supported', function (): void {
     ]);
 
     $target = Client::web('https://mcp.test/mcp')
-        ->withOAuth(clientId: 'client-123', scope: null, redirectUri: 'https://app.test/callback')
+        ->withOAuth(clientId: 'client-123', scope: 'mcp:use', redirectUri: 'https://app.test/callback')
         ->oAuth(challengeScope: 'files:read files:write')
         ->redirect()
         ->getTargetUrl();
@@ -694,9 +697,9 @@ it('sends a web application_type when registering a remote client', function ():
         && ($request['application_type'] ?? null) === 'web');
 });
 
-it('normalizes the resource to its canonical form without a trailing slash', function (): void {
+it('strips fragments but preserves trailing slashes in the resource identifier', function (): void {
     Http::fake([
-        'https://mcp.test/.well-known/oauth-protected-resource/mcp' => Http::response([
+        'https://mcp.test/.well-known/oauth-protected-resource/mcp/' => Http::response([
             'authorization_servers' => ['https://auth.test'],
         ]),
         'https://auth.test/.well-known/oauth-authorization-server' => Http::response([
@@ -714,7 +717,22 @@ it('normalizes the resource to its canonical form without a trailing slash', fun
 
     parse_str((string) parse_url($target, PHP_URL_QUERY), $query);
 
-    expect($query['resource'])->toBe('https://mcp.test/mcp');
+    expect($query['resource'])->toBe('https://mcp.test/mcp/');
+});
+
+it('rejects protected resource metadata when a trailing slash differs', function (): void {
+    Http::fake([
+        'https://mcp.test/.well-known/oauth-protected-resource/mcp/' => Http::response([
+            'resource' => 'https://mcp.test/mcp',
+            'authorization_servers' => ['https://auth.test'],
+        ]),
+    ]);
+
+    expect(fn (): RedirectResponse => Client::web('https://mcp.test/mcp/')
+        ->withOAuth(clientId: 'client-123', redirectUri: 'https://app.test/callback')
+        ->oAuth()
+        ->redirect())
+        ->toThrow(OAuthException::class, 'did not match the expected resource [https://mcp.test/mcp/]');
 });
 
 it('includes the resource parameter on a refresh token request', function (): void {
@@ -798,7 +816,7 @@ it('surfaces the dynamically registered credentials on the token set', function 
     $token = Client::web('https://mcp.test/mcp')
         ->withOAuth()
         ->oAuth()
-        ->token();
+        ->exchangeCallback();
 
     expect($token->clientId)->toBe('dcr-999')
         ->and($token->clientSecret)->toBe('dcr-secret');
@@ -840,7 +858,7 @@ it('uses client_secret_basic when the server only supports it', function (): voi
     Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'svc', clientSecret: 'secret', scope: 'mcp:use')
         ->oAuth()
-        ->token();
+        ->clientCredentials();
 
     Http::assertSent(function ($request): bool {
         $authorization = $request->header('Authorization')[0] ?? '';
@@ -861,7 +879,7 @@ it('honors an explicitly configured token endpoint auth method', function (): vo
     Client::web('https://mcp.test/mcp')
         ->withOAuth(clientId: 'svc', clientSecret: 'secret', scope: 'mcp:use', tokenEndpointAuthMethod: TokenEndpointAuthMethod::ClientSecretBasic)
         ->oAuth()
-        ->token();
+        ->clientCredentials();
 
     Http::assertSent(fn ($request): bool => ($request->header('Authorization')[0] ?? '') === 'Basic '.base64_encode('svc:secret'));
 });

--- a/tests/Unit/Client/OAuth/OAuthTransportTest.php
+++ b/tests/Unit/Client/OAuth/OAuthTransportTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Http;
 use Laravel\Mcp\Client\Exceptions\AuthorizationRequiredException;
+use Laravel\Mcp\Client\OAuth\WwwAuthenticateChallenge;
 use Laravel\Mcp\Client\Transport\HttpTransport;
 
 it('resolves a closure token at request time', function (): void {
@@ -51,6 +52,14 @@ it('throws AuthorizationRequiredException on a 403', function (): void {
 
     expect(fn () => $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'tools/list', 'params' => []])))
         ->toThrow(AuthorizationRequiredException::class);
+});
+
+it('parses mixed www authenticate challenges with quoted commas and unquoted values', function (): void {
+    $challenge = WwwAuthenticateChallenge::parse('Basic realm="api", Bearer resource_metadata="https://mcp.test/.well-known/oauth-protected-resource/a,b", scope=files:read, error_description="needs access"');
+
+    expect($challenge->resourceMetadataUrl)->toBe('https://mcp.test/.well-known/oauth-protected-resource/a,b')
+        ->and($challenge->scope)->toBe('files:read')
+        ->and($challenge->errorDescription)->toBe('needs access');
 });
 
 it('exposes the configured endpoint url', function (): void {

--- a/tests/Unit/Client/OAuth/OAuthTransportTest.php
+++ b/tests/Unit/Client/OAuth/OAuthTransportTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Laravel\Mcp\Client\Exceptions\AuthorizationRequiredException;
+use Laravel\Mcp\Client\Transport\HttpTransport;
+
+it('resolves a closure token at request time', function (): void {
+    Http::fake([
+        'https://mcp.test/mcp' => Http::response(
+            json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => ['ok' => true]]),
+            200,
+            ['Content-Type' => 'application/json'],
+        ),
+    ]);
+
+    $transport = new HttpTransport('https://mcp.test/mcp');
+    $transport->withToken(fn (): string => 'dynamic-token');
+    $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'ping', 'params' => []]));
+
+    Http::assertSent(fn ($request): bool => $request->hasHeader('Authorization', 'Bearer dynamic-token'));
+});
+
+it('throws AuthorizationRequiredException on a 401 with a challenge', function (): void {
+    Http::fake([
+        'https://mcp.test/mcp' => Http::response('', 401, [
+            'WWW-Authenticate' => 'Bearer error="invalid_token", resource_metadata="https://mcp.test/.well-known/oauth-protected-resource/mcp", scope="files:read"',
+        ]),
+    ]);
+
+    $transport = new HttpTransport('https://mcp.test/mcp');
+
+    try {
+        $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'tools/list', 'params' => []]));
+        $this->fail('Expected AuthorizationRequiredException.');
+    } catch (AuthorizationRequiredException $authorizationRequiredException) {
+        expect($authorizationRequiredException->resourceMetadataUrl())
+            ->toBe('https://mcp.test/.well-known/oauth-protected-resource/mcp')
+            ->and($authorizationRequiredException->challenge?->error)->toBe('invalid_token')
+            ->and($authorizationRequiredException->scope())->toBe('files:read');
+    }
+});
+
+it('throws AuthorizationRequiredException on a 403', function (): void {
+    Http::fake([
+        'https://mcp.test/mcp' => Http::response('', 403),
+    ]);
+
+    $transport = new HttpTransport('https://mcp.test/mcp');
+
+    expect(fn () => $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'tools/list', 'params' => []])))
+        ->toThrow(AuthorizationRequiredException::class);
+});
+
+it('exposes the configured endpoint url', function (): void {
+    expect((new HttpTransport('https://mcp.test/mcp'))->url())->toBe('https://mcp.test/mcp');
+});


### PR DESCRIPTION
This PR adds [OAuth authentication](https://modelcontextprotocol.io/specification/draft/basic/authorization) to the MCP web client, so your application can connect to remote MCP servers that sit behind OAuth (GitHub, Notion, your own internal servers, and so on).

The package takes care of the OAuth handshake for you. It handles discovery, PKCE, the `state` and `iss` checks, the authorization code exchange, dynamic client registration, and the refresh and client credentials grants. At the end it hands you back a `TokenSet`. Your application decides where to store that token, and passes it back on each call with `withToken()`.

You stay in control of your routes and your storage. The package never stores the token for you.

## Getting started

First register your client. This usually lives in a service provider, for example `app/Providers/AppServiceProvider.php`:

```php
use Laravel\Mcp\Client;
use Laravel\Mcp\Facades\Mcp;

Mcp::registerClient('github', fn () =>
    Client::web('https://api.githubcopilot.com/mcp')->withOAuth()
);
```

## Connecting a user (Dynamic Client Registration)

This is the most common flow. A user clicks "Connect", gets redirected to the provider to approve access, and comes back to your app with a token. When you leave out the `clientId` and `clientSecret`, the package registers a client on the fly using Dynamic Client Registration.

Register the routes in `routes/web.php`. A single call wires up both the connect route and the callback route for you:

```php
use Laravel\Mcp\Facades\Mcp;
use Laravel\Mcp\Client\OAuth\TokenSet;

Mcp::oAuthRoutesFor('github', function (string $provider, TokenSet $token) {
    auth()->user()->update([
        "mcp_{$provider}_token"   => encrypt($token->accessToken),
        "mcp_{$provider}_refresh" => encrypt($token->refreshToken),
    ]);

    return redirect('/dashboard');
});
```

That gives you two named routes:

- `mcp.oauth.github.connect` at `/mcp/github/connect`, which starts the flow
- `mcp.oauth.github.callback` at `/mcp/oauth/github/callback`, which receives the token

Now link to the connect route from your view:

```blade
<a href="{{ route('mcp.oauth.github.connect') }}">Connect GitHub</a>
```

If you would rather keep your handler in a controller, you may pass it as an array. The method receives the provider name and the token, and resolves through the container so you can type hint anything else you need:

```php
Mcp::oAuthRoutesFor('github', [GitHubConnectionController::class, 'store']);
```

Your handler owns the final redirect, so you decide where the user lands after connecting. You may also choose the middleware applied to both routes:

```php
Mcp::oAuthRoutesFor('github', $handler, middleware: ['web', 'auth']);
```

If the server registered you dynamically and your `clientId` was issued on the fly, the new credentials are available on the token so you can store them for later refreshes:

```php
Mcp::oAuthRoutesFor('github', function (string $provider, TokenSet $token) {
    auth()->user()->update([
        "mcp_{$provider}_token"     => encrypt($token->accessToken),
        "mcp_{$provider}_refresh"   => encrypt($token->refreshToken),
        "mcp_{$provider}_client_id" => encrypt((string) $token->clientId),
        "mcp_{$provider}_client_secret" => encrypt((string) $token->clientSecret),
    ]);

    return redirect('/dashboard');
});
```

## Server to server (client credentials)

For background jobs or service to service access where there is no user to redirect, provide a `clientId` and `clientSecret` and ask for a token directly. No routes are needed here:

```php
use Laravel\Mcp\Facades\Mcp;

Mcp::registerClient('billing', fn () => Client::web('https://billing.test/mcp')->withOAuth(
    clientId: env('BILLING_CLIENT_ID'),
    clientSecret: env('BILLING_CLIENT_SECRET'),
    scope: 'mcp:use',
));

$token = Mcp::client('billing')->oAuthClient()->clientCredentials();

cache()->put('mcp_billing_token', $token->accessToken, $token->expiresAt - time());
```

The package sends the client credentials in whichever way the authorization server advertises (it reads the server metadata and uses `client_secret_basic` or `client_secret_post` accordingly), so there is nothing to configure here.

## Using the token

Pass your stored token on each call with `withToken()`. It accepts a string, or a closure so you can resolve it lazily:

```php
$tools = Mcp::client('billing')
    ->withToken(fn () => cache()->get('mcp_billing_token'))
    ->tools();

$tools = Mcp::client('github')
    ->withToken(auth()->user()->mcp_github_token)
    ->tools();
```

## When the token is missing or expired

The package does not track expiry, so the signal that a user needs to reconnect is the server answering with a `401` or `403`. When that happens the client throws an `AuthorizationRequiredException`, which you can catch to send the user back through the connect route:

```php
use Laravel\Mcp\Client\Exceptions\AuthorizationRequiredException;

try {
    return Mcp::client('github')->withToken($user->mcp_github_token)->tools();
} catch (AuthorizationRequiredException $e) {
    return redirect()->route('mcp.oauth.github.connect', $e->query());
}
```

Passing `$e->query()` forwards the server's challenge details (the resource metadata URL and the scope it asked for) to the connect route, so the reconnect uses exactly what the server requested.

If you are combining tools from several servers and would rather skip one that is not connected yet, pass a default and the listing returns that instead of throwing:

```php
$tools = Mcp::client('github')
    ->withToken(fn () => $user->mcp_github_token)
    ->tools(default: []);
```

## Refreshing a token

Refresh is driven by your application, using the refresh token you stored earlier:

```php
$fresh = Mcp::client('github')->oAuthClient()->refreshCredentials($user->mcp_github_refresh);
```

For a dynamically registered client, pass the credentials you stored at connect time so the refresh authenticates as the same client:

```php
$fresh = Mcp::client('github')->oAuthClient()->refreshCredentials(
    $user->mcp_github_refresh,
    clientId: decrypt($user->mcp_github_client_id),
    clientSecret: decrypt($user->mcp_github_client_secret),
);
```

## Where things live

- The package owns the OAuth handshake, the connect and callback routes, and returning the `TokenSet`.
- Your application owns the client registration (a service provider), the route registration and handler (`routes/web.php` or a controller), and storing the token.



