### PR TITLE
Add read() to the MCP client resource primitive

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -163,7 +163,7 @@ class Client
     public function resources(?int $limit = null, ?iterable $default = null): Collection
     {
         try {
-            return (new ListResources(limit: $limit))->handle($this->protocol);
+            return (new ListResources(client: $this, limit: $limit))->handle($this->protocol);
         } catch (AuthorizationRequiredException $authorizationRequiredException) {
             if ($default === null) {
                 throw $authorizationRequiredException;

--- a/src/Client/Methods/Resources/ListResources.php
+++ b/src/Client/Methods/Resources/ListResources.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laravel\Mcp\Client\Methods\Resources;
 
 use Illuminate\Support\Collection;
+use Laravel\Mcp\Client;
 use Laravel\Mcp\Client\Contracts\Method;
 use Laravel\Mcp\Client\Methods\Concerns\PaginatesList;
 use Laravel\Mcp\Client\Primitives\Resource;
@@ -16,8 +17,11 @@ class ListResources implements Method
 {
     use PaginatesList;
 
-    public function __construct(?string $cursor = null, ?int $limit = null)
-    {
+    public function __construct(
+        protected ?Client $client = null,
+        ?string $cursor = null,
+        ?int $limit = null,
+    ) {
         $this->cursor = $cursor;
         $this->limit = $limit;
     }
@@ -29,7 +33,7 @@ class ListResources implements Method
 
     protected function nextPage(?string $cursor): static
     {
-        return new static($cursor, $this->limit);
+        return new static($this->client, $cursor, $this->limit);
     }
 
     /**
@@ -39,7 +43,7 @@ class ListResources implements Method
     protected function hydrate(array $payloads): Collection
     {
         return collect($payloads)->mapWithKeys(function (array $payload): array {
-            $resource = Resource::from($payload);
+            $resource = Resource::from($this->client, $payload);
 
             return [$resource->uri => $resource];
         });

--- a/src/Client/Primitives/Resource.php
+++ b/src/Client/Primitives/Resource.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Laravel\Mcp\Client\Primitives;
 
 use Illuminate\Support\Arr;
+use Laravel\Mcp\Client;
+use Laravel\Mcp\Client\Schema\ResourceReadResult;
 use Laravel\Mcp\Exceptions\ClientException;
 
 class Resource
@@ -14,6 +16,7 @@ class Resource
      * @param  array<string, mixed>|null  $meta
      */
     public function __construct(
+        protected ?Client $client,
         public readonly string $uri,
         public readonly string $name,
         public readonly ?string $title,
@@ -29,7 +32,7 @@ class Resource
     /**
      * @param  array<string, mixed>  $payload
      */
-    public static function from(array $payload): self
+    public static function from(?Client $client, array $payload): self
     {
         $uri = Arr::get($payload, 'uri');
         $name = Arr::get($payload, 'name');
@@ -52,6 +55,7 @@ class Resource
         }
 
         return new self(
+            client: $client,
             uri: $uri,
             name: $name,
             title: $title,
@@ -61,5 +65,14 @@ class Resource
             annotations: $annotations,
             meta: $meta,
         );
+    }
+
+    public function read(): ResourceReadResult
+    {
+        if (! $this->client instanceof Client) {
+            throw new ClientException("Resource [{$this->uri}] is not bound to a client.");
+        }
+
+        return $this->client->readResource($this->uri);
     }
 }

--- a/tests/Unit/Client/ResourcesTest.php
+++ b/tests/Unit/Client/ResourcesTest.php
@@ -451,3 +451,32 @@ it('coerces a non-array _meta from resources/read to null', function (): void {
 
     expect($result->meta)->toBeNull();
 });
+
+it('returns an unbound resource whose read throws until it is bound', function (): void {
+    $resource = Resource::from(null, ['uri' => 'file://readme', 'name' => 'readme']);
+
+    expect(fn (): ResourceReadResult => $resource->read())
+        ->toThrow(ClientException::class, 'Resource [file://readme] is not bound to a client.');
+});
+
+it('reads a bound resource returned from resources()', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => ['resources' => [['uri' => 'file://readme', 'name' => 'readme']]],
+    ]);
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 3,
+        'result' => ['contents' => [['uri' => 'file://readme', 'mimeType' => 'text/plain', 'text' => 'Hello, world!']]],
+    ]);
+
+    $resource = (new Client($transport))->resources()['file://readme'];
+
+    expect($resource->read()->content())->toBe('Hello, world!')
+        ->and(json_decode($transport->sent[3], true))
+        ->toHaveKey('method', 'resources/read')
+        ->toHaveKey('params.uri', 'file://readme');
+});


### PR DESCRIPTION
The client `Tool` primitive is bound to its `Client` and can invoke itself with `->call()`, introduced alongside tool listing in #226. When prompt and resource support landed later (#242, #243), those primitives were list-only, they are never handed the `Client`, so they cannot act on themselves.

That leaves the client API asymmetric. A listed tool reads fluently:

```php
$client->tools()['add']->call(['a' => 1, 'b' => 2]);
```

…but a listed resource has to hand its own URI back to the client to be read:

```php
$resource = $client->resources()['file://readme'];

$client->readResource($resource->uri); // there is no $resource->read()
```

This PR completes the pattern for resources by adding `Resource::read()`, mirroring `Tool::call()` exactly, the primitive is bound to the client during hydration, `read()` delegates to `Client::readResource()`, and an unbound resource throws the same guard exception as an unbound tool:

```php
$resource = $client->resources()['file://readme'];

$resource->read(); // ResourceReadResult
```
### Notes
- Same shape as the existing `Tool::call()` binding: `ListResources` now threads the `Client` through `nextPage()` and into `Resource::from()`, and `Client::resources()` passes `client: $this`.
- No behavioral change to the existing `resources()` / `readResource()` paths, this is purely additive.
- The matching `Prompt::get()` can follow as a separate PR to keep this one focused (mirroring how prompt and resource support were split across #242 and #243).

Tests cover both the bound case (reads through the client and sends `resources/read` with the correct `uri`) and the unbound case (throws until bound). 

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
