### PR TITLE
feat: automatically convert model not found exceptions to proper error messages

### DIFF
--- a/src/Server/Methods/CallTool.php
+++ b/src/Server/Methods/CallTool.php
@@ -8,6 +8,7 @@ use Generator;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Container\Container;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
 use Laravel\Mcp\Exceptions\JsonRpcException;
 use Laravel\Mcp\Response;
@@ -53,8 +54,12 @@ class CallTool implements Errable, Method
         try {
             // @phpstan-ignore-next-line
             $response = Container::getInstance()->call([$tool, 'handle']);
-        } catch (AuthenticationException|AuthorizationException $authException) {
-            $response = Response::error($authException->getMessage());
+        } catch (
+            AuthenticationException|
+            AuthorizationException|
+            ModelNotFoundException $exception
+        ) {
+            $response = Response::error($exception->getMessage());
         } catch (ValidationException $validationException) {
             $response = Response::error(ValidationMessages::from($validationException));
         }

--- a/src/Server/Methods/CompletionComplete.php
+++ b/src/Server/Methods/CompletionComplete.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laravel\Mcp\Server\Methods;
 
 use Illuminate\Container\Container;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use Laravel\Mcp\Exceptions\JsonRpcException;
@@ -74,7 +75,11 @@ class CompletionComplete implements Method
 
         $contextArguments = Arr::get($request->get('context'), 'arguments', []);
 
-        $result = $this->invokeCompletion($primitive, $argumentName, $argumentValue, $contextArguments);
+        try {
+            $result = $this->invokeCompletion($primitive, $argumentName, $argumentValue, $contextArguments);
+        } catch (ModelNotFoundException) {
+            $result = CompletionResponse::empty();
+        }
 
         return JsonRpcResponse::result($request->id, [
             'completion' => $result->toArray(),

--- a/src/Server/Methods/Concerns/InteractsWithResponses.php
+++ b/src/Server/Methods/Concerns/InteractsWithResponses.php
@@ -7,6 +7,7 @@ namespace Laravel\Mcp\Server\Methods\Concerns;
 use Generator;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Arr;
 use Illuminate\Validation\ValidationException;
 use InvalidArgumentException;
@@ -66,18 +67,15 @@ trait InteractsWithResponses
 
                 $pendingResponses[] = $response;
             }
-        } catch (AuthenticationException|AuthorizationException $authException) {
+        } catch (
+            AuthenticationException|
+            AuthorizationException|
+            ModelNotFoundException|
+            ValidationException $exception
+        ) {
             yield $this->toJsonRpcResponse(
                 $request,
-                Response::error($authException->getMessage()),
-                $serializable,
-            );
-
-            return;
-        } catch (ValidationException $validationException) {
-            yield $this->toJsonRpcResponse(
-                $request,
-                Response::error($validationException->getMessage()),
+                Response::error($exception->getMessage()),
                 $serializable,
             );
 

--- a/src/Server/Methods/GetPrompt.php
+++ b/src/Server/Methods/GetPrompt.php
@@ -6,6 +6,7 @@ namespace Laravel\Mcp\Server\Methods;
 
 use Generator;
 use Illuminate\Container\Container;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
 use InvalidArgumentException;
 use Laravel\Mcp\Exceptions\JsonRpcException;
@@ -41,6 +42,8 @@ class GetPrompt implements Method
             $response = Container::getInstance()->call([$prompt, 'handle']);
         } catch (ValidationException $validationException) {
             $response = Response::error('Invalid params: '.ValidationMessages::from($validationException));
+        } catch (ModelNotFoundException $modelNotFoundException) {
+            $response = Response::error($modelNotFoundException->getMessage());
         }
 
         return is_iterable($response)

--- a/src/Server/Methods/ReadResource.php
+++ b/src/Server/Methods/ReadResource.php
@@ -7,6 +7,7 @@ namespace Laravel\Mcp\Server\Methods;
 use Generator;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Validation\ValidationException;
 use InvalidArgumentException;
 use Laravel\Mcp\Exceptions\JsonRpcException;
@@ -48,6 +49,8 @@ class ReadResource implements Method
             $response = $this->invokeResource($resource, $uri);
         } catch (ValidationException $validationException) {
             $response = Response::error('Invalid params: '.ValidationMessages::from($validationException));
+        } catch (ModelNotFoundException $modelNotFoundException) {
+            $response = Response::error($modelNotFoundException->getMessage());
         }
 
         return is_iterable($response)
