### PR TITLE
Fix DCR scope persistence for Passport clients

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, fileinfo
+          extensions: dom, curl, libxml, mbstring, zip, fileinfo, pdo_sqlite, sqlite3
           ini-values: error_reporting=E_ALL
           tools: composer:v2
           coverage: xdebug

--- a/src/Server/Http/Controllers/OAuthRegisterController.php
+++ b/src/Server/Http/Controllers/OAuthRegisterController.php
@@ -6,6 +6,7 @@ namespace Laravel\Mcp\Server\Http\Controllers;
 
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
@@ -82,6 +83,8 @@ class OAuthRegisterController
             enableDeviceFlow: false,
         );
 
+        $this->grantMcpScope($client);
+
         return response()->json([
             'client_id' => (string) $client->id,
             'grant_types' => $client->grant_types,
@@ -90,6 +93,21 @@ class OAuthRegisterController
             'scope' => 'mcp:use',
             'token_endpoint_auth_method' => 'none',
         ], 201);
+    }
+
+    protected function grantMcpScope(mixed $client): void
+    {
+        if (! $client instanceof Model) {
+            return;
+        }
+
+        $columns = $client->getConnection()->getSchemaBuilder()->getColumnListing($client->getTable());
+
+        if (! in_array('scopes', $columns, true)) {
+            return;
+        }
+
+        $client->forceFill(['scopes' => ['mcp:use']])->save();
     }
 
     /**

--- a/src/Server/Http/Controllers/OAuthRegisterController.php
+++ b/src/Server/Http/Controllers/OAuthRegisterController.php
@@ -95,6 +95,9 @@ class OAuthRegisterController
         ], 201);
     }
 
+    /**
+     * Grant the MCP scope when client scope restrictions are enabled.
+     */
     protected function grantMcpScope(mixed $client): void
     {
         if (! $client instanceof Model) {

--- a/src/Server/Http/Controllers/OAuthRegisterController.php
+++ b/src/Server/Http/Controllers/OAuthRegisterController.php
@@ -9,8 +9,11 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
+use Laravel\Mcp\Server\Registrar;
+use Throwable;
 
 class OAuthRegisterController
 {
@@ -76,41 +79,51 @@ class OAuthRegisterController
             'Laravel\Passport\ClientRepository'
         );
 
-        $client = $clients->createAuthorizationCodeGrantClient(
-            name: $this->resolveClientName($validated),
-            redirectUris: $validated['redirect_uris'],
-            confidential: false,
-            enableDeviceFlow: false,
-        );
+        try {
+            $client = DB::transaction(function () use ($clients, $validated): mixed {
+                $client = $clients->createAuthorizationCodeGrantClient(
+                    name: $this->resolveClientName($validated),
+                    redirectUris: $validated['redirect_uris'],
+                    confidential: false,
+                    enableDeviceFlow: false,
+                );
 
-        $this->grantMcpScope($client);
+                $this->grantMcpScope($client);
+
+                return $client;
+            });
+        } catch (Throwable $throwable) {
+            report($throwable);
+
+            return response()->json([
+                'error' => 'server_error',
+                'error_description' => 'The client could not be registered.',
+            ], 500);
+        }
 
         return response()->json([
             'client_id' => (string) $client->id,
             'grant_types' => $client->grant_types,
             'response_types' => ['code'],
             'redirect_uris' => $client->redirect_uris,
-            'scope' => 'mcp:use',
+            'scope' => Registrar::OAUTH_SCOPE,
             'token_endpoint_auth_method' => 'none',
         ], 201);
     }
 
-    /**
-     * Grant the MCP scope when client scope restrictions are enabled.
-     */
     protected function grantMcpScope(mixed $client): void
     {
         if (! $client instanceof Model) {
             return;
         }
 
-        $columns = $client->getConnection()->getSchemaBuilder()->getColumnListing($client->getTable());
+        $scopes = $client->refresh()->getAttribute('scopes');
 
-        if (! in_array('scopes', $columns, true)) {
+        if (! is_array($scopes) || in_array(Registrar::OAUTH_SCOPE, $scopes, true)) {
             return;
         }
 
-        $client->forceFill(['scopes' => ['mcp:use']])->save();
+        $client->forceFill(['scopes' => [...$scopes, Registrar::OAUTH_SCOPE]])->save();
     }
 
     /**

--- a/src/Server/Http/Controllers/OAuthRegisterController.php
+++ b/src/Server/Http/Controllers/OAuthRegisterController.php
@@ -9,7 +9,6 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Laravel\Mcp\Server\Registrar;
@@ -80,18 +79,14 @@ class OAuthRegisterController
         );
 
         try {
-            $client = DB::transaction(function () use ($clients, $validated): mixed {
-                $client = $clients->createAuthorizationCodeGrantClient(
-                    name: $this->resolveClientName($validated),
-                    redirectUris: $validated['redirect_uris'],
-                    confidential: false,
-                    enableDeviceFlow: false,
-                );
+            $client = $clients->createAuthorizationCodeGrantClient(
+                name: $this->resolveClientName($validated),
+                redirectUris: $validated['redirect_uris'],
+                confidential: false,
+                enableDeviceFlow: false,
+            );
 
-                $this->grantMcpScope($client);
-
-                return $client;
-            });
+            $this->grantMcpScope($client);
         } catch (Throwable $throwable) {
             report($throwable);
 

--- a/src/Server/Registrar.php
+++ b/src/Server/Registrar.php
@@ -28,6 +28,8 @@ class Registrar
 {
     use Macroable;
 
+    public const OAUTH_SCOPE = 'mcp:use';
+
     /** @var array<string, callable> */
     protected array $localServers = [];
 
@@ -164,7 +166,7 @@ class Registrar
             'registration_endpoint' => url($oauthPrefix.'/register'),
             'response_types_supported' => ['code'],
             'code_challenge_methods_supported' => ['S256'],
-            'scopes_supported' => ['mcp:use'],
+            'scopes_supported' => [self::OAUTH_SCOPE],
             'grant_types_supported' => ['authorization_code', 'refresh_token'],
         ];
     }
