### PR TITLE
Add withHeaders() to the MCP web client for custom request headers

### DIFF
--- a/src/Client/Transport/HttpTransport.php
+++ b/src/Client/Transport/HttpTransport.php
@@ -23,6 +23,9 @@ class HttpTransport implements Transport
     /** @var string|(Closure(): string)|null */
     protected string|Closure|null $token = null;
 
+    /** @var array<string, string|(Closure(): string)> */
+    protected array $headers = [];
+
     protected ?string $sessionId = null;
 
     protected bool $initialized = false;
@@ -62,6 +65,21 @@ class HttpTransport implements Transport
         $this->token = $token;
     }
 
+    /**
+     * Add custom headers sent with every request.
+     *
+     * Reserved protocol headers (Accept, MCP-Session-Id, MCP-Protocol-Version) and
+     * the bearer token always take precedence and cannot be overridden, regardless
+     * of header-name casing. Values are persisted in the serialized recipe like the
+     * bearer token, so treat any secret they carry accordingly.
+     *
+     * @param  array<string, string|(Closure(): string)>  $headers
+     */
+    public function withHeaders(array $headers): void
+    {
+        $this->headers = array_merge($this->headers, $headers);
+    }
+
     public function url(): string
     {
         return $this->url;
@@ -72,10 +90,17 @@ class HttpTransport implements Transport
      */
     public function recipe(): array
     {
+        $headers = [];
+
+        foreach ($this->headers as $key => $value) {
+            $headers[$key] = $value instanceof Closure ? (string) $value() : $value;
+        }
+
         return [
             'driver' => 'http',
             'url' => $this->url,
             'token' => $this->token instanceof Closure ? (string) ($this->token)() : $this->token,
+            'headers' => $headers,
             'timeoutSeconds' => $this->timeoutSeconds,
         ];
     }
@@ -155,9 +180,25 @@ class HttpTransport implements Transport
      */
     protected function headers(): array
     {
-        $headers = [
-            'Accept' => 'application/json, text/event-stream',
-        ];
+        $reserved = ['accept', 'mcp-session-id', 'mcp-protocol-version'];
+
+        $token = $this->token instanceof Closure ? (string) ($this->token)() : $this->token;
+
+        if ($token !== null && $token !== '') {
+            $reserved[] = 'authorization';
+        }
+
+        $headers = [];
+
+        foreach ($this->headers as $key => $value) {
+            if (in_array(strtolower($key), $reserved, true)) {
+                continue;
+            }
+
+            $headers[$key] = $value instanceof Closure ? (string) $value() : $value;
+        }
+
+        $headers['Accept'] = 'application/json, text/event-stream';
 
         if ($this->sessionId !== null) {
             $headers['MCP-Session-Id'] = $this->sessionId;
@@ -166,8 +207,6 @@ class HttpTransport implements Transport
         if ($this->initialized) {
             $headers['MCP-Protocol-Version'] = ProtocolVersion::LATEST->value;
         }
-
-        $token = $this->token instanceof Closure ? (string) ($this->token)() : $this->token;
 
         if ($token !== null && $token !== '') {
             $headers['Authorization'] = "Bearer {$token}";

--- a/src/Client/Transport/TransportFactory.php
+++ b/src/Client/Transport/TransportFactory.php
@@ -60,6 +60,13 @@ class TransportFactory
             $transport->withToken($token);
         }
 
+        $headers = Arr::get($recipe, 'headers');
+
+        if (is_array($headers)) {
+            /** @var array<string, string> $headers */
+            $transport->withHeaders($headers);
+        }
+
         self::applyTimeout($transport, $recipe);
 
         return $transport;

--- a/src/WebClient.php
+++ b/src/WebClient.php
@@ -32,6 +32,22 @@ class WebClient extends Client
         return $this;
     }
 
+    /**
+     * Add custom headers sent with every request.
+     *
+     * Reserved protocol headers and the bearer token always take precedence,
+     * regardless of casing. Values are persisted in the serialized recipe like the
+     * bearer token.
+     *
+     * @param  array<string, string|(Closure(): string)>  $headers
+     */
+    public function withHeaders(array $headers): static
+    {
+        $this->httpTransport->withHeaders($headers);
+
+        return $this;
+    }
+
     public function withOAuth(
         ?string $clientId = null,
         ?string $clientSecret = null,

--- a/tests/Unit/Client/Transport/HttpTransportTest.php
+++ b/tests/Unit/Client/Transport/HttpTransportTest.php
@@ -129,6 +129,137 @@ it('sends a bearer Authorization header when a token is set', function (): void 
     Http::assertSent(fn ($request): bool => $request->hasHeader('Authorization', 'Bearer secret-token'));
 });
 
+it('sends custom headers set via withHeaders', function (): void {
+    Http::fake(['*' => Http::response(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => []]), 200, ['Content-Type' => 'application/json'])]);
+
+    $transport = new HttpTransport('https://mcp.test/mcp');
+    $transport->withHeaders(['X-Tenant' => 'acme']);
+    $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'ping', 'params' => []]));
+
+    Http::assertSent(fn ($request): bool => $request->hasHeader('X-Tenant', 'acme'));
+});
+
+it('sends a custom Authorization header verbatim without a Bearer prefix', function (): void {
+    Http::fake(['*' => Http::response(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => []]), 200, ['Content-Type' => 'application/json'])]);
+
+    $transport = new HttpTransport('https://mcp.test/mcp');
+    $transport->withHeaders(['Authorization' => 'Key raw-api-key']);
+    $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'ping', 'params' => []]));
+
+    Http::assertSent(fn ($request): bool => $request->hasHeader('Authorization', 'Key raw-api-key'));
+});
+
+it('lets a bearer token take precedence over a custom Authorization header', function (): void {
+    Http::fake(['*' => Http::response(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => []]), 200, ['Content-Type' => 'application/json'])]);
+
+    $transport = new HttpTransport('https://mcp.test/mcp');
+    $transport->withHeaders(['Authorization' => 'Key raw-api-key']);
+    $transport->withToken('secret-token');
+    $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'ping', 'params' => []]));
+
+    Http::assertSent(fn ($request): bool => $request->hasHeader('Authorization', 'Bearer secret-token'));
+});
+
+it('does not let custom headers override the protocol Accept header', function (): void {
+    Http::fake(['*' => Http::response(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => []]), 200, ['Content-Type' => 'application/json'])]);
+
+    $transport = new HttpTransport('https://mcp.test/mcp');
+    $transport->withHeaders(['Accept' => 'text/plain']);
+    $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'ping', 'params' => []]));
+
+    Http::assertSent(fn ($request): bool => $request->hasHeader('Accept', 'application/json, text/event-stream'));
+});
+
+it('sends custom headers configured via Client::web', function (): void {
+    Http::fakeSequence()
+        ->push(json_encode([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'result' => [
+                'protocolVersion' => ProtocolVersion::LATEST->value,
+                'capabilities' => new stdClass,
+                'serverInfo' => ['name' => 'Test Server', 'version' => '1.0.0'],
+            ],
+        ]), 200, ['Content-Type' => 'application/json', 'MCP-Session-Id' => 'session-hdr'])
+        ->push('', 202)
+        ->push(json_encode([
+            'jsonrpc' => '2.0',
+            'id' => 2,
+            'result' => ['tools' => [['name' => 'add', 'description' => 'Adds two numbers']]],
+        ]), 200, ['Content-Type' => 'application/json'])
+        ->whenEmpty(Http::response('', 202));
+
+    Client::web('https://mcp.test/mcp')
+        ->withHeaders(['Authorization' => 'Key raw-api-key'])
+        ->tools();
+
+    Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'tools/list' && $request->hasHeader('Authorization', 'Key raw-api-key'));
+});
+
+it('lets a bearer token take precedence over a lower-cased custom authorization header', function (): void {
+    Http::fake(['*' => Http::response(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => []]), 200, ['Content-Type' => 'application/json'])]);
+
+    $transport = new HttpTransport('https://mcp.test/mcp');
+    $transport->withHeaders(['authorization' => 'Key raw-api-key']);
+    $transport->withToken('secret-token');
+    $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'ping', 'params' => []]));
+
+    Http::assertSent(fn ($request): bool => $request->hasHeader('Authorization', 'Bearer secret-token')
+        && ! $request->hasHeader('Authorization', 'Key raw-api-key'));
+});
+
+it('does not let a lower-cased custom accept header double up the protocol Accept', function (): void {
+    Http::fake(['*' => Http::response(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => []]), 200, ['Content-Type' => 'application/json'])]);
+
+    $transport = new HttpTransport('https://mcp.test/mcp');
+    $transport->withHeaders(['accept' => 'text/plain']);
+    $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'ping', 'params' => []]));
+
+    Http::assertSent(fn ($request): bool => $request->hasHeader('Accept', 'application/json, text/event-stream')
+        && ! $request->hasHeader('Accept', 'text/plain'));
+});
+
+it('ignores attempts to set protocol-managed headers via withHeaders', function (): void {
+    Http::fake(['*' => Http::response(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => []]), 200, ['Content-Type' => 'application/json'])]);
+
+    $transport = new HttpTransport('https://mcp.test/mcp');
+    $transport->withHeaders(['mcp-session-id' => 'forged', 'MCP-Protocol-Version' => 'forged']);
+    $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'initialize', 'params' => []]));
+
+    Http::assertSent(fn ($request): bool => ! $request->hasHeader('MCP-Session-Id', 'forged')
+        && ! $request->hasHeader('MCP-Protocol-Version', 'forged'));
+});
+
+it('accumulates headers across multiple withHeaders calls with later values winning', function (): void {
+    Http::fake(['*' => Http::response(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => []]), 200, ['Content-Type' => 'application/json'])]);
+
+    $transport = new HttpTransport('https://mcp.test/mcp');
+    $transport->withHeaders(['X-A' => '1', 'X-B' => '2']);
+    $transport->withHeaders(['X-B' => '3', 'X-C' => '4']);
+    $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'ping', 'params' => []]));
+
+    Http::assertSent(fn ($request): bool => $request->hasHeader('X-A', '1')
+        && $request->hasHeader('X-B', '3')
+        && $request->hasHeader('X-C', '4'));
+});
+
+it('resolves closure header values on each request', function (): void {
+    Http::fake(['*' => Http::response(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => []]), 200, ['Content-Type' => 'application/json'])]);
+
+    $transport = new HttpTransport('https://mcp.test/mcp');
+    $transport->withHeaders(['Authorization' => fn (): string => 'Key '.'lazy-key']);
+    $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'ping', 'params' => []]));
+
+    Http::assertSent(fn ($request): bool => $request->hasHeader('Authorization', 'Key lazy-key'));
+});
+
+it('resolves closure header values when serializing the recipe', function (): void {
+    $transport = new HttpTransport('https://mcp.test/mcp');
+    $transport->withHeaders(['Authorization' => fn (): string => 'Key lazy-key']);
+
+    expect($transport->recipe()['headers'])->toBe(['Authorization' => 'Key lazy-key']);
+});
+
 it('throws a ClientException and resets the session on a 404 response', function (): void {
     Http::fakeSequence()
         ->push(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => []]), 200, ['Content-Type' => 'application/json', 'MCP-Session-Id' => 'session-xyz'])

