### PR TITLE
Fix multiline SSE data event parsing

### DIFF
--- a/src/Client/Transport/HttpTransport.php
+++ b/src/Client/Transport/HttpTransport.php
@@ -218,14 +218,28 @@ class HttpTransport implements Transport
     protected function readSseStream(ClientResponse $response): void
     {
         $stream = $response->toPsrResponse()->getBody();
+        $dataLines = [];
 
         while (! $stream->eof()) {
-            $line = trim($this->readLine($stream));
+            $line = rtrim($this->readLine($stream), "\r\n");
 
-            if (Str::startsWith($line, 'data:')) {
-                $this->queueSseEvent(trim(Str::after($line, 'data:')));
+            if ($line === '') {
+                $this->queueSseEvent(implode("\n", $dataLines));
+                $dataLines = [];
+
+                continue;
             }
+
+            [$field, $value] = array_pad(explode(':', $line, 2), 2, '');
+
+            if ($field !== 'data') {
+                continue;
+            }
+
+            $dataLines[] = Str::startsWith($value, ' ') ? Str::after($value, ' ') : $value;
         }
+
+        $this->queueSseEvent(implode("\n", $dataLines));
     }
 
     protected function readLine(StreamInterface $stream): string

--- a/tests/Unit/Client/Transport/HttpTransportTest.php
+++ b/tests/Unit/Client/Transport/HttpTransportTest.php
@@ -45,6 +45,40 @@ it('parses an SSE stream into individual frames in order', function (): void {
         ->and(json_decode($transport->receive(), true))->toMatchArray(['id' => 1, 'result' => ['done' => true]]);
 });
 
+it('joins multiple data lines from the same SSE event', function (): void {
+    $stream = <<<'SSE'
+data: {"jsonrpc":"2.0",
+data: "id":1,"result":{"done":true}}
+
+SSE;
+
+    Http::fake(['*' => Http::response($stream, 200, ['Content-Type' => 'text/event-stream'])]);
+
+    $transport = new HttpTransport('https://mcp.test/mcp');
+    $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'tools/call', 'params' => []]));
+
+    expect(json_decode($transport->receive(), true))->toBe([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'result' => ['done' => true],
+    ])->and(fn (): string => $transport->receive())
+        ->toThrow(ClientException::class, 'No message available');
+});
+
+it('queues the final SSE event without a trailing blank line', function (): void {
+    $stream = 'data: '.json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => ['done' => true]]);
+
+    Http::fake(['*' => Http::response($stream, 200, ['Content-Type' => 'text/event-stream'])]);
+
+    $transport = new HttpTransport('https://mcp.test/mcp');
+    $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'tools/call', 'params' => []]));
+
+    expect(json_decode($transport->receive(), true))->toMatchArray([
+        'id' => 1,
+        'result' => ['done' => true],
+    ]);
+});
+
 it('fails fast when the server initiates a request over the SSE stream', function (): void {
     Http::fake(['*' => Http::response(sseStream([
         ['jsonrpc' => '2.0', 'id' => 99, 'method' => 'ping'],


### PR DESCRIPTION
## Summary

- buffer SSE `data` fields until the event's blank-line boundary
- join multiple `data` values with newlines as required by the SSE event format
- dispatch a final event when the stream ends without a trailing blank line

Before this change, each `data:` line was queued as a separate JSON-RPC message. A valid response split across multiple data fields therefore produced malformed fragments instead of one response.

## Tests

- `vendor/bin/pest tests/Unit/Client/Transport/HttpTransportTest.php` (32 tests, 75 assertions)
- `vendor/bin/pest --ci` (1007 tests, 2283 assertions)
- `vendor/bin/phpstan analyse --no-progress`
- `vendor/bin/pint --test src/Client/Transport/HttpTransport.php tests/Unit/Client/Transport/HttpTransportTest.php`
- `vendor/bin/rector process --dry-run src/Client/Transport/HttpTransport.php tests/Unit/Client/Transport/HttpTransportTest.php`
