### PR TITLE
Fix CursorPaginator returning trailing items for a negative cursor offset

### DIFF
--- a/src/Server/Pagination/CursorPaginator.php
+++ b/src/Server/Pagination/CursorPaginator.php
@@ -56,7 +56,7 @@ class CursorPaginator
                 return 0;
             }
 
-            return (int) ($cursorData['offset'] ?? 0);
+            return max(0, (int) ($cursorData['offset'] ?? 0));
         } catch (Throwable) {
             //
         }

--- a/tests/Unit/Pagination/CursorPaginatorTest.php
+++ b/tests/Unit/Pagination/CursorPaginatorTest.php
@@ -73,3 +73,39 @@ it('handles invalid cursor gracefully', function (): void {
             ['name' => 'Item 2'],
         ]);
 });
+
+it('falls back to the first page for cursors that do not decode to an offset', function (string $cursor): void {
+    $items = collect([
+        ['name' => 'Item 1'],
+        ['name' => 'Item 2'],
+        ['name' => 'Item 3'],
+    ]);
+
+    $result = (new CursorPaginator($items, 2, $cursor))->paginate();
+
+    expect($result['items'])->toEqual([
+        ['name' => 'Item 1'],
+        ['name' => 'Item 2'],
+    ]);
+})->with([
+    'non-array JSON' => [base64_encode((string) json_encode(123))],
+    'valid base64 but invalid JSON' => [base64_encode('not-json{')],
+    'object without an offset key' => [base64_encode((string) json_encode(['foo' => 'bar']))],
+]);
+
+it('falls back to the first page for a negative offset', function (): void {
+    $items = collect([
+        ['name' => 'Item 1'],
+        ['name' => 'Item 2'],
+        ['name' => 'Item 3'],
+    ]);
+
+    $cursor = base64_encode((string) json_encode(['offset' => -1]));
+
+    $result = (new CursorPaginator($items, 2, $cursor))->paginate();
+
+    expect($result['items'])->toEqual([
+        ['name' => 'Item 1'],
+        ['name' => 'Item 2'],
+    ]);
+});


### PR DESCRIPTION
`CursorPaginator` decodes a client-supplied cursor into a numeric offset. Every unusable cursor is deliberately funneled back to offset `0` (the first page), an unparseable base64 string, non-JSON payload, non-array JSON, or an object without an `offset` key all fall back gracefully.                                                                                                                                                                               
                                                                                                                                                                                                                                         
A **negative** offset is the one case that slips through those guards. A cursor encoding `{"offset": -1}` is a valid array with an `offset` key, so it reaches `Collection::slice(-1, $perPage)` and `slice()` treats a negative offset as counting from the end, so the paginator returns the *trailing* items instead of the intended first-page fallback:                                                                                                            
                                                                                                                                                                                                                                         
  ```php                                                                                                                                                                                                                                 
  // items: [1, 2, 3, 4, 5], perPage: 2, cursor: {"offset": -1}                                                                                                                                                                          
  $paginator->paginate();                                                                                                                                                                                                                
  // before: ['items' => [5], 'nextCursor' => ...] last item                                                                                                                                                                          
  // after:  ['items' => [1, 2], 'nextCursor' => ...] first page   
```                                                                                                                                   
The fix clamps the decoded offset with max(0, ...), keeping it consistent with the method's existing "unusable cursor, first page" contract.                                                                                          
                                                                                                                                                                                                                                         
The tests add the negative-offset regression case, and also lock down the sibling decode-failure branches (non-array JSON, valid base64 with invalid JSON, object without an offset key) that previously had only the invalid-base64 case covered. 

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