@@ -57,6 +60,7 @@ class ReadResource implements Method
 
     /**
      * @throws BindingResolutionException
+     * @throws ModelNotFoundException
      * @throws ValidationException
      */
     protected function invokeResource(Resource $resource, string $uri): mixed

--- a/tests/Unit/Methods/CallToolTest.php
+++ b/tests/Unit/Methods/CallToolTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Laravel\Mcp\Exceptions\JsonRpcException;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
@@ -407,6 +408,134 @@ it('returns a valid call tool response with authentication error from generator 
                 [
                     'type' => 'text',
                     'text' => 'Unauthenticated.',
+                ],
+            ],
+            'isError' => true,
+        ]);
+});
+
+it('returns a valid call tool response with model not found error', function (): void {
+    $tool = new class extends Tool
+    {
+        protected string $description = 'Model not found tool';
+
+        public function handle(Request $request): Response
+        {
+            throw new ModelNotFoundException('No query results for model [App\Models\Post].');
+        }
+
+        public function schema(JsonSchema $schema): array
+        {
+            return [];
+        }
+    };
+
+    $toolClass = $tool::class;
+    $this->instance($toolClass, $tool);
+
+    $request = JsonRpcRequest::from([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => $tool->name(),
+            'arguments' => [],
+        ],
+    ]);
+
+    $context = new ServerContext(
+        supportedProtocolVersions: ['2025-03-26'],
+        serverCapabilities: [],
+        implementation: new Implementation('Test Server', '1.0.0'),
+        instructions: 'Test instructions',
+        maxPaginationLength: 50,
+        defaultPaginationLength: 10,
+        tools: [$toolClass],
+        resources: [],
+        prompts: [],
+    );
+
+    $method = new CallTool;
+
+    $this->instance('mcp.request', $request->toRequest());
+    $response = $method->handle($request, $context);
+
+    expect($response)->toBeInstanceOf(JsonRpcResponse::class);
+
+    $payload = $response->toArray();
+
+    expect($payload['id'])->toEqual(1)
+        ->and($payload['result'])->toEqual([
+            'content' => [
+                [
+                    'type' => 'text',
+                    'text' => 'No query results for model [App\Models\Post].',
+                ],
+            ],
+            'isError' => true,
+        ]);
+});
+
+it('returns a valid call tool response with model not found error from generator tool', function (): void {
+    $tool = new class extends Tool
+    {
+        protected string $description = 'Model not found generator tool';
+
+        public function handle(Request $request): Generator
+        {
+            yield Response::text('Starting...');
+
+            throw new ModelNotFoundException('No query results for model [App\Models\User] 42.');
+        }
+
+        public function schema(JsonSchema $schema): array
+        {
+            return [];
+        }
+    };
+
+    $toolClass = $tool::class;
+    $this->instance($toolClass, $tool);
+
+    $request = JsonRpcRequest::from([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => $tool->name(),
+            'arguments' => [],
+        ],
+    ]);
+
+    $context = new ServerContext(
+        supportedProtocolVersions: ['2025-03-26'],
+        serverCapabilities: [],
+        implementation: new Implementation('Test Server', '1.0.0'),
+        instructions: 'Test instructions',
+        maxPaginationLength: 50,
+        defaultPaginationLength: 10,
+        tools: [$toolClass],
+        resources: [],
+        prompts: [],
+    );
+
+    $method = new CallTool;
+
+    $this->instance('mcp.request', $request->toRequest());
+    $responses = $method->handle($request, $context);
+
+    $results = iterator_to_array($responses);
+
+    expect($results)->toHaveCount(1);
+
+    $payload = $results[0]->toArray();
+
+    expect($payload['id'])->toEqual(1)
+        ->and($payload['result'])->toEqual([
+            'content' => [
+                [
+                    'type' => 'text',
+                    'text' => 'No query results for model [App\Models\User] 42.',
                 ],
             ],
             'isError' => true,


### PR DESCRIPTION
Hello!

This allows users to use `::findOrFail` directly so that proper errors are returned instead of the generic "Something went wrong" message


Thanks!