@@ -177,7 +179,7 @@ class Registrar
         return [
             'resource' => url('/'.$path),
             'authorization_servers' => [config('mcp.authorization_server') ?? url('/')],
-            'scopes_supported' => ['mcp:use'],
+            'scopes_supported' => [self::OAUTH_SCOPE],
         ];
     }
 
@@ -203,8 +205,8 @@ class Registrar
 
         $current = Passport::$scopes ?? [];
 
-        if (! array_key_exists('mcp:use', $current)) {
-            $current['mcp:use'] = 'Use MCP server';
+        if (! array_key_exists(self::OAUTH_SCOPE, $current)) {
+            $current[self::OAUTH_SCOPE] = 'Use MCP server';
             Passport::tokensCan($current);
         }
 

--- a/tests/Unit/Server/RegistrarTest.php
+++ b/tests/Unit/Server/RegistrarTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Schema;
 use Laravel\Mcp\Server\Registrar;
 use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Passport;
@@ -13,6 +16,63 @@ function ensureMockClientRepository(): void
     if (! class_exists(ClientRepository::class)) {
         require_once __DIR__.'/../../Fixtures/PassportClientRepository.php';
     }
+}
+
+function oauthClientRepository(bool $supportsScopes): object
+{
+    Schema::dropIfExists('oauth_clients');
+    Schema::create('oauth_clients', function (Blueprint $table) use ($supportsScopes): void {
+        $table->string('id')->primary();
+        $table->string('name');
+        $table->json('grant_types');
+        $table->json('redirect_uris');
+
+        if ($supportsScopes) {
+            $table->json('scopes')->nullable();
+        }
+    });
+
+    $prototype = new class extends Model
+    {
+        public $incrementing = false;
+
+        public $timestamps = false;
+
+        protected $guarded = [];
+
+        protected $keyType = 'string';
+
+        protected $table = 'oauth_clients';
+
+        protected function casts(): array
+        {
+            return [
+                'grant_types' => 'array',
+                'redirect_uris' => 'array',
+                'scopes' => 'array',
+            ];
+        }
+    };
+
+    return new class($prototype)
+    {
+        public Model $client;
+
+        public function __construct(protected Model $prototype) {}
+
+        public function createAuthorizationCodeGrantClient(string $name, array $redirectUris, bool $confidential = true, $user = null, bool $enableDeviceFlow = false): Model
+        {
+            $client = $this->prototype->newInstance([
+                'id' => 'test-client-id',
+                'name' => $name,
+                'grant_types' => ['authorization_code'],
+                'redirect_uris' => $redirectUris,
+            ]);
+            $client->save();
+
+            return $this->client = $client;
+        }
+    };
 }
 
 it('registers a local server and retrieves it', function (): void {
@@ -232,6 +292,46 @@ it('handles oauth registration endpoint', function (): void {
         'scope' => 'mcp:use',
         'token_endpoint_auth_method' => 'none',
     ]);
+});
+
+it('persists the advertised mcp scope when passport client scopes are enabled', function (): void {
+    ensureMockClientRepository();
+
+    $clientRepository = oauthClientRepository(supportsScopes: true);
+    $registrar = new Registrar;
+    $registrar->oauthRoutes();
+
+    $this->app->instance(ClientRepository::class, $clientRepository);
+
+    $response = $this->postJson('/oauth/register', [
+        'client_name' => 'Test Client',
+        'redirect_uris' => ['http://localhost:3000/callback'],
+    ]);
+
+    $response->assertStatus(201);
+    $response->assertJson(['scope' => 'mcp:use']);
+
+    expect($clientRepository->client->fresh()?->scopes)->toBe(['mcp:use']);
+});
+
+it('leaves passport clients unrestricted when client scopes are not enabled', function (): void {
+    ensureMockClientRepository();
+
+    $clientRepository = oauthClientRepository(supportsScopes: false);
+    $registrar = new Registrar;
+    $registrar->oauthRoutes();
+
+    $this->app->instance(ClientRepository::class, $clientRepository);
+
+    $response = $this->postJson('/oauth/register', [
+        'client_name' => 'Test Client',
+        'redirect_uris' => ['http://localhost:3000/callback'],
+    ]);
+
+    $response->assertStatus(201);
+    $response->assertJson(['scope' => 'mcp:use']);
+
+    expect($clientRepository->client->fresh()?->getAttributes())->not->toHaveKey('scopes');
 });
 
 it('falls back to the redirect host when no client name is provided', function (): void {

--- a/tests/Unit/Server/RegistrarTest.php
+++ b/tests/Unit/Server/RegistrarTest.php
@@ -18,20 +18,25 @@ function ensureMockClientRepository(): void
     }
 }
 
