### PR TITLE
Fix nested OAuth resource path with preceding route parameters

### DIFF
--- a/src/Client/OAuth/AuthServerDiscovery.php
+++ b/src/Client/OAuth/AuthServerDiscovery.php
@@ -188,7 +188,7 @@ class AuthServerDiscovery
         $host = $this->normalizedHost($parts['host']);
         $resourceHost = $this->normalizedHost($resourceParts['host']);
 
-        if ($this->isInternalHost($host) && ! ($this->isLocalhost($host) && $this->isLocalhost($resourceHost))) {
+        if ($this->isInternalHost($host) && (! $this->isLocalhost($host) || ! $this->isLocalhost($resourceHost))) {
             throw new OAuthException("OAuth endpoint [{$url}] cannot use a private or internal host.");
         }
     }

--- a/src/Server/Registrar.php
+++ b/src/Server/Registrar.php
@@ -137,7 +137,11 @@ class Registrar
                 ->name('mcp.oauth.authorization-server');
         }
 
-        Router::get('/.well-known/oauth-protected-resource/{path}', static fn (string $path) => response()->json(static::protectedResourceMetadata($path)))
+        Router::get('/.well-known/oauth-protected-resource/{path}', static function (Route $route) {
+            $path = $route->parameter('path');
+
+            return response()->json(static::protectedResourceMetadata(is_string($path) ? $path : ''));
+        })
             ->where('path', '.*')
             ->name('mcp.oauth.protected-resource.nested');
 

--- a/tests/Unit/Server/RegistrarTest.php
+++ b/tests/Unit/Server/RegistrarTest.php
@@ -165,6 +165,19 @@ it('does not override an existing exact oauth protected resource route', functio
     ]);
 });
 
+it('resolves the nested protected resource path when a route parameter precedes it', function (): void {
+    Route::group(['domain' => '{account}.example.com'], function (): void {
+        (new Registrar)->oauthRoutes();
+    });
+
+    $response = $this->getJson('http://tenant.example.com/.well-known/oauth-protected-resource/mcp/server');
+
+    $response->assertStatus(200);
+    $response->assertJson([
+        'resource' => 'http://tenant.example.com/mcp/server',
+    ]);
+});
+
 it('adds mcp scope when passport is available', function (): void {
     if (! class_exists(Passport::class)) {
         require_once __DIR__.'/../../Fixtures/PassportPassport.php';


### PR DESCRIPTION
The `/.well-known/oauth-protected-resource/{path}` route closure type-hints `string $path`, and Laravel binds untyped closure parameters positionally rather than by name. When `oauthRoutes()` is registered inside a route group with a preceding parameter (e.g. a subdomain pattern), `$path` receives that parameter's value instead of the actual path segment, so the `resource` field in the JSON response is wrong.

This resolves the path by name from the injected `Route` instance instead of relying on positional binding.

Fixes #260
