### PR TITLE
Fix schema return type in tool stub

### DIFF
--- a/stubs/mcp-tool.stub
+++ b/stubs/mcp-tool.stub
@@ -24,7 +24,7 @@ class {{ class }} extends Tool
     /**
      * Get the tool's input schema.
      *
-     * @return array<string, JsonSchema>
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
      */
     public function schema(JsonSchema $schema): array
     {


### PR DESCRIPTION
The stub for tools currently always triggers PHPStan errors on the schema method. This is because its annotated as if it will return `array<string, \Illuminate\Contracts\JsonSchema\JsonSchema>`, but it should in fact return `array<string, \Illuminate\JsonSchema\Types\Type>` (which does not implement the `JsonSchema` contract).

The [docs](https://laravel.com/docs/13.x/mcp#tools) also provide an example where a `Type` return is used