### PR TITLE
Make MCP client tools cacheable via recipe serialization

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp;
 
+use Illuminate\Container\Container;
 use Illuminate\Support\Collection;
+use Laravel\Mcp\Client\ClientManager;
 use Laravel\Mcp\Client\Contracts\Transport;
 use Laravel\Mcp\Client\Methods\Ping;
 use Laravel\Mcp\Client\Methods\Tools\CallTool;
@@ -15,6 +17,7 @@ use Laravel\Mcp\Client\Schema\InitializeResult;
 use Laravel\Mcp\Client\Schema\ToolResult;
 use Laravel\Mcp\Client\Transport\HttpTransport;
 use Laravel\Mcp\Client\Transport\StdioTransport;
+use Laravel\Mcp\Client\Transport\TransportFactory;
 use Laravel\Mcp\Schema\Implementation;
 
 class Client
@@ -22,6 +25,8 @@ class Client
     public Implementation $clientInfo;
 
     protected Protocol $protocol;
+
+    protected ?string $name = null;
 
     public function __construct(
         protected Transport $transport,
@@ -33,6 +38,13 @@ class Client
         );
 
         $this->protocol = new Protocol($this->transport, $this->clientInfo);
+    }
+
+    public function setName(?string $name): static
+    {
+        $this->name = $name;
+
+        return $this;
     }
 
     /**
@@ -87,7 +99,7 @@ class Client
      */
     public function tools(?int $limit = null): Collection
     {
-        return (new ListTools(limit: $limit))->handle($this->protocol);
+        return (new ListTools(client: $this, limit: $limit))->handle($this->protocol);
     }
 
     /**
@@ -96,6 +108,42 @@ class Client
     public function callTool(string $name, array $arguments = []): ToolResult
     {
         return (new CallTool($name, $arguments))->handle($this->protocol);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function __serialize(): array
+    {
+        if ($this->name !== null) {
+            return ['name' => $this->name];
+        }
+
+        return [
+            'name' => null,
+            'clientInfo' => $this->clientInfo,
+            'transport' => $this->transport->recipe(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function __unserialize(array $data): void
+    {
+        $this->name = $data['name'] ?? null;
+
+        if ($this->name !== null) {
+            $resolved = Container::getInstance()->make(ClientManager::class)->build($this->name);
+
+            $this->transport = $resolved->transport;
+            $this->clientInfo = $resolved->clientInfo;
+        } else {
+            $this->clientInfo = $data['clientInfo'];
+            $this->transport = TransportFactory::fromRecipe($data['transport']);
+        }
+
+        $this->protocol = new Protocol($this->transport, $this->clientInfo);
     }
 
     public function __destruct()

--- a/src/Client/ClientManager.php
+++ b/src/Client/ClientManager.php
@@ -38,11 +38,16 @@ class ClientManager
 
     public function client(string $name): Client
     {
+        return $this->clients[$name] ??= $this->build($name);
+    }
+
+    public function build(string $name): Client
+    {
         if (! array_key_exists($name, $this->factories)) {
             throw new ClientException("MCP client [{$name}] has not been registered.");
         }
 
-        return $this->clients[$name] ??= ($this->factories[$name])();
+        return ($this->factories[$name])()->setName($name);
     }
 
     public function disconnectAll(): void

--- a/src/Client/Contracts/Transport.php
+++ b/src/Client/Contracts/Transport.php
@@ -15,4 +15,9 @@ interface Transport
     public function receive(): string;
 
     public function setTimeoutSeconds(float $seconds): void;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function recipe(): array;
 }

--- a/src/Client/Methods/Tools/ListTools.php
+++ b/src/Client/Methods/Tools/ListTools.php
@@ -6,6 +6,7 @@ namespace Laravel\Mcp\Client\Methods\Tools;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Laravel\Mcp\Client;
 use Laravel\Mcp\Client\Contracts\Method;
 use Laravel\Mcp\Client\Primitives\Tool;
 use Laravel\Mcp\Client\Protocol;
@@ -17,6 +18,7 @@ use Laravel\Mcp\Exceptions\ClientException;
 class ListTools implements Method
 {
     public function __construct(
+        protected ?Client $client = null,
         protected ?string $cursor = null,
         protected ?int $limit = null,
     ) {
@@ -51,7 +53,7 @@ class ListTools implements Method
     protected function hydrate(array $payloads): Collection
     {
         return collect($payloads)->mapWithKeys(function (array $payload): array {
-            $tool = Tool::from($payload);
+            $tool = Tool::from($this->client, $payload);
 
             return [$tool->name => $tool];
         });
@@ -83,7 +85,7 @@ class ListTools implements Method
                 $seenCursors[$cursor] = true;
             }
 
-            $result = $protocol->dispatch(new self($cursor, $this->limit));
+            $result = $protocol->dispatch(new self($this->client, $cursor, $this->limit));
             $page = Arr::get($result, 'tools');
 
             if (! is_array($page)) {

--- a/src/Client/Primitives/Tool.php
+++ b/src/Client/Primitives/Tool.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Laravel\Mcp\Client\Primitives;
 
 use Illuminate\Support\Arr;
+use Laravel\Mcp\Client;
+use Laravel\Mcp\Client\Schema\ToolResult;
 use Laravel\Mcp\Exceptions\ClientException;
 
 class Tool
@@ -16,6 +18,7 @@ class Tool
      * @param  array<string, mixed>|null  $meta
      */
     public function __construct(
+        protected ?Client $client,
         public readonly string $name,
         public readonly ?string $title,
         public readonly ?string $description,
@@ -30,7 +33,7 @@ class Tool
     /**
      * @param  array<string, mixed>  $payload
      */
-    public static function from(array $payload): self
+    public static function from(?Client $client, array $payload): self
     {
         $name = Arr::get($payload, 'name');
         $title = Arr::get($payload, 'title');
@@ -51,6 +54,7 @@ class Tool
         }
 
         return new self(
+            client: $client,
             name: $name,
             title: $title,
             description: $description,
@@ -59,5 +63,17 @@ class Tool
             annotations: $annotations,
             meta: $meta,
         );
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     */
+    public function call(array $arguments = []): ToolResult
+    {
+        if (! $this->client instanceof Client) {
+            throw new ClientException("Tool [{$this->name}] is not bound to a client.");
+        }
+
+        return $this->client->callTool($this->name, $arguments);
     }
 }