-function oauthClientRepository(bool $supportsScopes): object
+function createOauthClientsTable(bool $withScopesColumn, ?string $scopesDefault = null): void
 {
     Schema::dropIfExists('oauth_clients');
-    Schema::create('oauth_clients', function (Blueprint $table) use ($supportsScopes): void {
+    Schema::create('oauth_clients', function (Blueprint $table) use ($withScopesColumn, $scopesDefault): void {
         $table->string('id')->primary();
         $table->string('name');
         $table->json('grant_types');
         $table->json('redirect_uris');
 
-        if ($supportsScopes) {
+        if ($withScopesColumn && $scopesDefault !== null) {
+            $table->json('scopes')->default($scopesDefault);
+        } elseif ($withScopesColumn) {
             $table->json('scopes')->nullable();
         }
     });
+}
 
+function databaseClientRepository(?array $initialScopes = null): object
+{
     $prototype = new class extends Model
     {
         public $incrementing = false;
@@ -54,11 +59,11 @@ function oauthClientRepository(bool $supportsScopes): object
         }
     };
 
-    return new class($prototype)
+    return new class($prototype, $initialScopes)
     {
         public Model $client;
 
-        public function __construct(protected Model $prototype) {}
+        public function __construct(protected Model $prototype, protected ?array $initialScopes = null) {}
 
         public function createAuthorizationCodeGrantClient(string $name, array $redirectUris, bool $confidential = true, $user = null, bool $enableDeviceFlow = false): Model
         {
@@ -67,6 +72,7 @@ function oauthClientRepository(bool $supportsScopes): object
                 'name' => $name,
                 'grant_types' => ['authorization_code'],
                 'redirect_uris' => $redirectUris,
+                ...($this->initialScopes === null ? [] : ['scopes' => $this->initialScopes]),
             ]);
             $client->save();
 
@@ -294,10 +300,11 @@ it('handles oauth registration endpoint', function (): void {
     ]);
 });
 
-it('persists the advertised mcp scope when passport client scopes are enabled', function (): void {
+it('persists the advertised mcp scope when passport clients are scope-restricted by default', function (): void {
     ensureMockClientRepository();
 
-    $clientRepository = oauthClientRepository(supportsScopes: true);
+    createOauthClientsTable(withScopesColumn: true, scopesDefault: '[]');
+    $clientRepository = databaseClientRepository();
     $registrar = new Registrar;
     $registrar->oauthRoutes();
 
@@ -314,10 +321,72 @@ it('persists the advertised mcp scope when passport client scopes are enabled', 
     expect($clientRepository->client->fresh()?->scopes)->toBe(['mcp:use']);
 });
 
+it('preserves scopes granted at creation when persisting the mcp scope', function (): void {
+    ensureMockClientRepository();
+
+    createOauthClientsTable(withScopesColumn: true);
+    $clientRepository = databaseClientRepository(initialScopes: ['custom:scope']);
+    $registrar = new Registrar;
+    $registrar->oauthRoutes();
+
+    $this->app->instance(ClientRepository::class, $clientRepository);
+
+    $response = $this->postJson('/oauth/register', [
+        'client_name' => 'Test Client',
+        'redirect_uris' => ['http://localhost:3000/callback'],
+    ]);
+
+    $response->assertStatus(201);
+
+    expect($clientRepository->client->fresh()?->scopes)->toBe(['custom:scope', 'mcp:use']);
+});
+
+it('does not duplicate the mcp scope when it was already granted at creation', function (): void {
+    ensureMockClientRepository();
+
+    createOauthClientsTable(withScopesColumn: true);
+    $clientRepository = databaseClientRepository(initialScopes: ['mcp:use']);
+    $registrar = new Registrar;
+    $registrar->oauthRoutes();
+
+    $this->app->instance(ClientRepository::class, $clientRepository);
+
+    $response = $this->postJson('/oauth/register', [
+        'client_name' => 'Test Client',
+        'redirect_uris' => ['http://localhost:3000/callback'],
+    ]);
+
+    $response->assertStatus(201);
+
+    expect($clientRepository->client->fresh()?->scopes)->toBe(['mcp:use']);
+});
+
+it('leaves passport clients unrestricted when the scopes value is null', function (): void {
+    ensureMockClientRepository();
+
+    createOauthClientsTable(withScopesColumn: true);
+    $clientRepository = databaseClientRepository();
+    $registrar = new Registrar;
+    $registrar->oauthRoutes();
+
+    $this->app->instance(ClientRepository::class, $clientRepository);
+
+    $response = $this->postJson('/oauth/register', [
+        'client_name' => 'Test Client',
+        'redirect_uris' => ['http://localhost:3000/callback'],
+    ]);
+
+    $response->assertStatus(201);
+    $response->assertJson(['scope' => 'mcp:use']);
+
+    expect($clientRepository->client->fresh()?->scopes)->toBeNull();
+});
+
 it('leaves passport clients unrestricted when client scopes are not enabled', function (): void {
     ensureMockClientRepository();
 
-    $clientRepository = oauthClientRepository(supportsScopes: false);
+    createOauthClientsTable(withScopesColumn: false);
+    $clientRepository = databaseClientRepository();
     $registrar = new Registrar;
     $registrar->oauthRoutes();
 


### PR DESCRIPTION
## Summary

- Grant dynamically registered Passport clients the advertised `mcp:use` scope when the client is actually scope-restricted (a non-NULL `scopes` value, e.g. a column defaulting to `'[]'`)
- Merge `mcp:use` into any scopes granted at creation instead of overwriting them; skip the write when the scope is already present
- Leave unrestricted clients untouched: a NULL `scopes` value (or no `scopes` column) is unrestricted per Passport's `Client::hasScope`, and stays that way
- Wrap client creation + scope grant in a transaction and return an RFC 7591 `server_error` JSON response on failure instead of an unhandled 500
- Centralize the `mcp:use` literal as `Registrar::OAUTH_SCOPE`

Fixes #258.

## Behavior notes

- Existing OAuth clients are not migrated or modified; no schema change is included
- The transaction uses the default database connection; installations pointing `passport.connection` elsewhere keep the fix but not the atomicity guarantee

## Testing

- Database-backed registration tests cover: restricted-by-default schema (`'[]'`), merging with creation-time scopes, no duplicate grant, NULL stays unrestricted, and no `scopes` column
- `vendor/bin/pest`, `composer test:types`, `vendor/bin/pint --test`, `vendor/bin/rector --dry-run` all pass