### PR TITLE
Update phpdoc for assertStructuredContent

### DIFF
--- a/src/Server/Testing/TestResponse.php
+++ b/src/Server/Testing/TestResponse.php
@@ -107,7 +107,7 @@ class TestResponse
     }
 
     /**
-     * @param  array<string, mixed>|Closure(AssertableJson): bool  $structuredContent
+     * @param  array<string, mixed>|Closure(AssertableJson): mixed  $structuredContent
      */
     public function assertStructuredContent(Closure|array $structuredContent): static
     {


### PR DESCRIPTION
The closure doesn't actually need to return anything, but the PHPDoc requires a boolean return type. This means traditional closures need an explicit return statement, while arrow closures cannot be used due to not returning a boolean

this:

```php
->assertStructuredContent(function (AssertableJson $json) {
    $json->where('name', 'John');
    return true;
});

// invalid, as $json->where(...) returns AssertableJson, not bool
->assertStructuredContent(fn (AssertableJson $json) => $json->where('name', 'John'));
```
can be changed to:
```php
->assertStructuredContent(function (AssertableJson $json) {
    $json->where('name', 'John');
});


->assertStructuredContent(fn (AssertableJson $json) => $json->where('name', 'John'));