### PR TITLE
Add embedded resource responses

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -13,13 +13,16 @@ use InvalidArgumentException;
 use JsonException;
 use Laravel\Mcp\Enums\Role;
 use Laravel\Mcp\Schema\Icon;
+use Laravel\Mcp\Server\AppResource;
 use Laravel\Mcp\Server\Content\Audio;
 use Laravel\Mcp\Server\Content\Blob;
+use Laravel\Mcp\Server\Content\EmbeddedResource;
 use Laravel\Mcp\Server\Content\Image;
 use Laravel\Mcp\Server\Content\Notification;
 use Laravel\Mcp\Server\Content\ResourceLink;
 use Laravel\Mcp\Server\Content\Text;
 use Laravel\Mcp\Server\Contracts\Content;
+use Laravel\Mcp\Server\Contracts\HasUriTemplate;
 use Laravel\Mcp\Server\Resource;
 use League\Flysystem\UnableToReadFile;
 
@@ -186,6 +189,95 @@ class Response
         };
 
         return new static($link);
+    }
+
+    /**
+     * @param  class-string<Resource>|Resource|EmbeddedResource  $resource
+     * @param  array<string, mixed>  $arguments
+     */
+    public static function embeddedResource(string|Resource|EmbeddedResource $resource, array $arguments = []): static
+    {
+        if ($resource instanceof EmbeddedResource) {
+            return new static($resource);
+        }
+
+        if (is_string($resource)) {
+            if (! is_subclass_of($resource, Resource::class)) {
+                throw new InvalidArgumentException('Embedded resource class must extend [Laravel\Mcp\Server\Resource].');
+            }
+
+            $resource = Container::getInstance()->make($resource);
+        }
+
+        $uri = $resource instanceof HasUriTemplate
+            ? $resource->uriTemplate()->expand($arguments)
+            : $resource->uri();
+
+        return new static(new EmbeddedResource(
+            static::resourceContent($resource, $uri, $arguments),
+        ));
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     * @return array<string, mixed>
+     */
+    protected static function resourceContent(Resource $resource, string $uri, array $arguments): array
+    {
+        $container = Container::getInstance();
+        $request = new Request($arguments, uri: $uri);
+
+        if ($resource instanceof HasUriTemplate) {
+            $request->merge($resource->uriTemplate()->match($uri) ?? []);
+        }
+
+        $container->instance(Request::class, $request);
+
+        if ($resource instanceof AppResource) {
+            $container->instance('mcp.library_scripts', $resource->libraryScripts());
+        }
+
+        try {
+            $handler = [$resource, 'handle'];
+
+            if (! is_callable($handler)) {
+                throw new InvalidArgumentException('Embedded resource must define a callable handle method.');
+            }
+
+            $response = $container->call($handler);
+        } finally {
+            $container->forgetInstance(Request::class);
+            $container->forgetInstance('mcp.library_scripts');
+        }
+
+        $content = match (true) {
+            $response instanceof ResponseFactory => $response,
+            $response instanceof Response => new ResponseFactory($response),
+            is_string($response) => new ResponseFactory(str_contains($response, "\0") ? static::blob($response) : static::text($response)),
+            is_array($response) => new ResponseFactory($response),
+            default => throw new InvalidArgumentException('Embedded resources must return a Response instance, ResponseFactory, array of Response instances, or string.'),
+        };
+
+        if ($content->responses()->count() !== 1) {
+            throw new InvalidArgumentException('Embedded resources must contain exactly one response.');
+        }
+
+        $resourceContent = $content->responses()->sole()->content()->toResource($resource);
+        $resourceContent['uri'] = $uri;
+
+        if ($resource instanceof AppResource) {
+            $appMeta = $resource->resolvedAppMeta();
+
+            if ($appMeta !== []) {
+                $meta = $resourceContent['_meta'] ?? [];
+
+                $resourceContent['_meta'] = array_merge(is_array($meta) ? $meta : [], [
+                    'ui' => $appMeta,
+                ]);
+            }
+        }
+
+        return $resourceContent;
     }
 
     public static function fromStorage(string $path, ?string $disk = null, ?string $mimeType = null): static

--- a/src/Server/Content/EmbeddedResource.php
+++ b/src/Server/Content/EmbeddedResource.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Server\Content;
+
+use InvalidArgumentException;
+use Laravel\Mcp\Server\Concerns\HasMeta;
+use Laravel\Mcp\Server\Contracts\Content;
+use Laravel\Mcp\Server\Prompt;
+use Laravel\Mcp\Server\Resource;
+use Laravel\Mcp\Server\Tool;
+
+class EmbeddedResource implements Content
+{
+    use HasMeta;
+
+    /**
+     * @param  array<string, mixed>  $resource
+     */
+    public function __construct(
+        protected array $resource,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toTool(Tool $tool): array
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toPrompt(Prompt $prompt): array
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toResource(Resource $resource): array
+    {
+        throw new InvalidArgumentException(
+            'EmbeddedResource content may not be used in resources.',
+        );
+    }
+
+    public function __toString(): string
+    {
+        return (string) ($this->resource['text'] ?? $this->resource['blob'] ?? $this->resource['uri'] ?? '');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->mergeMeta([
+            'type' => 'resource',
+            'resource' => $this->resource,
+        ]);
+    }
+}

--- a/src/Server/Testing/PendingTestResponse.php
+++ b/src/Server/Testing/PendingTestResponse.php
@@ -18,7 +18,6 @@ use Laravel\Mcp\Server\Transport\FakeTransporter;
 use Laravel\Mcp\Support\UriTemplate;
 use Laravel\Mcp\Transport\JsonRpcRequest;
 use Laravel\Mcp\Transport\JsonRpcResponse;
-use Stringable;
 
 class PendingTestResponse
 {
@@ -183,28 +182,6 @@ class PendingTestResponse
      */
     protected function expandUriTemplate(UriTemplate $template, array $variables): string
     {
-        $expanded = (string) $template;
-
-        foreach ($template->variableNames() as $name) {
-            if (! array_key_exists($name, $variables)) {
-                throw new InvalidArgumentException("Missing value for URI template variable [{$name}].");
-            }
-
-            $value = $variables[$name];
-
-            if (! is_scalar($value) && ! $value instanceof Stringable) {
-                throw new InvalidArgumentException("URI template variable [{$name}] must be a scalar or Stringable value.");
-            }
-
-            $value = (string) $value;
-
-            if (str_contains($value, '/')) {
-                throw new InvalidArgumentException("URI template variable [{$name}] value must not contain '/'.");
-            }
-
-            $expanded = str_replace('{'.$name.'}', $value, $expanded);
-        }
-
-        return $expanded;
+        return $template->expand($variables);
     }
 }

--- a/src/Support/UriTemplate.php
+++ b/src/Support/UriTemplate.php
@@ -66,6 +66,36 @@ class UriTemplate implements Stringable
         return array_values(array_unique($this->variableNames));
     }
 
+    /**
+     * @param  array<string, mixed>  $variables
+     */
+    public function expand(array $variables): string
+    {
+        $expanded = $this->template;
+
+        foreach ($this->variableNames() as $name) {
+            if (! array_key_exists($name, $variables)) {
+                throw new InvalidArgumentException("Missing value for URI template variable [{$name}].");
+            }
+
+            $value = $variables[$name];
+
+            if (! is_scalar($value) && ! $value instanceof Stringable) {
+                throw new InvalidArgumentException("URI template variable [{$name}] must be a scalar or Stringable value.");
+            }
+
+            $value = (string) $value;
+
+            if (str_contains($value, '/')) {
+                throw new InvalidArgumentException("URI template variable [{$name}] value must not contain '/'.");
+            }
+
+            $expanded = str_replace('{'.$name.'}', $value, $expanded);
+        }
+
+        return $expanded;
+    }
+
     public function __toString(): string
     {
         return $this->template;

--- a/tests/Unit/Content/EmbeddedResourceTest.php
+++ b/tests/Unit/Content/EmbeddedResourceTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Mcp\Server\Content\EmbeddedResource;
+use Laravel\Mcp\Server\Prompt;
+use Laravel\Mcp\Server\Resource;
+use Laravel\Mcp\Server\Tool;
+
+it('may be used in tools and prompts', function (): void {
+    $embeddedResource = new EmbeddedResource([
+        'uri' => 'file://resources/summary.md',
+        'text' => 'Session summary',
+        'mimeType' => 'text/markdown',
+    ]);
+
+    $expected = [
+        'type' => 'resource',
+        'resource' => [
+            'uri' => 'file://resources/summary.md',
+            'text' => 'Session summary',
+            'mimeType' => 'text/markdown',
+        ],
+    ];
+
+    expect($embeddedResource->toTool(new class extends Tool {}))->toEqual($expected)
+        ->and($embeddedResource->toPrompt(new class extends Prompt {}))->toEqual($expected);
+});
+
+it('may not be used in resources', function (): void {
+    $embeddedResource = new EmbeddedResource([
+        'uri' => 'file://resources/summary.md',
+        'text' => 'Session summary',
+        'mimeType' => 'text/markdown',
+    ]);
+
+    $resource = new class extends Resource
+    {
+        protected string $uri = 'file://store/items.json';
+
+        protected string $mimeType = 'application/json';
+    };
+
+    expect(fn (): array => $embeddedResource->toResource($resource))
+        ->toThrow(InvalidArgumentException::class, 'EmbeddedResource content may not be used in resources.');
+});
+
+it('casts to string as the embedded text', function (): void {
+    $embeddedResource = new EmbeddedResource([
+        'uri' => 'file://resources/summary.md',
+        'text' => 'Session summary',
+        'mimeType' => 'text/markdown',
+    ]);
+
+    expect((string) $embeddedResource)->toBe('Session summary');
+});

--- a/tests/Unit/ResponseTest.php
+++ b/tests/Unit/ResponseTest.php
@@ -6,16 +6,20 @@ use Laravel\Mcp\Enums\Role;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\ResponseFactory;
 use Laravel\Mcp\Schema\Icon;
+use Laravel\Mcp\Server\AppResource;
 use Laravel\Mcp\Server\Attributes\Icon as IconAttribute;
 use Laravel\Mcp\Server\Content\Audio;
 use Laravel\Mcp\Server\Content\Blob;
+use Laravel\Mcp\Server\Content\EmbeddedResource;
 use Laravel\Mcp\Server\Content\Image;
 use Laravel\Mcp\Server\Content\Notification;
 use Laravel\Mcp\Server\Content\ResourceLink;
 use Laravel\Mcp\Server\Content\Text;
 use Laravel\Mcp\Server\Resource;
+use Laravel\Mcp\Server\Ui\AppMeta;
 use Tests\Fixtures\AnnotatedResource;
 use Tests\Fixtures\DailyPlanResource;
+use Tests\Fixtures\ExampleResourceTemplate;
 
 it('creates a notification response', function (): void {
     $response = Response::notification('test.method', ['key' => 'value']);
@@ -321,6 +325,81 @@ it('creates a resource link from a Resource instance', function (): void {
     $response = Response::resourceLink($resource);
 
     expect($response->content()->toArray()['uri'])->toBe($resource->uri());
+});
+
+it('creates an embedded resource from a Resource class-string', function (): void {
+    $response = Response::embeddedResource(DailyPlanResource::class);
+
+    expect($response->content())->toBeInstanceOf(EmbeddedResource::class)
+        ->and($response->content()->toArray())->toEqual([
+            'type' => 'resource',
+            'resource' => [
+                'text' => "# Daily Plan\n\n- [ ] Task 1\n- [ ] Task 2\n- [ ] Task 3",
+                'uri' => 'file://resources/daily-plan.md',
+                'mimeType' => 'text/markdown',
+            ],
+        ]);
+});
+
+it('creates an embedded resource from a URI template Resource', function (): void {
+    $response = Response::embeddedResource(ExampleResourceTemplate::class, ['id' => '42']);
+
+    expect($response->content()->toArray())->toEqual([
+        'type' => 'resource',
+        'resource' => [
+            'text' => 'Example resource: 42',
+            'uri' => 'file://example/42',
+            'mimeType' => 'text/plain',
+        ],
+    ]);
+});
+
+it('includes AppResource metadata in embedded resources', function (): void {
+    config(['app.url' => 'https://mcp.example.test']);
+
+    $resource = new class extends AppResource
+    {
+        protected string $uri = 'ui://resources/dashboard';
+
+        public function appMeta(): AppMeta
+        {
+            return AppMeta::make()->prefersBorder(false);
+        }
+
+        public function handle(): Response
+        {
+            return Response::text('<main>Dashboard</main>');
+        }
+    };
+
+    $response = Response::embeddedResource($resource);
+
+    expect($response->content()->toArray())->toEqual([
+        'type' => 'resource',
+        'resource' => [
+            'text' => '<main>Dashboard</main>',
+            'uri' => 'ui://resources/dashboard',
+            'mimeType' => 'text/html;profile=mcp-app',
+            '_meta' => [
+                'ui' => [
+                    'domain' => 'mcp.example.test',
+                    'prefersBorder' => false,
+                ],
+            ],
+        ],
+    ]);
+});
+
+it('wraps a pre-built embedded resource instance', function (): void {
+    $embeddedResource = new EmbeddedResource([
+        'uri' => 'file://resources/summary.md',
+        'text' => 'Session summary',
+        'mimeType' => 'text/markdown',
+    ]);
+
+    $response = Response::embeddedResource($embeddedResource);
+
+    expect($response->content())->toBe($embeddedResource);
 });
 
 it('inherits annotations from a Resource', function (): void {

--- a/tests/Unit/Support/UriTemplateTest.php
+++ b/tests/Unit/Support/UriTemplateTest.php
@@ -54,6 +54,29 @@ it('matches nested path segments', function (): void {
     ]);
 });
 
+it('expands URI templates with variables', function (): void {
+    $template = new UriTemplate('file://sessions/{sessionId}/summaries/{summaryId}');
+
+    expect($template->expand([
+        'sessionId' => 42,
+        'summaryId' => 'daily',
+    ]))->toBe('file://sessions/42/summaries/daily');
+});
+
+it('requires all variables when expanding URI templates', function (): void {
+    $template = new UriTemplate('file://sessions/{sessionId}/summaries/{summaryId}');
+
+    expect(fn (): string => $template->expand(['sessionId' => 42]))
+        ->toThrow(InvalidArgumentException::class, 'Missing value for URI template variable [summaryId].');
+});
+
+it('rejects slash values when expanding URI templates', function (): void {
+    $template = new UriTemplate('file://sessions/{sessionId}');
+
+    expect(fn (): string => $template->expand(['sessionId' => 'a/b']))
+        ->toThrow(InvalidArgumentException::class, "URI template variable [sessionId] value must not contain '/'.");
+});
+
 it('rejects partial matches and incomplete URIs', function (): void {
     $template = new UriTemplate('file://users/{id}');
 


### PR DESCRIPTION
Fixes #224.

This adds `Response::embeddedResource()` for embedding a resource content block in tool and prompt responses. It accepts resource class strings, resource instances, or prebuilt `EmbeddedResource` content, expands URI templates with the same validation used by test helpers, invokes resources through the container with an MCP request, and preserves AppResource UI metadata for embedded app resources.

Tests:
- `C:\laragon\bin\php\php-8.3.26-Win32-vs16-x64\php.exe vendor\bin\pest tests\Unit\Content\EmbeddedResourceTest.php tests\Unit\ResponseTest.php tests\Unit\Support\UriTemplateTest.php`
- `C:\laragon\bin\php\php-8.3.26-Win32-vs16-x64\php.exe vendor\bin\phpstan analyse src\Response.php src\Server\Content\EmbeddedResource.php src\Support\UriTemplate.php src\Server\Testing\PendingTestResponse.php --memory-limit=1G`
- `C:\laragon\bin\php\php-8.3.26-Win32-vs16-x64\php.exe vendor\bin\pint --test src\Response.php src\Server\Content\EmbeddedResource.php src\Support\UriTemplate.php src\Server\Testing\PendingTestResponse.php tests\Unit\Content\EmbeddedResourceTest.php tests\Unit\ResponseTest.php tests\Unit\Support\UriTemplateTest.php`