### PR TITLE
Fix Mcp alias: correct facade class name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
                 "Laravel\\Mcp\\Server\\McpServiceProvider"
             ],
             "aliases": {
-                "Mcp": "Laravel\\Mcp\\Server\\Facades\\Mcp"
+                "Mcp": "Laravel\\Mcp\\Facades\\Mcp"
             }
         }
     },


### PR DESCRIPTION
Looks like you moved the facade to the new namespace, but forgot about alias configuration.