--- a/src/Client/Transport/HttpTransport.php
+++ b/src/Client/Transport/HttpTransport.php
@@ -55,6 +55,19 @@ class HttpTransport implements Transport
         $this->token = $token;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
+    public function recipe(): array
+    {
+        return [
+            'driver' => 'http',
+            'url' => $this->url,
+            'token' => $this->token,
+            'timeoutSeconds' => $this->timeoutSeconds,
+        ];
+    }
+
     public function send(string $message): void
     {
         $hadSession = $this->sessionId !== null;

--- a/src/Client/Transport/StdioTransport.php
+++ b/src/Client/Transport/StdioTransport.php
@@ -65,6 +65,19 @@ class StdioTransport implements Transport
         $this->timeoutSeconds = $seconds;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
+    public function recipe(): array
+    {
+        return [
+            'driver' => 'stdio',
+            'command' => $this->command,
+            'args' => $this->args,
+            'timeoutSeconds' => $this->timeoutSeconds,
+        ];
+    }
+
     public function send(string $message): void
     {
         if (! $this->input instanceof InputStream || ! $this->process?->isRunning()) {

--- a/src/Client/Transport/TransportFactory.php
+++ b/src/Client/Transport/TransportFactory.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\Transport;
+
+use Illuminate\Support\Arr;
+use Laravel\Mcp\Client\Contracts\Transport;
+use Laravel\Mcp\Exceptions\ClientException;
+
+class TransportFactory
+{
+    /**
+     * @param  array<string, mixed>  $recipe
+     */
+    public static function fromRecipe(array $recipe): Transport
+    {
+        return match (Arr::get($recipe, 'driver')) {
+            'stdio' => self::stdio($recipe),
+            'http' => self::http($recipe),
+            default => throw new ClientException('Unable to rebuild transport from an unknown recipe.'),
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $recipe
+     */
+    protected static function stdio(array $recipe): StdioTransport
+    {
+        $command = Arr::get($recipe, 'command');
+        $args = Arr::get($recipe, 'args', []);
+
+        if (! is_string($command) || ! is_array($args)) {
+            throw new ClientException('Invalid stdio transport recipe.');
+        }
+
+        $transport = new StdioTransport($command, array_values($args));
+
+        self::applyTimeout($transport, $recipe);
+
+        return $transport;
+    }
+
+    /**
+     * @param  array<string, mixed>  $recipe
+     */
+    protected static function http(array $recipe): HttpTransport
+    {
+        $url = Arr::get($recipe, 'url');
+
+        if (! is_string($url)) {
+            throw new ClientException('Invalid http transport recipe.');
+        }
+
+        $transport = new HttpTransport($url);
+
+        $token = Arr::get($recipe, 'token');
+
+        if (is_string($token)) {
+            $transport->withToken($token);
+        }
+
+        self::applyTimeout($transport, $recipe);
+
+        return $transport;
+    }
+
+    /**
+     * @param  array<string, mixed>  $recipe
+     */
+    protected static function applyTimeout(Transport $transport, array $recipe): void
+    {
+        $timeout = Arr::get($recipe, 'timeoutSeconds');
+
+        if (is_int($timeout) || is_float($timeout)) {
+            $transport->setTimeoutSeconds((float) $timeout);
+        }
+    }
+}

--- a/src/WebClient.php
+++ b/src/WebClient.php
@@ -22,4 +22,16 @@ class WebClient extends Client
 
         return $this;
     }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function __unserialize(array $data): void
+    {
+        parent::__unserialize($data);
+
+        if ($this->transport instanceof HttpTransport) {
+            $this->httpTransport = $this->transport;
+        }
+    }
 }

--- a/tests/Fixtures/Client/FakeTransport.php
+++ b/tests/Fixtures/Client/FakeTransport.php
@@ -41,6 +41,14 @@ class FakeTransport implements Transport
         $this->timeoutSeconds = $seconds;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
+    public function recipe(): array
+    {
+        return ['driver' => 'fake'];
+    }
+
     public function receive(): string
     {
         if ($this->responses === []) {

--- a/tests/Unit/Client/ClientManagerTest.php
+++ b/tests/Unit/Client/ClientManagerTest.php
@@ -190,6 +190,50 @@ it('returns a tools list the application can cache and restore', function (): vo
     expect($restored['add']->description)->toBe('Adds two numbers');
 });
 
+it('serializes a named client as its name only and re-resolves it when a restored tool is called', function (): void {
+    $resolutions = 0;
+
+    Mcp::registerClient('everything', function () use (&$resolutions): Client {
+        $resolutions++;
+
+        $transport = new FakeTransport;
+        $transport->responses[] = initializeResponse();
+        $transport->responses[] = $resolutions === 1
+            ? toolsResponse(2)
+            : json_encode([
+                'jsonrpc' => '2.0',
+                'id' => 2,
+                'result' => ['content' => [['type' => 'text', 'text' => 'added']], 'isError' => false],
+            ]);
+
+        return new Client($transport);
+    });
+
+    $payload = serialize(Mcp::client('everything')->tools());
+
+    expect($payload)->toContain('everything')->not->toContain('secret');
+
+    app(ClientManager::class)->disconnectAll();
+
+    $restored = unserialize($payload);
+
+    expect($restored['add']->call()->text())->toBe('added')
+        ->and($resolutions)->toBe(2);
+});
+
+it('gives a restored named client its own transport instead of aliasing the cached one', function (): void {
+    Mcp::registerClient('everything', fn (): Client => new Client(new FakeTransport));
+
+    $live = Mcp::client('everything');
+
+    $restored = unserialize(serialize($live));
+
+    $transport = new ReflectionProperty(Client::class, 'transport');
+
+    expect($restored)->not->toBe($live)
+        ->and($transport->getValue($restored))->not->toBe($transport->getValue($live));
+});
+
 it('does not cache tools on the resolved client', function (): void {
     $transport = new FakeTransport;
     $transport->responses[] = initializeResponse();

--- a/tests/Unit/Client/ClientTest.php
+++ b/tests/Unit/Client/ClientTest.php
@@ -6,6 +6,7 @@ use Laravel\Mcp\Client;
 use Laravel\Mcp\Enums\ProtocolVersion;
 use Laravel\Mcp\Exceptions\ClientException;
 use Laravel\Mcp\Exceptions\JsonRpcException;
+use Laravel\Mcp\WebClient;
 use Tests\Fixtures\Client\FakeTransport;
 
 it('performs the initialize handshake on connect', function (): void {
@@ -354,4 +355,32 @@ it('times out when a stdio process stays silent', function (): void {
 
     expect(fn (): Client => $client->connect())
         ->toThrow(ClientException::class, 'Timed out while waiting for server response.');
+});
+
+it('preserves its shape across a serialize round-trip and wakes disconnected', function (): void {
+    config(['app.name' => 'Acme MCP App']);
+
+    $client = Client::local('node', ['server.js'])->withTimeout(12.5);
+
+    $payload = serialize($client);
+    $restored = unserialize($payload);
+
+    expect($restored)
+        ->toBeInstanceOf(Client::class)
+        ->and($restored->connected())->toBeFalse()
+        ->and($restored->__serialize())->toEqual($client->__serialize())
+        ->and($payload)
+        ->toContain('node')
+        ->not->toContain('Symfony\Component\Process');
+});
+
+it('restores a web client transport across a serialize round-trip', function (): void {
+    $client = Client::web('https://mcp.test/mcp')->withToken('tok');
+
+    $restored = unserialize(serialize($client));
+
+    expect($restored)
+        ->toBeInstanceOf(WebClient::class)
+        ->and($restored->connected())->toBeFalse()
+        ->and($restored->withToken('rotated'))->toBe($restored);
 });

--- a/tests/Unit/Client/ToolsTest.php
+++ b/tests/Unit/Client/ToolsTest.php
@@ -217,25 +217,34 @@ it('throws when tools/list returns a non-string cursor', function (): void {
         ->toThrow(ClientException::class, 'Invalid tools/list cursor from server.');
 });
 
-it('returns tools that survive a serialize round-trip for caching', function (): void {
+it('returns an unbound tool whose call throws until it is bound', function (): void {
+    $tool = Tool::from(null, ['name' => 'say-hi', 'description' => 'Greets a person']);
+
+    expect(fn (): ToolResult => $tool->call())
+        ->toThrow(ClientException::class, 'Tool [say-hi] is not bound to a client.');
+});
+
+it('calls a bound tool returned from tools()', function (): void {
     $transport = new FakeTransport;
     $transport->responses[] = initializeResponse();
     $transport->responses[] = json_encode([
         'jsonrpc' => '2.0',
         'id' => 2,
-        'result' => [
-            'tools' => [['name' => 'say-hi', 'description' => 'Greets a person']],
-        ],
+        'result' => ['tools' => [['name' => 'say-hi', 'description' => 'Greets a person']]],
+    ]);
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 3,
+        'result' => ['content' => [['type' => 'text', 'text' => 'Hello, John!']], 'isError' => false],
     ]);
 
-    $tools = (new Client($transport))->tools();
+    $tool = (new Client($transport))->tools()['say-hi'];
 
-    $restored = unserialize(serialize($tools));
-
-    expect($restored)
-        ->toBeInstanceOf(Collection::class)
-        ->and($restored->keys()->all())->toBe(['say-hi'])
-        ->and($restored['say-hi']->description)->toBe('Greets a person');
+    expect($tool->call(['name' => 'John'])->text())->toBe('Hello, John!')
+        ->and(json_decode($transport->sent[3], true))
+        ->toHaveKey('method', 'tools/call')
+        ->toHaveKey('params.name', 'say-hi')
+        ->toHaveKey('params.arguments', ['name' => 'John']);
 });
 
 it('sends tools/call by name and concatenates text content', function (): void {

--- a/tests/Unit/Client/Transport/TransportFactoryTest.php
+++ b/tests/Unit/Client/Transport/TransportFactoryTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Mcp\Client\Contracts\Transport;
+use Laravel\Mcp\Client\Transport\HttpTransport;
+use Laravel\Mcp\Client\Transport\StdioTransport;
+use Laravel\Mcp\Client\Transport\TransportFactory;
+use Laravel\Mcp\Exceptions\ClientException;
+
+it('rebuilds a stdio transport from its recipe', function (): void {
+    $recipe = (new StdioTransport('node', ['server.js']))->recipe();
+    $recipe['timeoutSeconds'] = 12.0;
+
+    $transport = TransportFactory::fromRecipe($recipe);
+
+    expect($transport)
+        ->toBeInstanceOf(StdioTransport::class)
+        ->and($transport->recipe())->toBe([
+            'driver' => 'stdio',
+            'command' => 'node',
+            'args' => ['server.js'],
+            'timeoutSeconds' => 12.0,
+        ]);
+});
+
+it('rebuilds an http transport with its token and timeout from a recipe', function (): void {
+    $source = new HttpTransport('https://mcp.test/mcp');
+    $source->withToken('tok');
+    $source->setTimeoutSeconds(7.5);
+
+    $transport = TransportFactory::fromRecipe($source->recipe());
+
+    expect($transport)
+        ->toBeInstanceOf(HttpTransport::class)
+        ->and($transport->recipe())->toBe([
+            'driver' => 'http',
+            'url' => 'https://mcp.test/mcp',
+            'token' => 'tok',
+            'timeoutSeconds' => 7.5,
+        ]);
+});
+
+it('throws for an unknown transport driver', function (): void {
+    expect(fn (): Transport => TransportFactory::fromRecipe(['driver' => 'carrier-pigeon']))
+        ->toThrow(ClientException::class, 'Unable to rebuild transport from an unknown recipe.');
+});
+
+it('throws when a stdio recipe is missing its command', function (): void {
+    expect(fn (): Transport => TransportFactory::fromRecipe(['driver' => 'stdio', 'args' => []]))
+        ->toThrow(ClientException::class, 'Invalid stdio transport recipe.');
+});
+
+it('throws when an http recipe is missing its url', function (): void {
+    expect(fn (): Transport => TransportFactory::fromRecipe(['driver' => 'http']))
+        ->toThrow(ClientException::class, 'Invalid http transport recipe.');
+});


### PR DESCRIPTION
Currently you can't cache or queue an MCP client's tool list. A connected client holds a live `Symfony\Component\Process` (stdio) or a session id (http), so the moment you try to stash the result it blows up on serialization:

```php
// throws: cannot serialize a live Process / stale session
Cache::remember('tools', 3600, fn () => Mcp::client('everything')->tools());
```

This PR makes clients serialize a reconstruction recipe instead of the live connection, and reconnect lazily on first use. The tools that come back from `tools()` are now callable too:

```php
$tools = Cache::remember('tools', 3600, fn () => Mcp::client('everything')->tools());

// later, in a queued job / next request, straight from cache:
$tools['add']->call(['a' => 1, 'b' => 2]);
```

Named clients serialize as just their name and re-resolve through the manager on wake, so registered tokens never land in the cache and you always reconnect with a fresh session. Ad-hoc clients (`Client::web(...)->withToken(...)`) serialize their own transport recipe, token included, since there's no registry to re-resolve from.
