### PR TITLE
Allow OAuth client registration without a client name

### DIFF
--- a/src/Server/Http/Controllers/OAuthRegisterController.php
+++ b/src/Server/Http/Controllers/OAuthRegisterController.php
@@ -75,15 +75,9 @@ class OAuthRegisterController
             'Laravel\Passport\ClientRepository'
         );
 
-        $redirectUris = (array) $validated['redirect_uris'];
-
-        $name = $validated['client_name']
-            ?? $validated['name']
-            ?? (parse_url((string) ($redirectUris[0] ?? ''), PHP_URL_HOST) ?: 'MCP Client');
-
         $client = $clients->createAuthorizationCodeGrantClient(
-            name: $name,
-            redirectUris: $redirectUris,
+            name: $this->resolveClientName($validated),
+            redirectUris: $validated['redirect_uris'],
             confidential: false,
             enableDeviceFlow: false,
         );
@@ -96,6 +90,18 @@ class OAuthRegisterController
             'scope' => 'mcp:use',
             'token_endpoint_auth_method' => 'none',
         ], 201);
+    }
+
+    /**
+     * Resolve the client name, falling back to the redirect host or a default.
+     *
+     * @param  array<string, mixed>  $validated
+     */
+    protected function resolveClientName(array $validated): string
+    {
+        return $validated['client_name']
+            ?? $validated['name']
+            ?? (parse_url((string) ($validated['redirect_uris'][0] ?? ''), PHP_URL_HOST) ?: 'MCP Client');
     }
 
     protected function isValidRedirectUri(string $value): bool

--- a/src/Server/Http/Controllers/OAuthRegisterController.php
+++ b/src/Server/Http/Controllers/OAuthRegisterController.php
@@ -21,8 +21,8 @@ class OAuthRegisterController
     public function __invoke(Request $request): JsonResponse
     {
         $validator = Validator::make($request->all(), [
-            'client_name' => ['nullable', 'string', 'min:1', 'max:255', 'required_without:name'],
-            'name' => ['nullable', 'string', 'min:1', 'max:255', 'required_without:client_name'],
+            'client_name' => ['nullable', 'string', 'min:1', 'max:255'],
+            'name' => ['nullable', 'string', 'min:1', 'max:255'],
             'redirect_uris' => ['required', 'array', 'min:1'],
             'redirect_uris.*' => ['required', 'string', function (string $attribute, $value, $fail): void {
                 if (! $this->isValidRedirectUri($value)) {
@@ -75,9 +75,15 @@ class OAuthRegisterController
             'Laravel\Passport\ClientRepository'
         );
 
+        $redirectUris = (array) $validated['redirect_uris'];
+
+        $name = $validated['client_name']
+            ?? $validated['name']
+            ?? (parse_url((string) ($redirectUris[0] ?? ''), PHP_URL_HOST) ?: 'MCP Client');
+
         $client = $clients->createAuthorizationCodeGrantClient(
-            name: $validated['client_name'] ?? $validated['name'],
-            redirectUris: $validated['redirect_uris'],
+            name: $name,
+            redirectUris: $redirectUris,
             confidential: false,
             enableDeviceFlow: false,
         );

--- a/tests/Unit/Server/RegistrarTest.php
+++ b/tests/Unit/Server/RegistrarTest.php
@@ -252,6 +252,57 @@ it('falls back to the redirect host when no client name is provided', function (
     expect($clientRepository->capturedName)->toBe('example.com');
 });
 
+it('returns invalid_client_metadata when client metadata is invalid', function (): void {
+    ensureMockClientRepository();
+
+    $registrar = new Registrar;
+    $registrar->oauthRoutes();
+
+    $this->app->instance(ClientRepository::class, new ClientRepository);
+
+    $response = $this->postJson('/oauth/register', [
+        'client_name' => str_repeat('a', 256),
+        'redirect_uris' => ['https://example.com/callback'],
+    ]);
+
+    $response->assertStatus(400);
+    $response->assertJson([
+        'error' => 'invalid_client_metadata',
+    ]);
+});
+
+it('preserves a falsy client name for oauth registration', function (): void {
+    $clientRepository = new class
+    {
+        public ?string $capturedName = null;
+
+        public function createAuthorizationCodeGrantClient(string $name, array $redirectUris, bool $confidential = true, $user = null, bool $enableDeviceFlow = false)
+        {
+            $this->capturedName = $name;
+
+            return (object) [
+                'id' => 'test-client-id',
+                'grant_types' => ['authorization_code'],
+                'redirect_uris' => $redirectUris,
+            ];
+        }
+    };
+
+    $registrar = new Registrar;
+    $registrar->oauthRoutes();
+
+    $this->app->instance(ClientRepository::class, $clientRepository);
+
+    $response = $this->postJson('/oauth/register', [
+        'client_name' => '0',
+        'redirect_uris' => ['https://example.com/callback'],
+    ]);
+
+    $response->assertStatus(201);
+
+    expect($clientRepository->capturedName)->toBe('0');
+});
+
 it('falls back to the legacy name field for oauth registration', function (): void {
     $clientRepository = new class
     {

--- a/tests/Unit/Server/RegistrarTest.php
+++ b/tests/Unit/Server/RegistrarTest.php
@@ -221,7 +221,7 @@ it('handles oauth registration endpoint', function (): void {
     ]);
 });
 
-it('requires an oauth client name for registration', function (): void {
+it('falls back to the redirect host when no client name is provided', function (): void {
     $clientRepository = new class
     {
         public ?string $capturedName = null;
@@ -244,13 +244,12 @@ it('requires an oauth client name for registration', function (): void {
     $this->app->instance(ClientRepository::class, $clientRepository);
 
     $response = $this->postJson('/oauth/register', [
-        'redirect_uris' => ['http://localhost:3000/callback'],
+        'redirect_uris' => ['https://example.com/callback'],
     ]);
 
-    $response->assertStatus(400);
-    $response->assertJson([
-        'error' => 'invalid_client_metadata',
-    ]);
+    $response->assertStatus(201);
+
+    expect($clientRepository->capturedName)->toBe('example.com');
 });
 
 it('falls back to the legacy name field for oauth registration', function (): void {
@@ -699,7 +698,7 @@ it('returns json validation errors even without Accept application/json header',
     $this->app->instance(ClientRepository::class, new ClientRepository);
 
     $response = $this->post('/oauth/register', [
-        'redirect_uris' => ['http://localhost:3000/callback'],
+        'redirect_uris' => ['not-a-valid-url'],
     ], ['Accept' => '*/*']);
 
     $response->assertStatus(400);


### PR DESCRIPTION
RFC 7591 §2 lists `client_name` as an OPTIONAL field for Dynamic Client Registration, but `OAuthRegisterController` rejects any registration that omits both `client_name` and the legacy `name`, returning `400 invalid_client_metadata`. This blocks spec-compliant clients — notably Claude's remote MCP connector, whose registration request leaves out `client_name` and currently fails with *"Couldn't register with … sign-in service"*.

This PR makes `client_name`/`name` optional. When neither is supplied, the client name falls back to the host of the first redirect URI (e.g. `example.com`), and to `MCP Client` when no host can be derived. The existing `client_name` > `name` precedence is unchanged, so requests that already send a name behave exactly as before.

Tests are updated to cover a registration request without a name and the fallback behaviour.

Fixes #253
