### PR TITLE
Add resources support to the MCP client

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -12,13 +12,17 @@ use Laravel\Mcp\Client\Exceptions\AuthorizationRequiredException;
 use Laravel\Mcp\Client\Methods\Ping;
 use Laravel\Mcp\Client\Methods\Prompts\GetPrompt;
 use Laravel\Mcp\Client\Methods\Prompts\ListPrompts;
+use Laravel\Mcp\Client\Methods\Resources\ListResources;
+use Laravel\Mcp\Client\Methods\Resources\ReadResource;
 use Laravel\Mcp\Client\Methods\Tools\CallTool;
 use Laravel\Mcp\Client\Methods\Tools\ListTools;
 use Laravel\Mcp\Client\Primitives\Prompt;
+use Laravel\Mcp\Client\Primitives\Resource;
 use Laravel\Mcp\Client\Primitives\Tool;
 use Laravel\Mcp\Client\Protocol;
 use Laravel\Mcp\Client\Schema\InitializeResult;
 use Laravel\Mcp\Client\Schema\PromptResult;
+use Laravel\Mcp\Client\Schema\ResourceReadResult;
 use Laravel\Mcp\Client\Schema\ToolResult;
 use Laravel\Mcp\Client\Transport\HttpTransport;
 use Laravel\Mcp\Client\Transport\StdioTransport;
