### PR TITLE
Add withHeaders() to the MCP web client

### DIFF
--- a/src/Client/Transport/HttpTransport.php
+++ b/src/Client/Transport/HttpTransport.php
@@ -29,6 +29,9 @@ class HttpTransport implements Transport
 
     protected float $timeoutSeconds = 30.0;
 
+    /** @var array<string, string> */
+    protected array $customHeaders = [];
+
     /** @var array<int, string> */
     protected array $queue = [];
 
@@ -62,6 +65,14 @@ class HttpTransport implements Transport
         $this->token = $token;
     }
 
+    /**
+     * @param  array<string, string>  $headers
+     */
+    public function withHeaders(array $headers): void
+    {
+        $this->customHeaders = array_merge($this->customHeaders, $headers);
+    }
+
     public function url(): string
     {
         return $this->url;
@@ -76,6 +87,7 @@ class HttpTransport implements Transport
             'driver' => 'http',
             'url' => $this->url,
             'token' => $this->token instanceof Closure ? (string) ($this->token)() : $this->token,
+            'headers' => $this->customHeaders,
             'timeoutSeconds' => $this->timeoutSeconds,
         ];
     }
@@ -171,6 +183,16 @@ class HttpTransport implements Transport
 
         if ($token !== null && $token !== '') {
             $headers['Authorization'] = "Bearer {$token}";
+        }
+
+        foreach ($this->customHeaders as $name => $value) {
+            foreach (array_keys($headers) as $existing) {
+                if (strcasecmp($existing, $name) === 0) {
+                    unset($headers[$existing]);
+                }
+            }
+
+            $headers[$name] = $value;
         }
 
         return $headers;

--- a/src/Client/Transport/TransportFactory.php
+++ b/src/Client/Transport/TransportFactory.php
@@ -60,6 +60,13 @@ class TransportFactory
             $transport->withToken($token);
         }
 
+        $headers = Arr::get($recipe, 'headers');
+
+        if (is_array($headers)) {
+            /** @var array<string, string> $headers */
+            $transport->withHeaders($headers);
+        }
+
         self::applyTimeout($transport, $recipe);
 
         return $transport;

--- a/src/WebClient.php
+++ b/src/WebClient.php
@@ -32,6 +32,16 @@ class WebClient extends Client
         return $this;
     }
 
+    /**
+     * @param  array<string, string>  $headers
+     */
+    public function withHeaders(array $headers): static
+    {
+        $this->httpTransport->withHeaders($headers);
+
+        return $this;
+    }
+
     public function withOAuth(
         ?string $clientId = null,
         ?string $clientSecret = null,

--- a/tests/Unit/Client/Transport/HttpTransportTest.php
+++ b/tests/Unit/Client/Transport/HttpTransportTest.php
@@ -129,6 +129,90 @@ it('sends a bearer Authorization header when a token is set', function (): void 
     Http::assertSent(fn ($request): bool => $request->hasHeader('Authorization', 'Bearer secret-token'));
 });
 
