### PR TITLE
Add `#[SensitiveParameter]` to parameters carrying secrets

### DIFF
--- a/src/Client/OAuth/ClientRegistration.php
+++ b/src/Client/OAuth/ClientRegistration.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp\Client\OAuth;
 
+use SensitiveParameter;
+
 class ClientRegistration
 {
     public function __construct(
         public string $clientId,
+        #[SensitiveParameter]
         public ?string $clientSecret = null,
     ) {}
 }

--- a/src/Client/OAuth/OAuthClient.php
+++ b/src/Client/OAuth/OAuthClient.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Uri;
 use Laravel\Mcp\Client\Exceptions\OAuthException;
 use Laravel\Mcp\Client\OAuth\Concerns\InteractsWithOAuthEndpoints;
 use Laravel\Mcp\Client\OAuth\Enums\TokenEndpointAuthMethod;
+use SensitiveParameter;
 
 class OAuthClient
 {
@@ -127,8 +128,13 @@ class OAuthClient
         return $this->returnTo;
     }
 
-    public function refreshCredentials(string $refreshToken, ?string $clientId = null, ?string $clientSecret = null): TokenSet
-    {
+    public function refreshCredentials(
+        #[SensitiveParameter]
+        string $refreshToken,
+        ?string $clientId = null,
+        #[SensitiveParameter]
+        ?string $clientSecret = null,
+    ): TokenSet {
         $discovered = $this->discover();
 
         $clientId ??= $this->config->clientId;
@@ -153,8 +159,12 @@ class OAuthClient
         return $token;
     }
 
-    protected function exchangeAuthorizationCode(string $code, string $state, ?string $iss): TokenSet
-    {
+    protected function exchangeAuthorizationCode(
+        #[SensitiveParameter]
+        string $code,
+        string $state,
+        ?string $iss,
+    ): TokenSet {
         /** @var array<string, mixed>|null $stored */
         $stored = Session::get($this->sessionKey());
 
@@ -215,8 +225,14 @@ class OAuthClient
     /**
      * @param  array<string, mixed>  $params
      */
-    protected function requestToken(string $tokenEndpoint, array $params, ?string $clientId, ?string $clientSecret, TokenEndpointAuthMethod $authMethod): TokenSet
-    {
+    protected function requestToken(
+        string $tokenEndpoint,
+        array $params,
+        ?string $clientId,
+        #[SensitiveParameter]
+        ?string $clientSecret,
+        TokenEndpointAuthMethod $authMethod,
+    ): TokenSet {
         $request = $this->oAuthRequest()->asForm();
 
         $credentials = match ($authMethod) {
@@ -278,8 +294,11 @@ class OAuthClient
         return $this->config->scope ?? 'mcp:use';
     }
 
-    protected function resolveTokenAuthMethod(AuthServerMetadata $metadata, ?string $clientSecret): TokenEndpointAuthMethod
-    {
+    protected function resolveTokenAuthMethod(
+        AuthServerMetadata $metadata,
+        #[SensitiveParameter]
+        ?string $clientSecret,
+    ): TokenEndpointAuthMethod {
         if (blank($clientSecret)) {
             return TokenEndpointAuthMethod::None;
         }

--- a/src/Client/OAuth/OAuthConfig.php
+++ b/src/Client/OAuth/OAuthConfig.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp\Client\OAuth;
 
+use SensitiveParameter;
+
 class OAuthConfig
 {
     public function __construct(
         public ?string $clientId = null,
+        #[SensitiveParameter]
         public ?string $clientSecret = null,
         public ?string $scope = null,
         public ?string $redirectUri = null,

--- a/src/Client/OAuth/TokenSet.php
+++ b/src/Client/OAuth/TokenSet.php
@@ -4,15 +4,20 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp\Client\OAuth;
 
+use SensitiveParameter;
+
 class TokenSet
 {
     public function __construct(
+        #[SensitiveParameter]
         public string $accessToken,
+        #[SensitiveParameter]
         public ?string $refreshToken = null,
         public ?int $expiresAt = null,
         public string $tokenType = 'Bearer',
         public ?string $scope = null,
         public ?string $clientId = null,
+        #[SensitiveParameter]
         public ?string $clientSecret = null,
     ) {}
 

--- a/src/Client/Transport/HttpTransport.php
+++ b/src/Client/Transport/HttpTransport.php
@@ -16,6 +16,7 @@ use Laravel\Mcp\Enums\ProtocolVersion;
 use Laravel\Mcp\Exceptions\ClientException;
 use Laravel\Mcp\Exceptions\SessionExpiredException;
 use Psr\Http\Message\StreamInterface;
+use SensitiveParameter;
 use Throwable;
 
 class HttpTransport implements Transport
@@ -62,7 +63,7 @@ class HttpTransport implements Transport
     /**
      * @param  string|Closure(): string  $token
      */
-    public function withToken(string|Closure $token): void
+    public function withToken(#[SensitiveParameter] string|Closure $token): void
     {
         $this->token = $token;
     }

--- a/src/WebClient.php
+++ b/src/WebClient.php
@@ -10,6 +10,7 @@ use Laravel\Mcp\Client\OAuth\OAuthClient;
 use Laravel\Mcp\Client\OAuth\OAuthConfig;
 use Laravel\Mcp\Client\Transport\HttpTransport;
 use Laravel\Mcp\Schema\Implementation;
+use SensitiveParameter;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 class WebClient extends Client
@@ -25,7 +26,7 @@ class WebClient extends Client
     /**
      * @param  string|Closure(): string  $token
      */
-    public function withToken(string|Closure $token): static
+    public function withToken(#[SensitiveParameter] string|Closure $token): static
     {
         $this->httpTransport->withToken($token);
 
@@ -44,6 +45,7 @@ class WebClient extends Client
 
     public function withOAuth(
         ?string $clientId = null,
+        #[SensitiveParameter]
         ?string $clientSecret = null,
         ?string $scope = null,
         ?string $redirectUri = null,


### PR DESCRIPTION
This prevents these secrets from showing up in stack traces