@@ -150,6 +154,28 @@ class Client
     public function getPrompt(string $name, array $arguments = []): PromptResult
     {
         return (new GetPrompt($name, $arguments))->handle($this->protocol);
+    }
+
+    /**
+     * @param  iterable<string, Resource>|null  $default
+     * @return Collection<string, Resource>
+     */
+    public function resources(?int $limit = null, ?iterable $default = null): Collection
+    {
+        try {
+            return (new ListResources(limit: $limit))->handle($this->protocol);
+        } catch (AuthorizationRequiredException $authorizationRequiredException) {
+            if ($default === null) {
+                throw $authorizationRequiredException;
+            }
+
+            return Collection::make($default);
+        }
+    }
+
+    public function readResource(string $uri): ResourceReadResult
+    {
+        return (new ReadResource($uri))->handle($this->protocol);
     }
 
     /**

--- a/src/Client/Methods/Resources/ListResources.php
+++ b/src/Client/Methods/Resources/ListResources.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\Methods\Resources;
+
+use Illuminate\Support\Collection;
+use Laravel\Mcp\Client\Contracts\Method;
+use Laravel\Mcp\Client\Methods\Concerns\PaginatesList;
+use Laravel\Mcp\Client\Primitives\Resource;
+
+/**
+ * @implements Method<Collection<string, Resource>>
+ */
+class ListResources implements Method
+{
+    use PaginatesList;
+
+    public function __construct(?string $cursor = null, ?int $limit = null)
+    {
+        $this->cursor = $cursor;
+        $this->limit = $limit;
+    }
+
+    protected function listType(): string
+    {
+        return 'resources';
+    }
+
+    protected function nextPage(?string $cursor): static
+    {
+        return new static($cursor, $this->limit);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $payloads
+     * @return Collection<string, Resource>
+     */
+    protected function hydrate(array $payloads): Collection
+    {
+        return collect($payloads)->mapWithKeys(function (array $payload): array {
+            $resource = Resource::from($payload);
+
+            return [$resource->uri => $resource];
+        });
+    }
+}

--- a/src/Client/Methods/Resources/ReadResource.php
+++ b/src/Client/Methods/Resources/ReadResource.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\Methods\Resources;
+
+use Laravel\Mcp\Client\Contracts\Method;
+use Laravel\Mcp\Client\Protocol;
+use Laravel\Mcp\Client\Schema\ResourceReadResult;
+
+/**
+ * @implements Method<ResourceReadResult>
+ */
+class ReadResource implements Method
+{
+    public function __construct(
+        protected string $uri,
+    ) {
+        //
+    }
+
+    public function method(): string
+    {
+        return 'resources/read';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function params(): array
+    {
+        return ['uri' => $this->uri];
+    }
+
+    public function handle(Protocol $protocol): ResourceReadResult
+    {
+        return ResourceReadResult::from($protocol->dispatch($this));
+    }
+}

--- a/src/Client/Primitives/Resource.php
+++ b/src/Client/Primitives/Resource.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\Primitives;
+
+use Illuminate\Support\Arr;
+use Laravel\Mcp\Exceptions\ClientException;
+
+class Resource
+{
+    /**
+     * @param  array<string, mixed>  $annotations
+     * @param  array<string, mixed>|null  $meta
+     */
+    public function __construct(
+        public readonly string $uri,
+        public readonly string $name,
+        public readonly ?string $title,
+        public readonly ?string $description,
+        public readonly ?string $mimeType,
+        public readonly ?int $size,
+        public readonly array $annotations,
+        public readonly ?array $meta,
+    ) {
+        //
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public static function from(array $payload): self
+    {
+        $uri = Arr::get($payload, 'uri');
+        $name = Arr::get($payload, 'name');
+        $title = Arr::get($payload, 'title');
+        $description = Arr::get($payload, 'description');
+        $mimeType = Arr::get($payload, 'mimeType');
+        $size = Arr::get($payload, 'size');
+        $annotations = Arr::get($payload, 'annotations', []);
+        $meta = Arr::get($payload, '_meta');
+
+        if (! is_string($uri) || blank($uri)
+            || ! is_string($name) || blank($name)
+            || ! is_array($annotations)
+            || (! is_null($title) && ! is_string($title))
+            || (! is_null($description) && ! is_string($description))
+            || (! is_null($mimeType) && ! is_string($mimeType))
+            || (! is_null($size) && ! is_int($size))
+            || (! is_null($meta) && ! is_array($meta))) {
+            throw new ClientException('Invalid resource payload from server.');
+        }
+
+        return new self(
+            uri: $uri,
+            name: $name,
+            title: $title,
+            description: $description,
+            mimeType: $mimeType,
+            size: $size,
+            annotations: $annotations,
+            meta: $meta,
+        );
+    }
+}

--- a/src/Client/Schema/ResourceReadResult.php
+++ b/src/Client/Schema/ResourceReadResult.php
@@ -61,6 +61,7 @@ class ResourceReadResult implements Stringable
 
             if (is_string($text)) {
                 $parts[] = $text;
+
                 continue;
             }
 

--- a/src/Client/Schema/ResourceReadResult.php
+++ b/src/Client/Schema/ResourceReadResult.php
@@ -39,7 +39,20 @@ class ResourceReadResult implements Stringable
         );
     }
 
-    public function text(): string
+    public function mimeType(): ?string
+    {
+        foreach ($this->contents as $content) {
+            $mimeType = Arr::get($content, 'mimeType');
+
+            if (is_string($mimeType) && $mimeType !== '') {
+                return $mimeType;
+            }
+        }
+
+        return null;
+    }
+
+    public function content(): string
     {
         $parts = [];
 
@@ -48,27 +61,17 @@ class ResourceReadResult implements Stringable
 
             if (is_string($text)) {
                 $parts[] = $text;
-            }
-        }
-
-        return implode('', $parts);
-    }
-
-    public function blob(): string
-    {
-        $parts = [];
-
-        foreach ($this->contents as $content) {
-            $blob = Arr::get($content, 'blob');
-
-            if (! is_string($blob)) {
                 continue;
             }
 
-            $decoded = base64_decode($blob, true);
+            $blob = Arr::get($content, 'blob');
 
-            if ($decoded !== false) {
-                $parts[] = $decoded;
+            if (is_string($blob)) {
+                $decoded = base64_decode($blob, true);
+
+                if ($decoded !== false) {
+                    $parts[] = $decoded;
+                }
             }
         }
 
@@ -77,6 +80,6 @@ class ResourceReadResult implements Stringable
 
     public function __toString(): string
     {
-        return $this->text();
+        return $this->content();
     }
 }

--- a/src/Client/Schema/ResourceReadResult.php
+++ b/src/Client/Schema/ResourceReadResult.php
@@ -15,8 +15,8 @@ class ResourceReadResult implements Stringable
      * @param  array<string, mixed>|null  $meta
      */
     public function __construct(
-        public array $contents,
-        public ?array $meta = null,
+        public readonly array $contents,
+        public readonly ?array $meta = null,
     ) {
         //
     }

--- a/src/Client/Schema/ResourceReadResult.php
+++ b/src/Client/Schema/ResourceReadResult.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\Schema;
+
+use Illuminate\Support\Arr;
+use Laravel\Mcp\Exceptions\ClientException;
+use Stringable;
+
+class ResourceReadResult implements Stringable
+{
+    /**
+     * @param  array<int, array<string, mixed>>  $contents
+     * @param  array<string, mixed>|null  $meta
+     */
+    public function __construct(
+        public array $contents,
+        public ?array $meta = null,
+    ) {
+        //
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     */
+    public static function from(array $result): self
+    {
+        $contents = Arr::get($result, 'contents', []);
+        $meta = Arr::get($result, '_meta');
+
+        if (! is_array($contents)) {
+            throw new ClientException('Invalid resources/read result from server.');
+        }
+
+        return new self(
+            contents: array_values(array_filter($contents, is_array(...))),
+            meta: is_array($meta) ? $meta : null,
+        );
+    }
+
+    public function text(): string
+    {
+        $parts = [];
+
+        foreach ($this->contents as $content) {
+            $text = Arr::get($content, 'text');
+
+            if (is_string($text)) {
+                $parts[] = $text;
+            }
+        }
+
+        return implode('', $parts);
+    }
+
+    public function blob(): string
+    {
+        $parts = [];
+
+        foreach ($this->contents as $content) {
+            $blob = Arr::get($content, 'blob');
+
+            if (! is_string($blob)) {
+                continue;
+            }
+
+            $decoded = base64_decode($blob, true);
+
+            if ($decoded !== false) {
+                $parts[] = $decoded;
+            }
+        }
+
+        return implode('', $parts);
+    }
+
+    public function __toString(): string
+    {
+        return $this->text();
+    }
+}

--- a/tests/Unit/Client/ResourcesTest.php
+++ b/tests/Unit/Client/ResourcesTest.php
@@ -171,6 +171,7 @@ it('throws when a resource payload is missing a uri or name', function (array $p
     'blank uri' => [['uri' => '   ', 'name' => 'readme']],
     'missing name' => [['uri' => 'file://readme']],
     'empty name' => [['uri' => 'file://readme', 'name' => '']],
+    'blank name' => [['uri' => 'file://readme', 'name' => '   ']],
 ]);
 
 it('throws when a resource payload has a field of the wrong type', function (array $payload): void {

--- a/tests/Unit/Client/ResourcesTest.php
+++ b/tests/Unit/Client/ResourcesTest.php
@@ -283,7 +283,7 @@ it('rethrows the authorization exception for resources when no default is given'
         ->toThrow(AuthorizationRequiredException::class);
 });
 
-it('sends resources/read by uri and concatenates text content', function (): void {
+it('sends resources/read by uri and returns text content', function (): void {
     $transport = new FakeTransport;
     $transport->responses[] = initializeResponse();
     $transport->responses[] = json_encode([
@@ -302,8 +302,7 @@ it('sends resources/read by uri and concatenates text content', function (): voi
     expect($result)
         ->toBeInstanceOf(ResourceReadResult::class)
         ->contents->toHaveCount(2)
-        ->and($result->text())->toBe('Hello, world!')
-        ->and($result->blob())->toBe('')
+        ->and($result->content())->toBe('Hello, world!')
         ->and((string) $result)->toBe('Hello, world!')
         ->and(json_decode($transport->sent[2], true))
         ->toHaveKey('method', 'resources/read')
@@ -328,8 +327,39 @@ it('decodes blob content from a resources/read result', function (): void {
 
     $result = (new Client($transport))->readResource('file://logo');
 
-    expect($result->blob())->toBe('binary-data')
-        ->and($result->text())->toBe('');
+    expect($result->content())->toBe('binary-data');
+});
+
+it('returns the mime type from the first content item', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'contents' => [
+                ['uri' => 'file://logo', 'mimeType' => 'image/png', 'blob' => base64_encode('data')],
+            ],
+        ],
+    ]);
+
+    $result = (new Client($transport))->readResource('file://logo');
+
+    expect($result->mimeType())->toBe('image/png');
+});
+
+it('returns null mime type when contents are empty', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => ['contents' => []],
+    ]);
+
+    $result = (new Client($transport))->readResource('file://empty');
+
+    expect($result->mimeType())->toBeNull();
 });
 
 it('preserves _meta from the resources/read response', function (): void {
@@ -380,8 +410,7 @@ it('returns an empty result when resources/read omits contents', function (): vo
         ->toBeInstanceOf(ResourceReadResult::class)
         ->contents->toBe([])
         ->meta->toBeNull()
-        ->and($result->text())->toBe('')
-        ->and($result->blob())->toBe('')
+        ->and($result->content())->toBe('')
         ->and((string) $result)->toBe('');
 });
 
@@ -402,7 +431,7 @@ it('filters out non-array content items from a resources/read result', function 
     $result = (new Client($transport))->readResource('file://readme');
 
     expect($result->contents)->toHaveCount(1)
-        ->and($result->text())->toBe('Hi');
+        ->and($result->content())->toBe('Hi');
 });
 
 it('coerces a non-array _meta from resources/read to null', function (): void {

--- a/tests/Unit/Client/ResourcesTest.php
+++ b/tests/Unit/Client/ResourcesTest.php
@@ -1,0 +1,423 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+use Laravel\Mcp\Client;
+use Laravel\Mcp\Client\Exceptions\AuthorizationRequiredException;
+use Laravel\Mcp\Client\Primitives\Resource;
+use Laravel\Mcp\Client\Schema\ResourceReadResult;
+use Laravel\Mcp\Client\Transport\HttpTransport;
+use Laravel\Mcp\Exceptions\ClientException;
+use Tests\Fixtures\Client\FakeTransport;
+
+it('returns a collection of resources keyed by uri', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'resources' => [
+                ['uri' => 'file://readme', 'name' => 'readme', 'description' => 'The readme', 'mimeType' => 'text/plain', 'size' => 1024],
+                ['uri' => 'file://license', 'name' => 'license'],
+            ],
+        ],
+    ]);
+
+    $resources = (new Client($transport))->resources();
+
+    expect($resources)
+        ->toBeInstanceOf(Collection::class)
+        ->toHaveCount(2)
+        ->and($resources->keys()->all())->toBe(['file://readme', 'file://license'])
+        ->and($resources['file://readme'])
+        ->toBeInstanceOf(Resource::class)
+        ->uri->toBe('file://readme')
+        ->name->toBe('readme')
+        ->description->toBe('The readme')
+        ->mimeType->toBe('text/plain')
+        ->size->toBe(1024)
+        ->and($resources['file://license'])
+        ->title->toBeNull()
+        ->description->toBeNull()
+        ->mimeType->toBeNull()
+        ->size->toBeNull()
+        ->and(json_decode($transport->sent[2], true))
+        ->toHaveKey('method', 'resources/list')
+        ->not->toHaveKey('params');
+});
+
+it('auto-paginates resources/list until nextCursor is absent', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'resources' => [['uri' => 'file://first', 'name' => 'first']],
+            'nextCursor' => 'cursor-page-2',
+        ],
+    ]);
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 3,
+        'result' => [
+            'resources' => [
+                ['uri' => 'file://second', 'name' => 'second'],
+                ['uri' => 'file://third', 'name' => 'third'],
+            ],
+        ],
+    ]);
+
+    $resources = (new Client($transport))->resources();
+
+    expect($resources->keys()->all())->toBe(['file://first', 'file://second', 'file://third'])
+        ->and(json_decode($transport->sent[2], true))->not->toHaveKey('params')
+        ->and(json_decode($transport->sent[3], true))->toHaveKey('params.cursor', 'cursor-page-2');
+});
+
+it('stops paginating once the resource limit is reached without fetching the next page', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'resources' => [
+                ['uri' => 'file://a', 'name' => 'a'],
+                ['uri' => 'file://b', 'name' => 'b'],
+                ['uri' => 'file://c', 'name' => 'c'],
+            ],
+            'nextCursor' => 'cursor-page-2',
+        ],
+    ]);
+
+    $resources = (new Client($transport))->resources(2);
+
+    expect($resources->keys()->all())->toBe(['file://a', 'file://b'])
+        ->and($transport->sent)->toHaveCount(3)
+        ->and($transport->responses)->toBeEmpty();
+});
+
+it('returns no resources without connecting when limit is zero', function (): void {
+    $transport = new FakeTransport;
+    $client = new Client($transport);
+
+    $resources = $client->resources(0);
+
+    expect($resources)
+        ->toBeInstanceOf(Collection::class)
+        ->toHaveCount(0)
+        ->and($client->connected())->toBeFalse()
+        ->and($transport->sent)->toBeEmpty();
+});
+
+it('throws when the resource limit is negative', function (): void {
+    $transport = new FakeTransport;
+
+    expect(fn (): Collection => (new Client($transport))->resources(-1))
+        ->toThrow(ClientException::class, 'Resource list limit must be greater than or equal to zero.')
+        ->and($transport->sent)->toBeEmpty();
+});
+
+it('throws when resources/list does not return a resources array', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'resources' => 'not-an-array',
+        ],
+    ]);
+
+    expect(fn (): Collection => (new Client($transport))->resources())
+        ->toThrow(ClientException::class, 'Invalid resources/list response from server.');
+});
+
+it('throws when a resource payload is not an object', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'resources' => ['invalid'],
+        ],
+    ]);
+
+    expect(fn (): Collection => (new Client($transport))->resources())
+        ->toThrow(ClientException::class, 'Invalid resource payload from server.');
+});
+
+it('throws when a resource payload is missing a uri or name', function (array $payload): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'resources' => [$payload],
+        ],
+    ]);
+
+    expect(fn (): Collection => (new Client($transport))->resources())
+        ->toThrow(ClientException::class, 'Invalid resource payload from server.');
+})->with([
+    'missing uri' => [['name' => 'readme']],
+    'empty uri' => [['uri' => '', 'name' => 'readme']],
+    'blank uri' => [['uri' => '   ', 'name' => 'readme']],
+    'missing name' => [['uri' => 'file://readme']],
+    'empty name' => [['uri' => 'file://readme', 'name' => '']],
+]);
+
+it('throws when a resource payload has a field of the wrong type', function (array $payload): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'resources' => [array_merge(['uri' => 'file://readme', 'name' => 'readme'], $payload)],
+        ],
+    ]);
+
+    expect(fn (): Collection => (new Client($transport))->resources())
+        ->toThrow(ClientException::class, 'Invalid resource payload from server.');
+})->with([
+    'non-string title' => [['title' => 1]],
+    'non-string description' => [['description' => []]],
+    'non-string mimeType' => [['mimeType' => 1]],
+    'non-int size' => [['size' => 'big']],
+    'non-array annotations' => [['annotations' => 'none']],
+    'non-array _meta' => [['_meta' => 'meta']],
+]);
+
+it('preserves title, annotations and _meta on a resource', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'resources' => [[
+                'uri' => 'file://readme',
+                'name' => 'readme',
+                'title' => 'Readme',
+                'annotations' => ['audience' => ['user']],
+                '_meta' => ['source' => 'cached'],
+            ]],
+        ],
+    ]);
+
+    $resource = (new Client($transport))->resources()['file://readme'];
+
+    expect($resource)
+        ->title->toBe('Readme')
+        ->annotations->toBe(['audience' => ['user']])
+        ->meta->toBe(['source' => 'cached']);
+});
+
+it('throws when a server repeats a resources/list cursor', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'resources' => [['uri' => 'file://first', 'name' => 'first']],
+            'nextCursor' => 'cursor-page-2',
+        ],
+    ]);
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 3,
+        'result' => [
+            'resources' => [['uri' => 'file://second', 'name' => 'second']],
+            'nextCursor' => 'cursor-page-2',
+        ],
+    ]);
+
+    expect(fn (): Collection => (new Client($transport))->resources())
+        ->toThrow(ClientException::class, 'Repeated resources/list cursor [cursor-page-2] received from server.')
+        ->and($transport->sent)->toHaveCount(4);
+});
+
+it('throws when resources/list returns a non-string cursor', function (mixed $nextCursor): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'resources' => [['uri' => 'file://first', 'name' => 'first']],
+            'nextCursor' => $nextCursor,
+        ],
+    ]);
+
+    expect(fn (): Collection => (new Client($transport))->resources())
+        ->toThrow(ClientException::class, 'Invalid resources/list cursor from server.');
+})->with([
+    'integer' => [123],
+    'array' => [[1, 2, 3]],
+]);
+
+it('returns the given default when authorization is required for resources', function (): void {
+    Http::fake([
+        'https://mcp.test/mcp' => Http::response('', 401),
+    ]);
+
+    $resources = (new Client(new HttpTransport('https://mcp.test/mcp')))->resources(default: []);
+
+    expect($resources)->toBeInstanceOf(Collection::class)->toBeEmpty();
+});
+
+it('rethrows the authorization exception for resources when no default is given', function (): void {
+    Http::fake([
+        'https://mcp.test/mcp' => Http::response('', 401),
+    ]);
+
+    expect(fn (): Collection => (new Client(new HttpTransport('https://mcp.test/mcp')))->resources())
+        ->toThrow(AuthorizationRequiredException::class);
+});
+
+it('sends resources/read by uri and concatenates text content', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'contents' => [
+                ['uri' => 'file://readme', 'mimeType' => 'text/plain', 'text' => 'Hello, '],
+                ['uri' => 'file://readme', 'mimeType' => 'text/plain', 'text' => 'world!'],
+            ],
+        ],
+    ]);
+
+    $result = (new Client($transport))->readResource('file://readme');
+
+    expect($result)
+        ->toBeInstanceOf(ResourceReadResult::class)
+        ->contents->toHaveCount(2)
+        ->and($result->text())->toBe('Hello, world!')
+        ->and($result->blob())->toBe('')
+        ->and((string) $result)->toBe('Hello, world!')
+        ->and(json_decode($transport->sent[2], true))
+        ->toHaveKey('method', 'resources/read')
+        ->toHaveKey('params.uri', 'file://readme');
+});
+
+it('decodes blob content from a resources/read result', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'contents' => [
+                ['uri' => 'file://logo', 'mimeType' => 'image/png', 'blob' => base64_encode('binary-')],
+                ['uri' => 'file://logo', 'mimeType' => 'image/png', 'blob' => 'not-valid-base64!!'],
+                ['uri' => 'file://logo', 'mimeType' => 'image/png', 'blob' => 123],
+                ['uri' => 'file://logo', 'mimeType' => 'image/png', 'blob' => base64_encode('data')],
+            ],
+        ],
+    ]);
+
+    $result = (new Client($transport))->readResource('file://logo');
+
+    expect($result->blob())->toBe('binary-data')
+        ->and($result->text())->toBe('');
+});
+
+it('preserves _meta from the resources/read response', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'contents' => [['uri' => 'file://readme', 'text' => 'Hi']],
+            '_meta' => ['source' => 'cached', 'duration_ms' => 12],
+        ],
+    ]);
+
+    $result = (new Client($transport))->readResource('file://readme');
+
+    expect($result)
+        ->meta->toBe(['source' => 'cached', 'duration_ms' => 12]);
+});
+
+it('throws when a resources/read result has a non-array contents field', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'contents' => 'not-an-array',
+        ],
+    ]);
+
+    expect(fn (): ResourceReadResult => (new Client($transport))->readResource('file://readme'))
+        ->toThrow(ClientException::class, 'Invalid resources/read result from server.');
+});
+
+it('returns an empty result when resources/read omits contents', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [],
+    ]);
+
+    $result = (new Client($transport))->readResource('file://empty');
+
+    expect($result)
+        ->toBeInstanceOf(ResourceReadResult::class)
+        ->contents->toBe([])
+        ->meta->toBeNull()
+        ->and($result->text())->toBe('')
+        ->and($result->blob())->toBe('')
+        ->and((string) $result)->toBe('');
+});
+
+it('filters out non-array content items from a resources/read result', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'contents' => [
+                'not-an-object',
+                ['uri' => 'file://readme', 'text' => 'Hi'],
+            ],
+        ],
+    ]);
+
+    $result = (new Client($transport))->readResource('file://readme');
+
+    expect($result->contents)->toHaveCount(1)
+        ->and($result->text())->toBe('Hi');
+});
+
+it('coerces a non-array _meta from resources/read to null', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'contents' => [['uri' => 'file://readme', 'text' => 'Hi']],
+            '_meta' => 'not-an-object',
+        ],
+    ]);
+
+    $result = (new Client($transport))->readResource('file://readme');
+
+    expect($result->meta)->toBeNull();
+});


### PR DESCRIPTION
Currently the MCP client can list/call tools and list/get prompts, but there's no way to read a server's resources. This PR adds that, mirroring the existing tools and prompts surface.

```php
$client = Mcp::client('everything')->connect();

// list (paginated, keyed by uri), with the same auth-fallback as tools()/prompts()
$resources = $client->resources();
$resources = $client->resources(limit: 50, default: []);

// read — content() returns text as-is or decoded blob bytes depending on the item type
$result = $client->readResource('file://readme');
$result->content();   // string (text or decoded binary)
$result->mimeType();  // "text/plain", "image/png", etc. — use this to decide what to do with it
(string) $result;     // same as content()
```

Scope matches what the package server exposes: `resources/list` and `resources/read` only (no templates, no subscribe/unsubscribe). The list collection is keyed by URI since that's the identifier you read by.