### PR TITLE
Serialize structured content before asserting

### DIFF
--- a/src/Server/Testing/TestResponse.php
+++ b/src/Server/Testing/TestResponse.php
@@ -9,6 +9,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Testing\AssertableJsonString;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Laravel\Mcp\Server\Primitive;
 use Laravel\Mcp\Server\Prompt;
@@ -111,8 +112,10 @@ class TestResponse
      */
     public function assertStructuredContent(Closure|array $structuredContent): static
     {
+        $structuredContentResponse = $this->decodeStructuredContentResponse();
+
         if ($structuredContent instanceof Closure) {
-            $assertableJson = AssertableJson::fromArray($this->response->toArray()['result']['structuredContent'] ?? null);
+            $assertableJson = AssertableJson::fromAssertableJsonString($structuredContentResponse);
 
             $structuredContent($assertableJson);
 
@@ -123,7 +126,7 @@ class TestResponse
 
         Assert::assertSame(
             $structuredContent,
-            $this->response->toArray()['result']['structuredContent'] ?? null,
+            $structuredContentResponse->json(),
             'The expected structured content does not match the actual structured content.'
         );
 
@@ -373,5 +376,16 @@ class TestResponse
         $response = $this->response->toArray();
 
         return $response['result']['completion']['values'] ?? [];
+    }
+
+    protected function decodeStructuredContentResponse(): AssertableJsonString
+    {
+        $response = json_decode(
+            $this->response->toJson(),
+            associative: true,
+            flags: JSON_THROW_ON_ERROR,
+        );
+
+        return new AssertableJsonString($response['result']['structuredContent'] ?? []);
     }
 }

--- a/src/Server/Testing/TestResponse.php
+++ b/src/Server/Testing/TestResponse.php
@@ -9,7 +9,6 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
-use Illuminate\Testing\AssertableJsonString;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Laravel\Mcp\Server\Primitive;
 use Laravel\Mcp\Server\Prompt;