+it('sends custom headers alongside the default headers', function (): void {
+    Http::fake(['*' => Http::response(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => []]), 200, ['Content-Type' => 'application/json'])]);
+
+    $transport = new HttpTransport('https://mcp.test/mcp');
+    $transport->withHeaders(['X-Tenant-Id' => 'acme', 'X-Api-Version' => '2025-01-01']);
+    $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'ping', 'params' => []]));
+
+    Http::assertSent(fn ($request): bool => $request->hasHeader('X-Tenant-Id', 'acme')
+        && $request->hasHeader('X-Api-Version', '2025-01-01')
+        && $request->hasHeader('Accept', 'application/json, text/event-stream'));
+});
+
+it('replaces a default header case-insensitively instead of sending a duplicate', function (): void {
+    Http::fake(['*' => Http::response(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => []]), 200, ['Content-Type' => 'application/json'])]);
+
+    $transport = new HttpTransport('https://mcp.test/mcp');
+    $transport->withToken('secret-token');
+    $transport->withHeaders(['accept' => 'text/plain', 'authorization' => 'raw-api-key']);
+    $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'ping', 'params' => []]));
+
+    Http::assertSent(function ($request): bool {
+        $headers = [];
+
+        foreach ($request->headers() as $name => $values) {
+            $headers[strtolower($name)][] = implode(',', $values);
+        }
+
+        return $headers['accept'] === ['text/plain']
+            && $headers['authorization'] === ['raw-api-key'];
+    });
+});
+
+it('lets a custom Authorization header override the bearer token', function (): void {
+    Http::fake(['*' => Http::response(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => []]), 200, ['Content-Type' => 'application/json'])]);
+
+    $transport = new HttpTransport('https://mcp.test/mcp');
+    $transport->withToken('secret-token');
+    $transport->withHeaders(['Authorization' => 'raw-api-key']);
+    $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'ping', 'params' => []]));
+
+    Http::assertSent(fn ($request): bool => $request->hasHeader('Authorization', 'raw-api-key'));
+});
+
+it('merges custom headers across multiple withHeaders calls', function (): void {
+    Http::fake(['*' => Http::response(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => []]), 200, ['Content-Type' => 'application/json'])]);
+
+    $transport = new HttpTransport('https://mcp.test/mcp');
+    $transport->withHeaders(['X-One' => 'first']);
+    $transport->withHeaders(['X-Two' => 'second', 'X-One' => 'overridden']);
+    $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'ping', 'params' => []]));
+
+    Http::assertSent(fn ($request): bool => $request->hasHeader('X-One', 'overridden') && $request->hasHeader('X-Two', 'second'));
+});
+
+it('sends custom headers when built via Client::web', function (): void {
+    Http::fakeSequence()
+        ->push(json_encode([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'result' => [
+                'protocolVersion' => ProtocolVersion::LATEST->value,
+                'capabilities' => new stdClass,
+                'serverInfo' => ['name' => 'Test Server', 'version' => '1.0.0'],
+            ],
+        ]), 200, ['Content-Type' => 'application/json', 'MCP-Session-Id' => 'session-headers'])
+        ->push('', 202)
+        ->push(json_encode([
+            'jsonrpc' => '2.0',
+            'id' => 2,
+            'result' => ['tools' => [['name' => 'add', 'description' => 'Adds two numbers']]],
+        ]), 200, ['Content-Type' => 'application/json'])
+        ->whenEmpty(Http::response('', 202));
+
+    $client = Client::web('https://mcp.test/mcp')->withHeaders(['Authorization' => 'raw-api-key', 'X-Tenant-Id' => 'acme']);
+
+    expect($client)->toBeInstanceOf(WebClient::class);
+
+    $client->tools();
+
+    Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'tools/list'
+        && $request->hasHeader('Authorization', 'raw-api-key')
+        && $request->hasHeader('X-Tenant-Id', 'acme'));
+});
+
 it('throws a ClientException and resets the session on a 404 response', function (): void {
     Http::fakeSequence()
         ->push(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => []]), 200, ['Content-Type' => 'application/json', 'MCP-Session-Id' => 'session-xyz'])

--- a/tests/Unit/Client/Transport/TransportFactoryTest.php
+++ b/tests/Unit/Client/Transport/TransportFactoryTest.php
@@ -37,7 +37,25 @@ it('rebuilds an http transport with its token and timeout from a recipe', functi
             'driver' => 'http',
             'url' => 'https://mcp.test/mcp',
             'token' => 'tok',
+            'headers' => [],
             'timeoutSeconds' => 7.5,
+        ]);
+});
+
+it('rebuilds an http transport with its custom headers from a recipe', function (): void {
+    $source = new HttpTransport('https://mcp.test/mcp');
+    $source->withHeaders(['Authorization' => 'raw-api-key', 'X-Tenant-Id' => 'acme']);
+
+    $transport = TransportFactory::fromRecipe($source->recipe());
+
+    expect($transport)
+        ->toBeInstanceOf(HttpTransport::class)
+        ->and($transport->recipe())->toBe([
+            'driver' => 'http',
+            'url' => 'https://mcp.test/mcp',
+            'token' => null,
+            'headers' => ['Authorization' => 'raw-api-key', 'X-Tenant-Id' => 'acme'],
+            'timeoutSeconds' => 30.0,
         ]);
 });
 


### PR DESCRIPTION
Currently the streamable-HTTP web client only exposes withToken() for auth, which always sends `Authorization: Bearer {token}`. That leaves out servers that need a raw Authorization header (e.g. Stedi's healthcare server expects `Authorization: <api-key>` with no scheme) or extra headers like a tenant id or API version. There's no way to reach those servers today.

This PR adds withHeaders():

```php
Client::web('https://mcp.example.com/mcp')
    ->withHeaders([
        'Authorization' => $apiKey,   // sent verbatim, no Bearer prefix
        'X-Tenant-Id' => 'acme',
    ])
    ->tools();
```

Custom headers take precedence over the transport's defaults and override them case-insensitively, so a lowercase `accept` replaces the default rather than sending a duplicate header on the wire. Headers round-trip through the transport recipe, so named/serialized clients keep them.

Fixes #247