--- a/tests/Unit/Client/Transport/TransportFactoryTest.php
+++ b/tests/Unit/Client/Transport/TransportFactoryTest.php
@@ -37,6 +37,43 @@ it('rebuilds an http transport with its token and timeout from a recipe', functi
             'driver' => 'http',
             'url' => 'https://mcp.test/mcp',
             'token' => 'tok',
+            'headers' => [],
+            'timeoutSeconds' => 7.5,
+        ]);
+});
+
+it('rebuilds an http transport with custom headers from a recipe', function (): void {
+    $source = new HttpTransport('https://mcp.test/mcp');
+    $source->withHeaders(['Authorization' => 'Key abc123', 'X-Tenant' => 'acme']);
+
+    $transport = TransportFactory::fromRecipe($source->recipe());
+
+    expect($transport)
+        ->toBeInstanceOf(HttpTransport::class)
+        ->and($transport->recipe())->toBe([
+            'driver' => 'http',
+            'url' => 'https://mcp.test/mcp',
+            'token' => null,
+            'headers' => ['Authorization' => 'Key abc123', 'X-Tenant' => 'acme'],
+            'timeoutSeconds' => 30.0,
+        ]);
+});
+
+it('rebuilds an http transport from a legacy recipe without a headers key', function (): void {
+    $transport = TransportFactory::fromRecipe([
+        'driver' => 'http',
+        'url' => 'https://mcp.test/mcp',
+        'token' => 'tok',
+        'timeoutSeconds' => 7.5,
+    ]);
+
+    expect($transport)
+        ->toBeInstanceOf(HttpTransport::class)
+        ->and($transport->recipe())->toBe([
+            'driver' => 'http',
+            'url' => 'https://mcp.test/mcp',
+            'token' => 'tok',
+            'headers' => [],
             'timeoutSeconds' => 7.5,
         ]);
 });


