### PR TITLE
Add prompts support to the MCP client

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -10,11 +10,15 @@ use Laravel\Mcp\Client\ClientManager;
 use Laravel\Mcp\Client\Contracts\Transport;
 use Laravel\Mcp\Client\Exceptions\AuthorizationRequiredException;
 use Laravel\Mcp\Client\Methods\Ping;
+use Laravel\Mcp\Client\Methods\Prompts\GetPrompt;
+use Laravel\Mcp\Client\Methods\Prompts\ListPrompts;
 use Laravel\Mcp\Client\Methods\Tools\CallTool;
 use Laravel\Mcp\Client\Methods\Tools\ListTools;
+use Laravel\Mcp\Client\Primitives\Prompt;
 use Laravel\Mcp\Client\Primitives\Tool;
 use Laravel\Mcp\Client\Protocol;
 use Laravel\Mcp\Client\Schema\InitializeResult;
+use Laravel\Mcp\Client\Schema\PromptResult;
 use Laravel\Mcp\Client\Schema\ToolResult;
 use Laravel\Mcp\Client\Transport\HttpTransport;
 use Laravel\Mcp\Client\Transport\StdioTransport;
@@ -121,6 +125,31 @@ class Client
     public function callTool(string $name, array $arguments = []): ToolResult
     {
         return (new CallTool($name, $arguments))->handle($this->protocol);
+    }
+
+    /**
+     * @param  iterable<string, Prompt>|null  $default
+     * @return Collection<string, Prompt>
+     */
+    public function prompts(?int $limit = null, ?iterable $default = null): Collection
+    {
+        try {
+            return (new ListPrompts(limit: $limit))->handle($this->protocol);
+        } catch (AuthorizationRequiredException $authorizationRequiredException) {
+            if ($default === null) {
+                throw $authorizationRequiredException;
+            }
+
+            return Collection::make($default);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     */
+    public function getPrompt(string $name, array $arguments = []): PromptResult
+    {
+        return (new GetPrompt($name, $arguments))->handle($this->protocol);
     }
 
     /**

--- a/src/Client/Methods/Concerns/PaginatesList.php
+++ b/src/Client/Methods/Concerns/PaginatesList.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\Methods\Concerns;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Laravel\Mcp\Client\Protocol;
+use Laravel\Mcp\Exceptions\ClientException;
+
+trait PaginatesList
+{
+    protected ?string $cursor = null;
+
+    protected ?int $limit = null;
+
+    /**
+     * The plural primitive name used as the list key and method prefix (e.g. 'tools', 'prompts').
+     */
+    abstract protected function listType(): string;
+
+    /**
+     * Build the request for the next page at the given cursor.
+     */
+    abstract protected function nextPage(?string $cursor): static;
+
+    /**
+     * @param  array<int, array<string, mixed>>  $payloads
+     * @return Collection<string, mixed>
+     */
+    abstract protected function hydrate(array $payloads): Collection;
+
+    public function method(): string
+    {
+        return "{$this->listType()}/list";
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function params(): array
+    {
+        return $this->cursor === null ? [] : ['cursor' => $this->cursor];
+    }
+
+    /**
+     * @return Collection<string, mixed>
+     */
+    public function handle(Protocol $protocol): Collection
+    {
+        return $this->hydrate($this->fetch($protocol));
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    protected function fetch(Protocol $protocol): array
+    {
+        $type = $this->listType();
+        $singular = Str::singular($type);
+
+        if ($this->limit === 0) {
+            return [];
+        }
+
+        if ($this->limit !== null && $this->limit < 0) {
+            throw new ClientException(ucfirst($singular).' list limit must be greater than or equal to zero.');
+        }
+
+        $payloads = [];
+        $cursor = $this->cursor;
+        $seenCursors = [];
+
+        while (true) {
+            if (filled($cursor)) {
+                if (isset($seenCursors[$cursor])) {
+                    throw new ClientException("Repeated {$type}/list cursor [{$cursor}] received from server.");
+                }
+
+                $seenCursors[$cursor] = true;
+            }
+
+            $result = $protocol->dispatch($this->nextPage($cursor));
+            $page = Arr::get($result, $type);
+
+            if (! is_array($page)) {
+                throw new ClientException("Invalid {$type}/list response from server.");
+            }
+
+            foreach ($page as $payload) {
+                if (! is_array($payload)) {
+                    throw new ClientException("Invalid {$singular} payload from server.");
+                }
+
+                if ($this->limit !== null && count($payloads) >= $this->limit) {
+                    return $payloads;
+                }
+
+                $payloads[] = $payload;
+            }
+
+            $next = Arr::get($result, 'nextCursor');
+
+            if ($next !== null && ! is_string($next)) {
+                throw new ClientException("Invalid {$type}/list cursor from server.");
+            }
+
+            if (blank($next)) {
+                return $payloads;
+            }
+
+            $cursor = $next;
+        }
+    }
+}

--- a/src/Client/Methods/Prompts/GetPrompt.php
+++ b/src/Client/Methods/Prompts/GetPrompt.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\Methods\Prompts;
+
+use Laravel\Mcp\Client\Contracts\Method;
+use Laravel\Mcp\Client\Protocol;
+use Laravel\Mcp\Client\Schema\PromptResult;
+
+/**
+ * @implements Method<PromptResult>
+ */
+class GetPrompt implements Method
+{
+    /**
+     * @param  array<string, mixed>  $arguments
+     */
+    public function __construct(
+        protected string $name,
+        protected array $arguments = [],
+    ) {
+        //
+    }
+
+    public function method(): string
+    {
+        return 'prompts/get';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function params(): array
+    {
+        return [
+            'name' => $this->name,
+            'arguments' => (object) $this->arguments,
+        ];
+    }
+
+    public function handle(Protocol $protocol): PromptResult
+    {
+        return PromptResult::from($protocol->dispatch($this));
+    }
+}

--- a/src/Client/Methods/Prompts/ListPrompts.php
+++ b/src/Client/Methods/Prompts/ListPrompts.php
@@ -2,50 +2,46 @@
 
 declare(strict_types=1);
 
-namespace Laravel\Mcp\Client\Methods\Tools;
+namespace Laravel\Mcp\Client\Methods\Prompts;
 
 use Illuminate\Support\Collection;
-use Laravel\Mcp\Client;
 use Laravel\Mcp\Client\Contracts\Method;
 use Laravel\Mcp\Client\Methods\Concerns\PaginatesList;
-use Laravel\Mcp\Client\Primitives\Tool;
+use Laravel\Mcp\Client\Primitives\Prompt;
 
 /**
- * @implements Method<Collection<string, Tool>>
+ * @implements Method<Collection<string, Prompt>>
  */
-class ListTools implements Method
+class ListPrompts implements Method
 {
     use PaginatesList;
 
-    public function __construct(
-        protected ?Client $client = null,
-        ?string $cursor = null,
-        ?int $limit = null,
-    ) {
+    public function __construct(?string $cursor = null, ?int $limit = null)
+    {
         $this->cursor = $cursor;
         $this->limit = $limit;
     }
 
     protected function listType(): string
     {
-        return 'tools';
+        return 'prompts';
     }
 
     protected function nextPage(?string $cursor): static
     {
-        return new static($this->client, $cursor, $this->limit);
+        return new static($cursor, $this->limit);
     }
 
     /**
      * @param  array<int, array<string, mixed>>  $payloads
-     * @return Collection<string, Tool>
+     * @return Collection<string, Prompt>
      */
     protected function hydrate(array $payloads): Collection
     {
         return collect($payloads)->mapWithKeys(function (array $payload): array {
-            $tool = Tool::from($this->client, $payload);
+            $prompt = Prompt::from($payload);
 
-            return [$tool->name => $tool];
+            return [$prompt->name => $prompt];
         });
     }
 }

--- a/src/Client/Primitives/Prompt.php
+++ b/src/Client/Primitives/Prompt.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\Primitives;
+
+use Illuminate\Support\Arr;
+use Laravel\Mcp\Exceptions\ClientException;
+
+class Prompt
+{
+    /**
+     * @param  array<int, array<string, mixed>>  $arguments
+     * @param  array<string, mixed>|null  $meta
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly ?string $title,
+        public readonly ?string $description,
+        public readonly array $arguments,
+        public readonly ?array $meta,
+    ) {
+        //
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public static function from(array $payload): self
+    {
+        $name = Arr::get($payload, 'name');
+        $title = Arr::get($payload, 'title');
+        $description = Arr::get($payload, 'description');
+        $arguments = Arr::get($payload, 'arguments', []);
+        $meta = Arr::get($payload, '_meta');
+
+        if (! is_string($name) || blank($name)
+            || ! is_array($arguments)
+            || (! is_null($title) && ! is_string($title))
+            || (! is_null($description) && ! is_string($description))
+            || (! is_null($meta) && ! is_array($meta))) {
+            throw new ClientException('Invalid prompt payload from server.');
+        }
+
+        return new self(
+            name: $name,
+            title: $title,
+            description: $description,
+            arguments: array_values(array_filter($arguments, is_array(...))),
+            meta: $meta,
+        );
+    }
+}

--- a/src/Client/Schema/PromptResult.php
+++ b/src/Client/Schema/PromptResult.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\Schema;
+
+use Illuminate\Support\Arr;
+use Laravel\Mcp\Exceptions\ClientException;
+use Stringable;
+
+class PromptResult implements Stringable
+{
+    /**
+     * @param  array<int, array<string, mixed>>  $messages
+     * @param  array<string, mixed>|null  $meta
+     */
+    public function __construct(
+        public array $messages,
+        public ?string $description = null,
+        public ?array $meta = null,
+    ) {
+        //
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     */
+    public static function from(array $result): self
+    {
+        $messages = Arr::get($result, 'messages', []);
+        $description = Arr::get($result, 'description');
+        $meta = Arr::get($result, '_meta');
+
+        if (! is_array($messages)
+            || (! is_null($description) && ! is_string($description))) {
+            throw new ClientException('Invalid prompts/get result from server.');
+        }
+
+        return new self(
+            messages: array_values(array_filter($messages, is_array(...))),
+            description: $description,
+            meta: is_array($meta) ? $meta : null,
+        );
+    }
+
+    public function text(): string
+    {
+        $parts = [];
+
+        foreach ($this->messages as $message) {
+            $content = Arr::get($message, 'content');
+
+            if (! is_array($content)) {
+                continue;
+            }
+
+            $text = Arr::get($content, 'text');
+
+            if (Arr::get($content, 'type') === 'text' && is_string($text)) {
+                $parts[] = $text;
+            }
+        }
+
+        return implode('', $parts);
+    }
+
+    public function __toString(): string
+    {
+        return $this->text();
+    }
+}

--- a/tests/Unit/Client/PromptsTest.php
+++ b/tests/Unit/Client/PromptsTest.php
@@ -1,0 +1,316 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Collection;
+use Laravel\Mcp\Client;
+use Laravel\Mcp\Client\Primitives\Prompt;
+use Laravel\Mcp\Client\Schema\PromptResult;
+use Laravel\Mcp\Exceptions\ClientException;
+use Tests\Fixtures\Client\FakeTransport;
+
+it('returns a collection of prompts keyed by name', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'prompts' => [
+                ['name' => 'summarize', 'description' => 'Summarizes text'],
+                ['name' => 'translate', 'description' => 'Translates text'],
+            ],
+        ],
+    ]);
+
+    $prompts = (new Client($transport))->prompts();
+
+    expect($prompts)
+        ->toBeInstanceOf(Collection::class)
+        ->toHaveCount(2)
+        ->and($prompts->keys()->all())->toBe(['summarize', 'translate'])
+        ->and($prompts['summarize'])
+        ->toBeInstanceOf(Prompt::class)
+        ->name->toBe('summarize')
+        ->description->toBe('Summarizes text')
+        ->and(json_decode($transport->sent[2], true))
+        ->toHaveKey('method', 'prompts/list')
+        ->not->toHaveKey('params');
+});
+
+it('auto-paginates prompts/list until nextCursor is absent', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'prompts' => [['name' => 'first']],
+            'nextCursor' => 'cursor-page-2',
+        ],
+    ]);
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 3,
+        'result' => [
+            'prompts' => [['name' => 'second'], ['name' => 'third']],
+        ],
+    ]);
+
+    $prompts = (new Client($transport))->prompts();
+
+    expect($prompts->keys()->all())->toBe(['first', 'second', 'third'])
+        ->and(json_decode($transport->sent[2], true))->not->toHaveKey('params')
+        ->and(json_decode($transport->sent[3], true))->toHaveKey('params.cursor', 'cursor-page-2');
+});
+
+it('stops paginating once the prompt limit is reached without fetching the next page', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'prompts' => [['name' => 'a'], ['name' => 'b'], ['name' => 'c']],
+            'nextCursor' => 'cursor-page-2',
+        ],
+    ]);
+
+    $prompts = (new Client($transport))->prompts(2);
+
+    expect($prompts->keys()->all())->toBe(['a', 'b'])
+        ->and($transport->sent)->toHaveCount(3)
+        ->and($transport->responses)->toBeEmpty();
+});
+
+it('returns no prompts without connecting when limit is zero', function (): void {
+    $transport = new FakeTransport;
+    $client = new Client($transport);
+
+    $prompts = $client->prompts(0);
+
+    expect($prompts)
+        ->toBeInstanceOf(Collection::class)
+        ->toHaveCount(0)
+        ->and($client->connected())->toBeFalse()
+        ->and($transport->sent)->toBeEmpty();
+});
+
+it('throws when the prompt limit is negative', function (): void {
+    $transport = new FakeTransport;
+
+    expect(fn (): Collection => (new Client($transport))->prompts(-1))
+        ->toThrow(ClientException::class, 'Prompt list limit must be greater than or equal to zero.')
+        ->and($transport->sent)->toBeEmpty();
+});
+
+it('throws when prompts/list does not return a prompts array', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'prompts' => 'not-an-array',
+        ],
+    ]);
+
+    expect(fn (): Collection => (new Client($transport))->prompts())
+        ->toThrow(ClientException::class, 'Invalid prompts/list response from server.');
+});
+
+it('throws when a prompt payload is not an object', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'prompts' => ['invalid'],
+        ],
+    ]);
+
+    expect(fn (): Collection => (new Client($transport))->prompts())
+        ->toThrow(ClientException::class, 'Invalid prompt payload from server.');
+});
+
+it('throws when a prompt name is missing or empty', function (array $payload): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'prompts' => [$payload],
+        ],
+    ]);
+
+    expect(fn (): Collection => (new Client($transport))->prompts())
+        ->toThrow(ClientException::class, 'Invalid prompt payload from server.');
+})->with([
+    'missing name' => [[]],
+    'empty name' => [['name' => '']],
+    'blank name' => [['name' => '   ']],
+]);
+
+it('throws when a prompt payload has a field of the wrong type', function (array $payload): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'prompts' => [array_merge(['name' => 'summarize'], $payload)],
+        ],
+    ]);
+
+    expect(fn (): Collection => (new Client($transport))->prompts())
+        ->toThrow(ClientException::class, 'Invalid prompt payload from server.');
+})->with([
+    'non-string name' => [['name' => 123]],
+    'non-string title' => [['title' => 1]],
+    'non-string description' => [['description' => []]],
+    'non-array arguments' => [['arguments' => 'none']],
+    'non-array _meta' => [['_meta' => 'meta']],
+]);
+
+it('throws when a server repeats a prompts/list cursor', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'prompts' => [['name' => 'first']],
+            'nextCursor' => 'cursor-page-2',
+        ],
+    ]);
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 3,
+        'result' => [
+            'prompts' => [['name' => 'second']],
+            'nextCursor' => 'cursor-page-2',
+        ],
+    ]);
+
+    expect(fn (): Collection => (new Client($transport))->prompts())
+        ->toThrow(ClientException::class, 'Repeated prompts/list cursor [cursor-page-2] received from server.')
+        ->and($transport->sent)->toHaveCount(4);
+});
+
+it('throws when prompts/list returns a non-string cursor', function (mixed $nextCursor): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'prompts' => [['name' => 'first']],
+            'nextCursor' => $nextCursor,
+        ],
+    ]);
+
+    expect(fn (): Collection => (new Client($transport))->prompts())
+        ->toThrow(ClientException::class, 'Invalid prompts/list cursor from server.');
+})->with([
+    'integer' => [123],
+    'array' => [[1, 2, 3]],
+]);
+
+it('sends prompts/get by name and concatenates text content', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'description' => 'A greeting prompt',
+            'messages' => [
+                ['role' => 'user', 'content' => ['type' => 'text', 'text' => 'Hello, ']],
+                ['role' => 'assistant', 'content' => ['type' => 'image', 'data' => 'base64', 'mimeType' => 'image/png']],
+                ['role' => 'user', 'content' => ['type' => 'text', 'text' => 'John!']],
+            ],
+        ],
+    ]);
+
+    $result = (new Client($transport))->getPrompt('greeting', ['name' => 'John']);
+
+    expect($result)
+        ->toBeInstanceOf(PromptResult::class)
+        ->description->toBe('A greeting prompt')
+        ->messages->toHaveCount(3)
+        ->and($result->text())->toBe('Hello, John!')
+        ->and((string) $result)->toBe('Hello, John!')
+        ->and(json_decode($transport->sent[2], true))
+        ->toHaveKey('method', 'prompts/get')
+        ->toHaveKey('params.name', 'greeting')
+        ->toHaveKey('params.arguments', ['name' => 'John']);
+});
+
+it('encodes empty prompt arguments as an object on the wire', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => ['messages' => []],
+    ]);
+
+    (new Client($transport))->getPrompt('no-args');
+
+    expect(json_decode($transport->sent[2])->params->arguments)->toBeInstanceOf(stdClass::class);
+});
+
+it('skips messages whose content is not an object when extracting text', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'messages' => [
+                ['role' => 'user', 'content' => 'plain-string'],
+                ['role' => 'user', 'content' => ['type' => 'text', 'text' => 'Hello!']],
+            ],
+        ],
+    ]);
+
+    $result = (new Client($transport))->getPrompt('greeting');
+
+    expect($result->text())->toBe('Hello!');
+});
+
+it('preserves _meta from the prompts/get response', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'messages' => [['role' => 'user', 'content' => ['type' => 'text', 'text' => 'Hi']]],
+            '_meta' => ['source' => 'cached', 'duration_ms' => 12],
+        ],
+    ]);
+
+    $result = (new Client($transport))->getPrompt('greeting');
+
+    expect($result)
+        ->meta->toBe(['source' => 'cached', 'duration_ms' => 12]);
+});
+
+it('throws when a prompts/get result has a field of the wrong type', function (array $result): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => $result,
+    ]);
+
+    expect(fn (): PromptResult => (new Client($transport))->getPrompt('greeting'))
+        ->toThrow(ClientException::class, 'Invalid prompts/get result from server.');
+})->with([
+    'non-array messages' => [['messages' => 'not-an-array']],
+    'non-string description' => [['messages' => [], 'description' => []]],
+]);

