### PR TITLE
Improve test error when unexpected errors are found in response

### DIFF
--- a/src/Server/Testing/TestResponse.php
+++ b/src/Server/Testing/TestResponse.php
@@ -195,7 +195,7 @@ class TestResponse
 
     public function assertHasNoErrors(): static
     {
-        Assert::assertEmpty($this->errors());
+        Assert::assertSame([], $this->errors(), 'The response has errors.');
 
         return $this;
     }


### PR DESCRIPTION
Minor improvement to improve test output when `assertOk` or `assertHasNoErrors` fails:


Before:

```text
Failed asserting that an array is empty.
```

After:

```text
The response has errors.
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
-Array &0 []
+Array &0 [
+    0 => 'An internal server error occurred.',
+]
```