### PR TITLE
Use negotiated MCP protocol version for HTTP client requests

### DIFF
--- a/src/Client/Contracts/Transport.php
+++ b/src/Client/Contracts/Transport.php
@@ -10,8 +10,6 @@ interface Transport
 
     public function disconnect(): void;
 
-    public function setProtocolVersion(?string $version): void;
-
     public function send(string $message): void;
 
     public function receive(): string;

--- a/src/Client/Contracts/Transport.php
+++ b/src/Client/Contracts/Transport.php
@@ -10,6 +10,8 @@ interface Transport
 
     public function disconnect(): void;
 
+    public function setProtocolVersion(?string $version): void;
+
     public function send(string $message): void;
 
     public function receive(): string;

--- a/src/Client/Contracts/Transport.php
+++ b/src/Client/Contracts/Transport.php
@@ -16,6 +16,8 @@ interface Transport
 
     public function setTimeoutSeconds(float $seconds): void;
 
+    public function setProtocolVersion(string $version): void;
+
     /**
      * @return array<string, mixed>
      */

--- a/src/Client/Protocol.php
+++ b/src/Client/Protocol.php
@@ -58,6 +58,8 @@ class Protocol
         try {
             $this->initializeResult = (new Initialize($this->clientInfo))->handle($this);
 
+            $this->transport->setProtocolVersion($this->initializeResult->protocolVersion);
+
             $this->notify('notifications/initialized');
         } catch (Throwable $throwable) {
             $this->disconnect();

--- a/src/Client/Protocol.php
+++ b/src/Client/Protocol.php
@@ -57,7 +57,6 @@ class Protocol
 
         try {
             $this->initializeResult = (new Initialize($this->clientInfo))->handle($this);
-            $this->transport->setProtocolVersion($this->initializeResult->protocolVersion);
 
             $this->notify('notifications/initialized');
         } catch (Throwable $throwable) {

--- a/src/Client/Protocol.php
+++ b/src/Client/Protocol.php
@@ -57,6 +57,7 @@ class Protocol
 
         try {
             $this->initializeResult = (new Initialize($this->clientInfo))->handle($this);
+            $this->transport->setProtocolVersion($this->initializeResult->protocolVersion);
 
             $this->notify('notifications/initialized');
         } catch (Throwable $throwable) {

--- a/src/Client/Schema/InitializeResult.php
+++ b/src/Client/Schema/InitializeResult.php
@@ -36,9 +36,11 @@ class InitializeResult
         $serverVersion = Arr::get($serverInfo, 'version');
         $instructions = Arr::get($payload, 'instructions');
 
-        if (! is_string($protocolVersion)
-            || ! in_array($protocolVersion, ProtocolVersion::supported(), true)
-            || ! is_array($capabilities)
+        if (! is_string($protocolVersion) || ! in_array($protocolVersion, ProtocolVersion::clientSupported(), true)) {
+            throw new ClientException('The server negotiated an unsupported protocol version.');
+        }
+
+        if (! is_array($capabilities)
             || ! is_array($serverInfo)
             || ! is_string($serverName)
             || ! is_string($serverVersion)) {

--- a/src/Client/Transport/HttpTransport.php
+++ b/src/Client/Transport/HttpTransport.php
@@ -27,6 +27,8 @@ class HttpTransport implements Transport
 
     protected bool $initialized = false;
 
+    protected ?string $protocolVersion = null;
+
     protected float $timeoutSeconds = 30.0;
 
     /** @var array<string, string> */
@@ -55,6 +57,11 @@ class HttpTransport implements Transport
     public function setTimeoutSeconds(float $seconds): void
     {
         $this->timeoutSeconds = $seconds;
+    }
+
+    public function setProtocolVersion(?string $version): void
+    {
+        $this->protocolVersion = $version;
     }
 
     /**
@@ -176,7 +183,7 @@ class HttpTransport implements Transport
         }
 
         if ($this->initialized) {
-            $headers['MCP-Protocol-Version'] = ProtocolVersion::LATEST->value;
+            $headers['MCP-Protocol-Version'] = $this->protocolVersion ?? ProtocolVersion::LATEST->value;
         }
 
         $token = $this->token instanceof Closure ? (string) ($this->token)() : $this->token;
@@ -275,6 +282,7 @@ class HttpTransport implements Transport
     {
         $this->sessionId = null;
         $this->initialized = false;
+        $this->protocolVersion = null;
         $this->queue = [];
     }
 

--- a/src/Client/Transport/HttpTransport.php
+++ b/src/Client/Transport/HttpTransport.php
@@ -7,7 +7,6 @@ namespace Laravel\Mcp\Client\Transport;
 use Closure;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\Response as ClientResponse;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use Laravel\Mcp\Client\Contracts\Transport;
@@ -132,45 +131,26 @@ class HttpTransport implements Transport
             $this->failWith("Unexpected HTTP status [{$response->status()}] from endpoint [{$this->url}].");
         }
 
-        $justInitialized = ! $this->initialized;
         $this->initialized = true;
-        $queuedBefore = count($this->queue);
 
         if (str_contains($response->header('Content-Type'), 'text/event-stream')) {
             $this->readSseStream($response);
-        } else {
-            $body = trim($response->body());
 
-            if (! $response->accepted() && $body !== '') {
-                $this->queue[] = $body;
-            }
+            return;
         }
 
-        if ($justInitialized) {
-            $this->captureProtocolVersion(array_slice($this->queue, $queuedBefore));
+        $body = trim($response->body());
+
+        if ($response->accepted() || $body === '') {
+            return;
         }
+
+        $this->queue[] = $body;
     }
 
-    /**
-     * @param  array<int, string>  $messages
-     */
-    protected function captureProtocolVersion(array $messages): void
+    public function setProtocolVersion(string $version): void
     {
-        foreach ($messages as $message) {
-            $decoded = json_decode($message, true);
-
-            if (! is_array($decoded)) {
-                continue;
-            }
-
-            $version = Arr::get($decoded, 'result.protocolVersion');
-
-            if (is_string($version)) {
-                $this->protocolVersion = $version;
-
-                return;
-            }
-        }
+        $this->protocolVersion = $version;
     }
 
     public function receive(): string

--- a/src/Client/Transport/HttpTransport.php
+++ b/src/Client/Transport/HttpTransport.php
@@ -7,6 +7,7 @@ namespace Laravel\Mcp\Client\Transport;
 use Closure;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\Response as ClientResponse;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use Laravel\Mcp\Client\Contracts\Transport;
@@ -57,11 +58,6 @@ class HttpTransport implements Transport
     public function setTimeoutSeconds(float $seconds): void
     {
         $this->timeoutSeconds = $seconds;
-    }
-
-    public function setProtocolVersion(?string $version): void
-    {
-        $this->protocolVersion = $version;
     }
 
     /**
@@ -136,21 +132,45 @@ class HttpTransport implements Transport
             $this->failWith("Unexpected HTTP status [{$response->status()}] from endpoint [{$this->url}].");
         }
 
+        $justInitialized = ! $this->initialized;
         $this->initialized = true;
+        $queuedBefore = count($this->queue);
 
         if (str_contains($response->header('Content-Type'), 'text/event-stream')) {
             $this->readSseStream($response);
+        } else {
+            $body = trim($response->body());
 
-            return;
+            if (! $response->accepted() && $body !== '') {
+                $this->queue[] = $body;
+            }
         }
 
-        $body = trim($response->body());
-
-        if ($response->accepted() || $body === '') {
-            return;
+        if ($justInitialized) {
+            $this->captureProtocolVersion(array_slice($this->queue, $queuedBefore));
         }
+    }
 
-        $this->queue[] = $body;
+    /**
+     * @param  array<int, string>  $messages
+     */
+    protected function captureProtocolVersion(array $messages): void
+    {
+        foreach ($messages as $message) {
+            $decoded = json_decode($message, true);
+
+            if (! is_array($decoded)) {
+                continue;
+            }
+
+            $version = Arr::get($decoded, 'result.protocolVersion');
+
+            if (is_string($version)) {
+                $this->protocolVersion = $version;
+
+                return;
+            }
+        }
     }
 
     public function receive(): string

--- a/src/Client/Transport/StdioTransport.php
+++ b/src/Client/Transport/StdioTransport.php
@@ -65,11 +65,6 @@ class StdioTransport implements Transport
         $this->timeoutSeconds = $seconds;
     }
 
-    public function setProtocolVersion(?string $version): void
-    {
-        // Stdio transports do not send protocol version headers.
-    }
-
     /**
      * @return array<string, mixed>
      */

--- a/src/Client/Transport/StdioTransport.php
+++ b/src/Client/Transport/StdioTransport.php
@@ -65,6 +65,11 @@ class StdioTransport implements Transport
         $this->timeoutSeconds = $seconds;
     }
 
+    public function setProtocolVersion(?string $version): void
+    {
+        // Stdio transports do not send protocol version headers.
+    }
+
     /**
      * @return array<string, mixed>
      */

--- a/src/Client/Transport/StdioTransport.php
+++ b/src/Client/Transport/StdioTransport.php
@@ -65,6 +65,11 @@ class StdioTransport implements Transport
         $this->timeoutSeconds = $seconds;
     }
 
+    public function setProtocolVersion(string $version): void
+    {
+        //
+    }
+
     /**
      * @return array<string, mixed>
      */

--- a/src/Enums/ProtocolVersion.php
+++ b/src/Enums/ProtocolVersion.php
@@ -20,4 +20,15 @@ enum ProtocolVersion: string
     {
         return array_column(self::cases(), 'value');
     }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function clientSupported(): array
+    {
+        return [
+            self::V2025_11_25->value,
+            self::V2025_06_18->value,
+        ];
+    }
 }

--- a/tests/Fixtures/Client/FakeTransport.php
+++ b/tests/Fixtures/Client/FakeTransport.php
@@ -19,6 +19,8 @@ class FakeTransport implements Transport
 
     public ?string $repeatResponse = null;
 
+    public ?string $protocolVersion = null;
+
     public float $timeoutSeconds = 30.0;
 
     public function connect(): void
@@ -39,6 +41,11 @@ class FakeTransport implements Transport
     public function setTimeoutSeconds(float $seconds): void
     {
         $this->timeoutSeconds = $seconds;
+    }
+
+    public function setProtocolVersion(?string $version): void
+    {
+        $this->protocolVersion = $version;
     }
 
     /**

--- a/tests/Fixtures/Client/FakeTransport.php
+++ b/tests/Fixtures/Client/FakeTransport.php
@@ -21,6 +21,8 @@ class FakeTransport implements Transport
 
     public float $timeoutSeconds = 30.0;
 
+    public ?string $protocolVersion = null;
+
     public function connect(): void
     {
         $this->connected = true;
@@ -39,6 +41,11 @@ class FakeTransport implements Transport
     public function setTimeoutSeconds(float $seconds): void
     {
         $this->timeoutSeconds = $seconds;
+    }
+
+    public function setProtocolVersion(string $version): void
+    {
+        $this->protocolVersion = $version;
     }
 
     /**

--- a/tests/Fixtures/Client/FakeTransport.php
+++ b/tests/Fixtures/Client/FakeTransport.php
@@ -19,8 +19,6 @@ class FakeTransport implements Transport
 
     public ?string $repeatResponse = null;
 
-    public ?string $protocolVersion = null;
-
     public float $timeoutSeconds = 30.0;
 
     public function connect(): void
@@ -41,11 +39,6 @@ class FakeTransport implements Transport
     public function setTimeoutSeconds(float $seconds): void
     {
         $this->timeoutSeconds = $seconds;
-    }
-
-    public function setProtocolVersion(?string $version): void
-    {
-        $this->protocolVersion = $version;
     }
 
     /**

--- a/tests/Unit/Client/ClientTest.php
+++ b/tests/Unit/Client/ClientTest.php
@@ -37,22 +37,25 @@ it('performs the initialize handshake on connect', function (): void {
     expect($initialized)->not->toHaveKey('id');
 });
 
-it('stores the negotiated protocol version on the transport before initialized notification', function (): void {
+it('disconnects when the server negotiates a version the client does not support', function (): void {
     $transport = new FakeTransport;
     $transport->responses[] = json_encode([
         'jsonrpc' => '2.0',
         'id' => 1,
         'result' => [
-            'protocolVersion' => ProtocolVersion::V2025_06_18->value,
+            'protocolVersion' => ProtocolVersion::V2024_11_05->value,
             'capabilities' => new stdClass,
             'serverInfo' => ['name' => 'Test Server', 'version' => '1.0.0'],
         ],
     ]);
 
     $client = new Client($transport);
-    $client->connect();
 
-    expect($transport->protocolVersion)->toBe(ProtocolVersion::V2025_06_18->value);
+    expect(function () use ($client): void {
+        $client->connect();
+    })->toThrow(ClientException::class, 'The server negotiated an unsupported protocol version.');
+
+    expect($transport->connected)->toBeFalse();
 });
 
 it('pings the server', function (): void {
@@ -241,15 +244,15 @@ it('throws when the error payload is not an object', function (): void {
         ->toThrow(ClientException::class, 'Invalid JSON-RPC error payload.');
 });
 
-it('throws when the initialize result is invalid', function (): void {
+it('throws when the initialize result is structurally invalid', function (): void {
     $transport = new FakeTransport;
     $transport->responses[] = json_encode([
         'jsonrpc' => '2.0',
         'id' => 1,
         'result' => [
-            'protocolVersion' => 'invalid',
+            'protocolVersion' => ProtocolVersion::LATEST->value,
             'capabilities' => new stdClass,
-            'serverInfo' => ['name' => 'Test Server', 'version' => '1.0.0'],
+            'serverInfo' => ['version' => '1.0.0'],
         ],
     ]);
 

--- a/tests/Unit/Client/ClientTest.php
+++ b/tests/Unit/Client/ClientTest.php
@@ -37,6 +37,24 @@ it('performs the initialize handshake on connect', function (): void {
     expect($initialized)->not->toHaveKey('id');
 });
 
+it('stores the negotiated protocol version on the transport before initialized notification', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'result' => [
+            'protocolVersion' => ProtocolVersion::V2025_06_18->value,
+            'capabilities' => new stdClass,
+            'serverInfo' => ['name' => 'Test Server', 'version' => '1.0.0'],
+        ],
+    ]);
+
+    $client = new Client($transport);
+    $client->connect();
+
+    expect($transport->protocolVersion)->toBe(ProtocolVersion::V2025_06_18->value);
+});
+
 it('pings the server', function (): void {
     $transport = new FakeTransport;
     $transport->responses[] = initializeResponse();

--- a/tests/Unit/Client/Transport/HttpTransportTest.php
+++ b/tests/Unit/Client/Transport/HttpTransportTest.php
@@ -108,11 +108,12 @@ it('captures the MCP-Session-Id and resends it on later requests', function (): 
 });
 
 it('omits the protocol version header on initialize and includes the negotiated version afterwards', function (): void {
-    Http::fake(['*' => Http::response(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => ['protocolVersion' => ProtocolVersion::V2025_06_18->value]]), 200, ['Content-Type' => 'application/json'])]);
+    Http::fake(['*' => Http::response(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => []]), 200, ['Content-Type' => 'application/json'])]);
 
     $transport = new HttpTransport('https://mcp.test/mcp');
     $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'initialize', 'params' => []]));
     $transport->receive();
+    $transport->setProtocolVersion(ProtocolVersion::V2025_06_18->value);
     $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 2, 'method' => 'tools/list']));
 
     Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'initialize' && ! $request->hasHeader('MCP-Protocol-Version'));
@@ -128,21 +129,6 @@ it('falls back to the latest protocol version when initialized without a negotia
     $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 2, 'method' => 'tools/list']));
 
     Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'tools/list' && $request->hasHeader('MCP-Protocol-Version', ProtocolVersion::LATEST->value));
-});
-
-it('captures the negotiated protocol version from an SSE initialize response', function (): void {
-    Http::fake(['*' => Http::response(
-        sseStream([['jsonrpc' => '2.0', 'id' => 1, 'result' => ['protocolVersion' => ProtocolVersion::V2025_06_18->value]]]),
-        200,
-        ['Content-Type' => 'text/event-stream'],
-    )]);
-
-    $transport = new HttpTransport('https://mcp.test/mcp');
-    $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'initialize', 'params' => []]));
-    $transport->receive();
-    $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 2, 'method' => 'tools/list']));
-
-    Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'tools/list' && $request->hasHeader('MCP-Protocol-Version', ProtocolVersion::V2025_06_18->value));
 });
 
 it('sends a bearer Authorization header when a token is set', function (): void {

--- a/tests/Unit/Client/Transport/HttpTransportTest.php
+++ b/tests/Unit/Client/Transport/HttpTransportTest.php
@@ -107,7 +107,20 @@ it('captures the MCP-Session-Id and resends it on later requests', function (): 
     Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'ping' && $request->hasHeader('MCP-Session-Id', 'session-abc'));
 });
 
-it('omits the protocol version header on initialize and includes it afterwards', function (): void {
+it('omits the protocol version header on initialize and includes the negotiated version afterwards', function (): void {
+    Http::fake(['*' => Http::response(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => []]), 200, ['Content-Type' => 'application/json'])]);
+
+    $transport = new HttpTransport('https://mcp.test/mcp');
+    $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'initialize', 'params' => []]));
+    $transport->receive();
+    $transport->setProtocolVersion(ProtocolVersion::V2025_06_18->value);
+    $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 2, 'method' => 'tools/list']));
+
+    Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'initialize' && ! $request->hasHeader('MCP-Protocol-Version'));
+    Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'tools/list' && $request->hasHeader('MCP-Protocol-Version', ProtocolVersion::V2025_06_18->value));
+});
+
+it('falls back to the latest protocol version when initialized without a negotiated version', function (): void {
     Http::fake(['*' => Http::response(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => []]), 200, ['Content-Type' => 'application/json'])]);
 
     $transport = new HttpTransport('https://mcp.test/mcp');
@@ -115,7 +128,6 @@ it('omits the protocol version header on initialize and includes it afterwards',
     $transport->receive();
     $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 2, 'method' => 'tools/list']));
 
-    Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'initialize' && ! $request->hasHeader('MCP-Protocol-Version'));
     Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'tools/list' && $request->hasHeader('MCP-Protocol-Version', ProtocolVersion::LATEST->value));
 });
 

--- a/tests/Unit/Client/Transport/HttpTransportTest.php
+++ b/tests/Unit/Client/Transport/HttpTransportTest.php
@@ -108,12 +108,11 @@ it('captures the MCP-Session-Id and resends it on later requests', function (): 
 });
 
 it('omits the protocol version header on initialize and includes the negotiated version afterwards', function (): void {
-    Http::fake(['*' => Http::response(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => []]), 200, ['Content-Type' => 'application/json'])]);
+    Http::fake(['*' => Http::response(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => ['protocolVersion' => ProtocolVersion::V2025_06_18->value]]), 200, ['Content-Type' => 'application/json'])]);
 
     $transport = new HttpTransport('https://mcp.test/mcp');
     $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'initialize', 'params' => []]));
     $transport->receive();
-    $transport->setProtocolVersion(ProtocolVersion::V2025_06_18->value);
     $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 2, 'method' => 'tools/list']));
 
     Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'initialize' && ! $request->hasHeader('MCP-Protocol-Version'));
@@ -129,6 +128,21 @@ it('falls back to the latest protocol version when initialized without a negotia
     $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 2, 'method' => 'tools/list']));
 
     Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'tools/list' && $request->hasHeader('MCP-Protocol-Version', ProtocolVersion::LATEST->value));
+});
+
+it('captures the negotiated protocol version from an SSE initialize response', function (): void {
+    Http::fake(['*' => Http::response(
+        sseStream([['jsonrpc' => '2.0', 'id' => 1, 'result' => ['protocolVersion' => ProtocolVersion::V2025_06_18->value]]]),
+        200,
+        ['Content-Type' => 'text/event-stream'],
+    )]);
+
+    $transport = new HttpTransport('https://mcp.test/mcp');
+    $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'initialize', 'params' => []]));
+    $transport->receive();
+    $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 2, 'method' => 'tools/list']));
+
+    Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'tools/list' && $request->hasHeader('MCP-Protocol-Version', ProtocolVersion::V2025_06_18->value));
 });
 
 it('sends a bearer Authorization header when a token is set', function (): void {
@@ -367,6 +381,87 @@ it('drives a full handshake and tools list over HTTP via Client::web', function 
     Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'tools/list' && $request->hasHeader('MCP-Session-Id', 'session-e2e'));
     Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'tools/list' && $request->hasHeader('Authorization', 'Bearer e2e-token'));
     Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'tools/list' && $request->hasHeader('MCP-Protocol-Version', ProtocolVersion::LATEST->value));
+});
+
+it('throws when the server negotiates a protocol version the client does not support', function (): void {
+    Http::fakeSequence()
+        ->push(json_encode([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'result' => [
+                'protocolVersion' => ProtocolVersion::V2025_03_26->value,
+                'capabilities' => new stdClass,
+                'serverInfo' => ['name' => 'Test Server', 'version' => '1.0.0'],
+            ],
+        ]), 200, ['Content-Type' => 'application/json', 'MCP-Session-Id' => 'session-old'])
+        ->whenEmpty(Http::response('', 202));
+
+    expect(function (): void {
+        Client::web('https://mcp.test/mcp')->tools();
+    })->toThrow(ClientException::class, 'The server negotiated an unsupported protocol version.');
+});
+
+it('interoperates with a server negotiated down to 2025-06-18', function (): void {
+    Http::fakeSequence()
+        ->push(json_encode([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'result' => [
+                'protocolVersion' => ProtocolVersion::V2025_06_18->value,
+                'capabilities' => new stdClass,
+                'serverInfo' => ['name' => 'Legacy Server', 'version' => '1.0.0'],
+            ],
+        ]), 200, ['Content-Type' => 'application/json', 'MCP-Session-Id' => 'session-2025-06-18'])
+        ->push('', 202)
+        ->push(json_encode([
+            'jsonrpc' => '2.0',
+            'id' => 2,
+            'result' => [
+                'tools' => [[
+                    'name' => 'add',
+                    'title' => 'Add Numbers',
+                    'description' => 'Adds two numbers',
+                    'inputSchema' => [
+                        'type' => 'object',
+                        'properties' => ['a' => ['type' => 'number'], 'b' => ['type' => 'number']],
+                        'required' => ['a', 'b'],
+                    ],
+                    'outputSchema' => [
+                        'type' => 'object',
+                        'properties' => ['sum' => ['type' => 'number']],
+                    ],
+                ]],
+            ],
+        ]), 200, ['Content-Type' => 'application/json'])
+        ->push(json_encode([
+            'jsonrpc' => '2.0',
+            'id' => 3,
+            'result' => [
+                'content' => [['type' => 'text', 'text' => '3']],
+                'structuredContent' => ['sum' => 3],
+                'isError' => false,
+            ],
+        ]), 200, ['Content-Type' => 'application/json'])
+        ->whenEmpty(Http::response('', 202));
+
+    $client = Client::web('https://mcp.test/mcp');
+    $tools = $client->tools();
+    $result = $client->callTool('add', ['a' => 1, 'b' => 2]);
+
+    expect($tools->keys()->all())->toBe(['add'])
+        ->and($tools->get('add')->title)->toBe('Add Numbers')
+        ->and($tools->get('add')->outputSchema)->toBe([
+            'type' => 'object',
+            'properties' => ['sum' => ['type' => 'number']],
+        ])
+        ->and($result->text())->toBe('3')
+        ->and($result->structuredContent)->toBe(['sum' => 3])
+        ->and($result->isError)->toBeFalse();
+
+    Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'initialize' && ! $request->hasHeader('MCP-Protocol-Version'));
+    Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'notifications/initialized' && $request->hasHeader('MCP-Protocol-Version', ProtocolVersion::V2025_06_18->value));
+    Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'tools/list' && $request->hasHeader('MCP-Protocol-Version', ProtocolVersion::V2025_06_18->value));
+    Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'tools/call' && $request->hasHeader('MCP-Protocol-Version', ProtocolVersion::V2025_06_18->value));
 });
 
 it('builds a WebClient from Client::web', function (): void {

--- a/tests/Unit/Enums/ProtocolVersionTest.php
+++ b/tests/Unit/Enums/ProtocolVersionTest.php
@@ -21,3 +21,10 @@ it('returns only string values', function (): void {
         expect($version)->toBeString();
     }
 });
+
+it('supports only the versions that define the protocol version header as a client', function (): void {
+    expect(ProtocolVersion::clientSupported())->toBe([
+        ProtocolVersion::V2025_11_25->value,
+        ProtocolVersion::V2025_06_18->value,
+    ]);
+});


### PR DESCRIPTION
Fixes #256 

Summary:
- stores the negotiated protocol version from `initialize`
- uses that negotiated version for post-initialize HTTP requests
- preserves existing behavior by falling back to `ProtocolVersion::LATEST` when no negotiated version is set

Validated with:
- `vendor/bin/pest tests/Unit/Client/ClientTest.php tests/Unit/Client/Transport/HttpTransportTest.php`
- `vendor/bin/pest tests/Unit/Client`
- `vendor/bin/pint --dirty`