--- a/tests/Unit/Client/ToolsTest.php
+++ b/tests/Unit/Client/ToolsTest.php
@@ -201,7 +201,7 @@ it('throws when a server repeats a tools/list cursor', function (): void {
         ->and($transport->sent)->toHaveCount(4);
 });
 
-it('throws when tools/list returns a non-string cursor', function (): void {
+it('throws when tools/list returns a non-string cursor', function (mixed $nextCursor): void {
     $transport = new FakeTransport;
     $transport->responses[] = initializeResponse();
     $transport->responses[] = json_encode([
@@ -209,13 +209,16 @@ it('throws when tools/list returns a non-string cursor', function (): void {
         'id' => 2,
         'result' => [
             'tools' => [['name' => 'first']],
-            'nextCursor' => 123,
+            'nextCursor' => $nextCursor,
         ],
     ]);
 
     expect(fn (): Collection => (new Client($transport))->tools())
         ->toThrow(ClientException::class, 'Invalid tools/list cursor from server.');
-});
+})->with([
+    'integer' => [123],
+    'array' => [[1, 2, 3]],
+]);
 
 it('returns an unbound tool whose call throws until it is bound', function (): void {
     $tool = Tool::from(null, ['name' => 'say-hi', 'description' => 'Greets a person']);


### PR DESCRIPTION
Currently the MCP client can list and call tools but has no equivalent for prompts, so there's no way to discover or fetch a server's prompts from the client side.

This PR adds the prompt half, mirroring the existing tools API:

```php
// already possible
$client->tools();
$client->callTool('greeting', ['name' => 'John']);

// now also
$client->prompts();                                  // Collection<string, Prompt>
$client->getPrompt('greeting', ['name' => 'John'])->text();
```

`prompts()` paginates and honors `$limit` / the auth-fallback `$default` exactly like `tools()`, and `getPrompt()` returns a `PromptResult` whose `text()` concatenates the text content across messages.

While wiring it up I pulled the duplicated `tools/list` pagination loop (cursor cycle guard, limit handling, page validation) out of `ListTools` into a shared `PaginatesList` trait that both list methods now use, so the two can't drift. Only spec-supported methods are covered (`prompts/list`, `prompts/get`).