@@ -112,10 +111,12 @@ class TestResponse
      */
     public function assertStructuredContent(Closure|array $structuredContent): static
     {
-        $structuredContentResponse = $this->decodeStructuredContentResponse();
+        $actual = $this->structuredContent();
 
         if ($structuredContent instanceof Closure) {
-            $assertableJson = AssertableJson::fromAssertableJsonString($structuredContentResponse);
+            Assert::assertNotNull($actual, 'The response does not contain any structured content.');
+
+            $assertableJson = AssertableJson::fromArray($actual);
 
             $structuredContent($assertableJson);
 
@@ -125,8 +126,8 @@ class TestResponse
         }
 
         Assert::assertSame(
-            $structuredContent,
-            $structuredContentResponse->json(),
+            $this->toJsonRepresentation($structuredContent),
+            $actual,
             'The expected structured content does not match the actual structured content.'
         );
 
@@ -148,7 +149,7 @@ class TestResponse
         foreach ($this->notifications as $notification) {
             $content = $notification->toArray();
 
-            if ($content['method'] === $method && (is_array($params) === false || $content['params'] === $params)) {
+            if ($content['method'] === $method && (is_array($params) === false || $this->toJsonRepresentation($content['params']) === $this->toJsonRepresentation($params))) {
                 Assert::assertTrue(true); // @phpstan-ignore-line
 
                 return $this;
@@ -378,14 +379,29 @@ class TestResponse
         return $response['result']['completion']['values'] ?? [];
     }
 
-    protected function decodeStructuredContentResponse(): AssertableJsonString
+    /**
+     * @return array<string, mixed>|null
+     */
+    protected function structuredContent(): ?array
     {
-        $response = json_decode(
-            $this->response->toJson(),
+        $structuredContent = $this->response->toArray()['result']['structuredContent'] ?? null;
+
+        if (is_array($structuredContent) === false) {
+            return null;
+        }
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = $this->toJsonRepresentation($structuredContent);
+
+        return $decoded;
+    }
+
+    protected function toJsonRepresentation(mixed $value): mixed
+    {
+        return json_decode(
+            json_encode($value, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE),
             associative: true,
             flags: JSON_THROW_ON_ERROR,
         );
-
-        return new AssertableJsonString($response['result']['structuredContent'] ?? []);
     }
 }

--- a/tests/Feature/Testing/Tools/AssertNotificationTest.php
+++ b/tests/Feature/Testing/Tools/AssertNotificationTest.php
@@ -7,11 +7,29 @@ use Laravel\Mcp\Server\Tool;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\ExpectationFailedException;
 
+enum ReservationStep: string
+{
+    case Starting = 'starting';
+}
+
 class RestaurantT extends Server
 {
     protected array $tools = [
         ReservationTool::class,
+        SerializableNotificationTool::class,
     ];
+}
+
+class SerializableNotificationTool extends Tool
+{
+    public function handle(): Generator
+    {
+        yield Response::notification('booking/step', ['step' => ReservationStep::Starting]);
+
+        yield Response::notification('booking/empty', []);
+
+        yield 'Your booking is confirmed!';
+    }
 }
 
 class ReservationTool extends Tool
@@ -70,3 +88,16 @@ it('may fail to assert a notification that was sent with wrong params', function
 
     $response->assertSentNotification('booking/starting', ['step' => 2]);
 })->throws(AssertionFailedError::class);
+
+it('serializes notification params before asserting', function (): void {
+    $response = RestaurantT::tool(SerializableNotificationTool::class);
+
+    $response->assertSentNotification('booking/step', ['step' => ReservationStep::Starting])
+        ->assertSentNotification('booking/step', ['step' => 'starting']);
+});
+
+it('may assert a notification that was sent with empty params', function (): void {
+    $response = RestaurantT::tool(SerializableNotificationTool::class);
+
+    $response->assertSentNotification('booking/empty', []);
+});

--- a/tests/Feature/Testing/Tools/AssertStructuredContentTest.php
+++ b/tests/Feature/Testing/Tools/AssertStructuredContentTest.php
@@ -7,12 +7,35 @@ use Laravel\Mcp\Server;
 use Laravel\Mcp\Server\Tool;
 use PHPUnit\Framework\ExpectationFailedException;
 
+enum BookingStatus: string
+{
+    case Confirmed = 'confirmed';
+}
+
 class BookingServer extends Server
 {
     protected array $tools = [
         GetBookingTool::class,
         GetBookingWithoutStructuredContentTool::class,
+        GetBookingWithSerializableValuesTool::class,
     ];
+}
+
+class GetBookingWithSerializableValuesTool extends Tool
+{
+    protected string $name = 'booking/get/serializable';
+
+    protected string $title = 'Get booking';
+
+    protected string $description = 'Get a booking';
+
+    public function handle(): ResponseFactory
+    {
+        return Response::structured([
+            'status' => BookingStatus::Confirmed,
+            'amount' => 10.0,
+        ]);
+    }
 }
 
 class GetBookingTool extends Tool
@@ -87,4 +110,30 @@ it('fails to assert the structured content with closure', function (): void {
     $response = BookingServer::tool(GetBookingTool::class);
 
     $response->assertStructuredContent(fn (AssertableJson $json): AssertableJson => $json->where('type', 'foo')->etc());
+})->throws(ExpectationFailedException::class);
+
+it('serializes the structured content before asserting with a closure', function (): void {
+    $response = BookingServer::tool(GetBookingWithSerializableValuesTool::class);
+
+    $response->assertStructuredContent(
+        fn (AssertableJson $json): AssertableJson => $json
+            ->where('status', BookingStatus::Confirmed)
+            ->where('amount', 10)
+            ->etc()
+    );
+});
+
+it('serializes the structured content before asserting with an array', function (): void {
+    $response = BookingServer::tool(GetBookingWithSerializableValuesTool::class);
+
+    $response->assertStructuredContent([
+        'status' => BookingStatus::Confirmed,
+        'amount' => 10.0,
+    ]);
+});
+
+it('fails to assert the structured content with a closure when it is not present', function (): void {
+    $response = BookingServer::tool(GetBookingWithoutStructuredContentTool::class);
+
+    $response->assertStructuredContent(fn (AssertableJson $json): AssertableJson => $json->etc());
 })->throws(ExpectationFailedException::class);


### PR DESCRIPTION
Currently, the actual structuredContent sent in the response is not serialized when testing. Serialization only happens in `\Laravel\Mcp\Server` which is skipped when testing, which means the structured content being asserted is not the same as what is actually sent over the wire to the client.
Because of this, assertions produce a lot of unexpected behavior, as AssertableJson expects serialized/deserialized JSON.

For example:
```php
public function handle(): ResponseFactory                                                                                                                  
{                                                                                                                                                          
    return Response::structured([                                                                                                                          
        'status' => EmployeeStatus::ToDo                                                                                       
    ]);                                                                                                                                                    
}                                                                                                                                                          
                                                                                                                                                             
$response->assertStructuredContent(                                                                                                                        
    fn (AssertableJson $json): AssertableJson => $json                                                                                                     
        ->where('status', EmployeeStatus::Todo)                                                                                     
        ->etc()                                                                                                                                            
);
```
Currently does not work:
> Property [status] does not match the expected value.
Failed asserting that \EmployeeStatus Enum #5278 (ToDo, 'to_do') is identical to 'to_do'.

In this case "expected" enums are converted to strings for expectations. Which is correct, but the content in `AssertableJson` was never actually serialized to json. So the assertion fails.

When classes are used in the response, `where` always fails, as its checked by reference instead of value like the api `->assertJson`