### PR DESCRIPTION
This adds a `withHeaders()` method to the MCP web client so callers can send custom HTTP headers with each request.

### Why

Today the streamable-HTTP client only supports authentication via `withToken()`, which always emits `Authorization: Bearer {token}`. That doesn't cover MCP servers that require:

- a **raw `Authorization` header** (e.g. an API key sent with no `Bearer` prefix), or
- **additional custom headers** such as a tenant id or an API-version pin.

There's currently no public way to set these, so those servers can't be reached at all. For example, Stedi's healthcare MCP server documents `Authorization: <api-key>` with no scheme prefix — `withToken()` produces `Bearer <api-key>`, which the server rejects.

### Usage

```php
use Laravel\Mcp\Client;

$tools = Client::web('https://mcp.example.com/mcp')
    ->withHeaders([
        'Authorization' => 'Key '.$apiKey,        // sent verbatim, no Bearer prefix
        'X-Tenant' => 'acme',
        'X-Signature' => fn (): string => sign(), // lazily resolved per request
    ])
    ->tools();
```

### Behavior & precedence

- Custom headers are the base set. The transport's protocol-managed headers (`Accept`, `MCP-Session-Id`, `MCP-Protocol-Version`) always take precedence and cannot be clobbered — **case-insensitively**, so a lowercase `accept` or `mcp-session-id` can't slip a duplicate value onto the wire.
- If a bearer token is also set via `withToken()`, its `Authorization: Bearer …` wins over a custom `Authorization` (any casing), so the two auth paths never conflict. When no token is set, a custom `Authorization` header is sent verbatim.
- Header values accept `string` or `Closure(): string`, mirroring `withToken()` — useful for request signing or resolving a secret lazily. Closures are resolved on each request and when serializing the recipe.
- Headers are re-applied when a transport is rebuilt from its `recipe()` — e.g. anonymous clients serialized into queued jobs, and named clients (which the factory rebuilds on each `build()`). As with the bearer token, resolved header values are persisted in the recipe, so treat any secret they carry accordingly (documented on the method).

### No breaking changes

Purely additive: `withHeaders()` is new, and behavior is unchanged when it isn't called. The transport `recipe()` gains an additive `headers` key; recipes serialized before this change (without the key) rebuild safely.

### Tests

Added coverage in `HttpTransportTest`:
- custom header sent; raw `Authorization` without a `Bearer` prefix; bearer-token precedence over a custom `Authorization` (canonical **and** lowercase casing); lowercase `accept` not doubling the protocol header; protocol-managed headers (`mcp-session-id`, `MCP-Protocol-Version`) cannot be injected via `withHeaders`; accumulation across multiple `withHeaders()` calls; closure header values resolved per request and when serializing the recipe; an end-to-end fluent test through `Client::web`.

And in `TransportFactoryTest`: headers round-trip via the recipe, plus a legacy recipe (no `headers` key) rebuilding safely.

The full suite passes (958 tests), with Pint and PHPStan clean.
