### PR TITLE
Add dual-era support for the MCP 2026-07-28 stateless revision

### DIFF
--- a/src/Client/Methods/Discover.php
+++ b/src/Client/Methods/Discover.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\Methods;
+
+use Laravel\Mcp\Client\Contracts\Method;
+use Laravel\Mcp\Client\Protocol;
+use Laravel\Mcp\Client\Schema\DiscoverResult;
+use Laravel\Mcp\Enums\MetaKey;
+use Laravel\Mcp\Schema\Implementation;
+
+/**
+ * @implements Method<DiscoverResult>
+ */
+class Discover implements Method
+{
+    public function __construct(
+        protected Implementation $clientInfo,
+        protected string $protocolVersion,
+    ) {
+        //
+    }
+
+    public function method(): string
+    {
+        return 'server/discover';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function params(): array
+    {
+        return [
+            '_meta' => [
+                MetaKey::PROTOCOL_VERSION->value => $this->protocolVersion,
+                MetaKey::CLIENT_INFO->value => $this->clientInfo->toArray(),
+                MetaKey::CLIENT_CAPABILITIES->value => (object) [],
+            ],
+        ];
+    }
+
+    public function handle(Protocol $protocol): DiscoverResult
+    {
+        return DiscoverResult::from($protocol->dispatch($this));
+    }
+}

--- a/src/Client/Methods/Initialize.php
+++ b/src/Client/Methods/Initialize.php
@@ -31,7 +31,7 @@ class Initialize implements Method
     public function params(): array
     {
         return [
-            'protocolVersion' => ProtocolVersion::LATEST->value,
+            'protocolVersion' => ProtocolVersion::LATEST_LEGACY->value,
             'capabilities' => (object) [],
             'clientInfo' => $this->clientInfo->toArray(),
         ];

--- a/src/Client/Protocol.php
+++ b/src/Client/Protocol.php
@@ -8,8 +8,13 @@ use Illuminate\Support\Arr;
 use JsonException;
 use Laravel\Mcp\Client\Contracts\Method;
 use Laravel\Mcp\Client\Contracts\Transport;
+use Laravel\Mcp\Client\Exceptions\OAuthException;
+use Laravel\Mcp\Client\Methods\Discover;
 use Laravel\Mcp\Client\Methods\Initialize;
 use Laravel\Mcp\Client\Schema\InitializeResult;
+use Laravel\Mcp\Enums\ErrorCode;
+use Laravel\Mcp\Enums\MetaKey;
+use Laravel\Mcp\Enums\ProtocolVersion;
 use Laravel\Mcp\Exceptions\ClientException;
 use Laravel\Mcp\Exceptions\JsonRpcException;
 use Laravel\Mcp\Exceptions\SessionExpiredException;
@@ -25,7 +30,20 @@ class Protocol
 
     protected bool $connecting = false;
 
+    protected bool $modern = false;
+
+    /**
+     * Whether the server is known to require the legacy initialize handshake.
+     * The era determination is a property of the server, so it is cached for
+     * the lifetime of this protocol instance and reconnects skip the probe.
+     */
+    protected bool $knownLegacy = false;
+
+    protected ?string $negotiatedVersion = null;
+
     protected int $nextRequestId = 1;
+
+    protected int $nextProbeId = 1;
 
     protected ?InitializeResult $initializeResult = null;
 
@@ -56,11 +74,7 @@ class Protocol
         $this->connecting = true;
 
         try {
-            $this->initializeResult = (new Initialize($this->clientInfo))->handle($this);
-
-            $this->transport->setProtocolVersion($this->initializeResult->protocolVersion);
-
-            $this->notify('notifications/initialized');
+            $this->initializeResult = $this->negotiate();
         } catch (Throwable $throwable) {
             $this->disconnect();
 
@@ -70,6 +84,101 @@ class Protocol
         }
 
         $this->connected = true;
+    }
+
+    /**
+     * Probe the server with a modern, stateless [server/discover] request and
+     * fall back to the legacy initialize handshake when the server does not
+     * speak a mutually supported per-request-metadata revision.
+     */
+    protected function negotiate(): InitializeResult
+    {
+        if ($this->knownLegacy) {
+            return $this->legacyHandshake();
+        }
+
+        try {
+            return $this->discover(ProtocolVersion::LATEST->value);
+        } catch (JsonRpcException $jsonRpcException) {
+            if ($jsonRpcException->getCode() === ErrorCode::UNSUPPORTED_PROTOCOL_VERSION->value) {
+                $mutualVersion = $this->selectModernVersion(
+                    Arr::wrap($jsonRpcException->data()['supported'] ?? []),
+                );
+
+                if ($mutualVersion !== null) {
+                    return $this->discover($mutualVersion);
+                }
+            }
+
+            // Any other JSON-RPC error (e.g. method not found) identifies a legacy server.
+        } catch (OAuthException $oauthException) {
+            throw $oauthException;
+        } catch (ClientException) {
+            // An HTTP-level rejection without a modern JSON-RPC error body, or a
+            // stdio failure, identifies a legacy server.
+        }
+
+        // The transport may have torn itself down while the probe failed, and any
+        // probe-related transport state must not leak into the legacy handshake.
+        $this->transport->connect();
+
+        return $this->legacyHandshake();
+    }
+
+    /**
+     * @throws ClientException
+     * @throws JsonRpcException
+     */
+    protected function discover(string $protocolVersion): InitializeResult
+    {
+        $result = (new Discover($this->clientInfo, $protocolVersion))->handle($this);
+
+        $negotiated = in_array($protocolVersion, $result->supportedVersions, true)
+            ? $protocolVersion
+            : $this->selectModernVersion($result->supportedVersions);
+
+        if ($negotiated === null) {
+            throw new JsonRpcException('Unsupported protocol version', ErrorCode::UNSUPPORTED_PROTOCOL_VERSION->value, null, [
+                'supported' => $result->supportedVersions,
+                'requested' => $protocolVersion,
+            ]);
+        }
+
+        $this->modern = true;
+        $this->negotiatedVersion = $negotiated;
+        $this->transport->setProtocolVersion($negotiated);
+
+        return $result->toInitializeResult($negotiated);
+    }
+
+    protected function legacyHandshake(): InitializeResult
+    {
+        $this->knownLegacy = true;
+
+        $result = (new Initialize($this->clientInfo))->handle($this);
+
+        $this->modern = false;
+        $this->negotiatedVersion = $result->protocolVersion;
+        $this->transport->setProtocolVersion($result->protocolVersion);
+
+        $this->notify('notifications/initialized');
+
+        return $result;
+    }
+
+    /**
+     * The newest modern revision both parties support, if any.
+     *
+     * @param  array<array-key, mixed>  $serverVersions
+     */
+    protected function selectModernVersion(array $serverVersions): ?string
+    {
+        $mutual = array_intersect(
+            array_filter(ProtocolVersion::clientSupported(), ProtocolVersion::isModern(...)),
+            array_filter($serverVersions, is_string(...)),
+        );
+
+        return $mutual === [] ? null : max($mutual);
     }
 
     public function disconnect(): void
@@ -104,10 +213,16 @@ class Protocol
      */
     protected function attempt(Method $method): array
     {
+        $params = $method->params();
+
+        if ($this->modern) {
+            $params = $this->withModernMeta($params);
+        }
+
         $request = new JsonRpcRequest(
-            id: $this->nextRequestId++,
+            id: $method instanceof Discover ? 'discover-'.$this->nextProbeId++ : $this->nextRequestId++,
             method: $method->method(),
-            params: $method->params(),
+            params: $params,
         );
 
         try {
@@ -166,8 +281,33 @@ class Protocol
         }
 
         $result = Arr::get($response, 'result');
+        $result = is_array($result) ? $result : [];
 
-        return is_array($result) ? $result : [];
+        // Clients must treat results that omit [resultType] as complete. Interim
+        // multi-round-trip results cannot occur, as this client does not advertise
+        // any of the capabilities that allow servers to request input.
+        if (($result['resultType'] ?? 'complete') === 'input_required') {
+            throw new ClientException('The server returned an [input_required] result, but this client does not support multi round-trip requests.');
+        }
+
+        return $result;
+    }
+
+    /**
+     * Stamp the protocol metadata that modern revisions carry on every request.
+     *
+     * @param  array<string, mixed>  $params
+     * @return array<string, mixed>
+     */
+    protected function withModernMeta(array $params): array
+    {
+        $params['_meta'] = array_merge([
+            MetaKey::PROTOCOL_VERSION->value => $this->negotiatedVersion ?? ProtocolVersion::LATEST->value,
+            MetaKey::CLIENT_INFO->value => $this->clientInfo->toArray(),
+            MetaKey::CLIENT_CAPABILITIES->value => (object) [],
+        ], is_array($params['_meta'] ?? null) ? $params['_meta'] : []);
+
+        return $params;
     }
 
     public function notify(string $method): void

--- a/src/Client/Schema/DiscoverResult.php
+++ b/src/Client/Schema/DiscoverResult.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\Schema;
+
+use Illuminate\Support\Arr;
+use Laravel\Mcp\Enums\MetaKey;
+use Laravel\Mcp\Exceptions\ClientException;
+use Laravel\Mcp\Schema\Implementation;
+
+class DiscoverResult
+{
+    /**
+     * @param  array<int, string>  $supportedVersions
+     * @param  array<string, mixed>  $capabilities
+     */
+    public function __construct(
+        public array $supportedVersions,
+        public array $capabilities,
+        public ?Implementation $serverInfo = null,
+        public ?string $instructions = null,
+    ) {
+        //
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public static function from(array $payload): self
+    {
+        $supportedVersions = Arr::get($payload, 'supportedVersions');
+        $capabilities = Arr::get($payload, 'capabilities');
+        $instructions = Arr::get($payload, 'instructions');
+
+        if (! is_array($supportedVersions) || $supportedVersions === [] || $supportedVersions !== array_filter($supportedVersions, is_string(...))) {
+            throw new ClientException('Invalid discover response from server.');
+        }
+
+        /** @var array{name?: mixed, version?: mixed}|null $serverInfo */
+        $serverInfo = $payload['_meta'][MetaKey::SERVER_INFO->value] ?? null;
+
+        $hasServerInfo = is_array($serverInfo)
+            && is_string($serverInfo['name'] ?? null)
+            && is_string($serverInfo['version'] ?? null);
+
+        return new self(
+            supportedVersions: array_values($supportedVersions),
+            capabilities: is_array($capabilities) ? $capabilities : [],
+            // @phpstan-ignore-next-line
+            serverInfo: $hasServerInfo ? Implementation::from($serverInfo) : null,
+            instructions: is_string($instructions) ? $instructions : null,
+        );
+    }
+
+    /**
+     * Represent this discovery as the initialize result shape the client API exposes.
+     */
+    public function toInitializeResult(string $protocolVersion): InitializeResult
+    {
+        return new InitializeResult(
+            protocolVersion: $protocolVersion,
+            capabilities: $this->capabilities,
+            serverInfo: $this->serverInfo ?? new Implementation(name: 'unknown', version: 'unknown'),
+            instructions: $this->instructions,
+        );
+    }
+}

--- a/src/Client/Transport/HttpTransport.php
+++ b/src/Client/Transport/HttpTransport.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Str;
 use Laravel\Mcp\Client\Contracts\Transport;
 use Laravel\Mcp\Client\Exceptions\AuthorizationRequiredException;
 use Laravel\Mcp\Client\OAuth\WwwAuthenticateChallenge;
+use Laravel\Mcp\Enums\MetaKey;
 use Laravel\Mcp\Enums\ProtocolVersion;
 use Laravel\Mcp\Exceptions\ClientException;
 use Laravel\Mcp\Exceptions\SessionExpiredException;
@@ -100,7 +101,7 @@ class HttpTransport implements Transport
         $hadSession = $this->sessionId !== null;
 
         try {
-            $response = Http::withHeaders($this->headers())
+            $response = Http::withHeaders(array_merge($this->headers(), $this->requestMetadataHeaders($message)))
                 ->withBody($message, 'application/json')
                 ->timeout($this->timeoutSeconds)
                 ->withOptions(['stream' => true])
@@ -129,6 +130,18 @@ class HttpTransport implements Transport
         }
 
         if (! $response->successful()) {
+            // Modern servers reject requests with an HTTP error status carrying a
+            // JSON-RPC error body (e.g. 400 UnsupportedProtocolVersion, 404 Method
+            // not found). Surface those to the protocol layer instead of failing.
+            $body = trim($response->body());
+            $decoded = json_decode($body, true);
+
+            if (is_array($decoded) && isset($decoded['error']['code'])) {
+                $this->queue[] = $body;
+
+                return;
+            }
+
             $this->failWith("Unexpected HTTP status [{$response->status()}] from endpoint [{$this->url}].");
         }
 
@@ -184,7 +197,7 @@ class HttpTransport implements Transport
         }
 
         if ($this->initialized) {
-            $headers['MCP-Protocol-Version'] = $this->protocolVersion ?? ProtocolVersion::LATEST->value;
+            $headers['MCP-Protocol-Version'] = $this->protocolVersion ?? ProtocolVersion::LATEST_LEGACY->value;
         }
 
         $token = $this->token instanceof Closure ? (string) ($this->token)() : $this->token;
@@ -204,6 +217,61 @@ class HttpTransport implements Transport
         }
 
         return $headers;
+    }
+
+    /**
+     * The request metadata headers modern revisions require on every POST:
+     * MCP-Protocol-Version, Mcp-Method, and Mcp-Name mirror the body fields.
+     *
+     * @return array<string, string>
+     */
+    protected function requestMetadataHeaders(string $message): array
+    {
+        $decoded = json_decode($message, true);
+
+        if (! is_array($decoded) || ! array_key_exists('id', $decoded) || ! is_string($decoded['method'] ?? null)) {
+            return [];
+        }
+
+        $meta = $decoded['params']['_meta'] ?? null;
+        $version = is_array($meta) ? ($meta[MetaKey::PROTOCOL_VERSION->value] ?? null) : null;
+
+        if (! is_string($version) || ! ProtocolVersion::isModern($version)) {
+            return [];
+        }
+
+        $headers = [
+            'MCP-Protocol-Version' => $version,
+            'Mcp-Method' => $decoded['method'],
+        ];
+
+        $nameParameter = match ($decoded['method']) {
+            'tools/call', 'prompts/get' => 'name',
+            'resources/read' => 'uri',
+            default => null,
+        };
+
+        $name = $nameParameter !== null ? ($decoded['params'][$nameParameter] ?? null) : null;
+
+        if (is_string($name)) {
+            $headers['Mcp-Name'] = $this->encodeHeaderValue($name);
+        }
+
+        return $headers;
+    }
+
+    /**
+     * Encode a header value using the Base64 sentinel format when it cannot be
+     * safely represented as a plain ASCII header value.
+     */
+    protected function encodeHeaderValue(string $value): string
+    {
+        $plainAscii = preg_match('/^[\x21-\x7E](?:[\x20-\x7E]*[\x21-\x7E])?$/', $value) === 1;
+        $matchesSentinel = str_starts_with($value, '=?base64?') && str_ends_with($value, '?=');
+
+        return $plainAscii && ! $matchesSentinel
+            ? $value
+            : '=?base64?'.base64_encode($value).'?=';
     }
 
     protected function captureSessionId(ClientResponse $response): void

--- a/src/Enums/ErrorCode.php
+++ b/src/Enums/ErrorCode.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Enums;
+
+enum ErrorCode: int
+{
+    case METHOD_NOT_FOUND = -32601;
+    case INVALID_PARAMS = -32602;
+    case RESOURCE_NOT_FOUND_LEGACY = -32002;
+    case HEADER_MISMATCH = -32020;
+    case MISSING_REQUIRED_CLIENT_CAPABILITY = -32021;
+    case UNSUPPORTED_PROTOCOL_VERSION = -32022;
+}

--- a/src/Enums/MetaKey.php
+++ b/src/Enums/MetaKey.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Enums;
+
+enum MetaKey: string
+{
+    case PROTOCOL_VERSION = 'io.modelcontextprotocol/protocolVersion';
+    case CLIENT_INFO = 'io.modelcontextprotocol/clientInfo';
+    case CLIENT_CAPABILITIES = 'io.modelcontextprotocol/clientCapabilities';
+    case SERVER_INFO = 'io.modelcontextprotocol/serverInfo';
+}

--- a/src/Enums/ProtocolVersion.php
+++ b/src/Enums/ProtocolVersion.php
@@ -6,12 +6,15 @@ namespace Laravel\Mcp\Enums;
 
 enum ProtocolVersion: string
 {
+    case V2026_07_28 = '2026-07-28';
     case V2025_11_25 = '2025-11-25';
     case V2025_06_18 = '2025-06-18';
     case V2025_03_26 = '2025-03-26';
     case V2024_11_05 = '2024-11-05';
 
-    public const LATEST = self::V2025_11_25;
+    public const LATEST = self::V2026_07_28;
+
+    public const LATEST_LEGACY = self::V2025_11_25;
 
     /**
      * @return array<int, string>
@@ -27,8 +30,30 @@ enum ProtocolVersion: string
     public static function clientSupported(): array
     {
         return [
+            self::V2026_07_28->value,
             self::V2025_11_25->value,
             self::V2025_06_18->value,
         ];
+    }
+
+    /**
+     * Determine if the given revision conveys protocol metadata per-request
+     * instead of negotiating a session with an initialize handshake.
+     */
+    public static function isModern(string $version): bool
+    {
+        return $version >= self::V2026_07_28->value;
+    }
+
+    /**
+     * The newest handshake-based revision within the given supported list.
+     *
+     * @param  array<int, string>  $supportedVersions
+     */
+    public static function latestLegacy(array $supportedVersions): ?string
+    {
+        $legacy = array_filter($supportedVersions, fn (string $version): bool => ! self::isModern($version));
+
+        return $legacy === [] ? null : max($legacy);
     }
 }

--- a/src/Exceptions/JsonRpcException.php
+++ b/src/Exceptions/JsonRpcException.php
@@ -21,6 +21,14 @@ class JsonRpcException extends Exception
         parent::__construct($message, $code);
     }
 
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function data(): ?array
+    {
+        return $this->data;
+    }
+
     public function toJsonRpcResponse(): JsonRpcResponse
     {
         $id = is_string($this->requestId) || is_int($this->requestId)

--- a/src/Server.php
+++ b/src/Server.php
@@ -6,6 +6,8 @@ namespace Laravel\Mcp;
 
 use Illuminate\Container\Container;
 use Illuminate\Support\Str;
+use Laravel\Mcp\Enums\ErrorCode;
+use Laravel\Mcp\Enums\MetaKey;
 use Laravel\Mcp\Enums\ProtocolVersion;
 use Laravel\Mcp\Events\SessionInitialized;
 use Laravel\Mcp\Exceptions\JsonRpcException;
@@ -20,6 +22,7 @@ use Laravel\Mcp\Server\Contracts\Method;
 use Laravel\Mcp\Server\Contracts\Transport;
 use Laravel\Mcp\Server\Methods\CallTool;
 use Laravel\Mcp\Server\Methods\CompletionComplete;
+use Laravel\Mcp\Server\Methods\Discover;
 use Laravel\Mcp\Server\Methods\GetPrompt;
 use Laravel\Mcp\Server\Methods\Initialize;
 use Laravel\Mcp\Server\Methods\ListPrompts;
@@ -105,6 +108,28 @@ abstract class Server
     public int $defaultPaginationLength = 15;
 
     /**
+     * Freshness hint, in milliseconds, attached to cacheable results for modern clients.
+     */
+    protected int $cacheTtlMs = 0;
+
+    /**
+     * Whether shared intermediaries may cache responses: "public" or "private".
+     */
+    protected string $cacheScope = 'private';
+
+    /**
+     * Methods whose results carry the [ttlMs] and [cacheScope] fields for modern clients.
+     */
+    protected const CACHEABLE_METHODS = [
+        'tools/list',
+        'prompts/list',
+        'resources/list',
+        'resources/read',
+        'resources/templates/list',
+        'server/discover',
+    ];
+
+    /**
      * @var array<string, class-string<Method>>
      */
     protected array $methods = [
@@ -117,6 +142,7 @@ abstract class Server
         'prompts/get' => GetPrompt::class,
         'completion/complete' => CompletionComplete::class,
         'ping' => Ping::class,
+        'server/discover' => Discover::class,
     ];
 
     public function __construct(
@@ -193,7 +219,25 @@ abstract class Server
                 return;
             }
 
-            if ($request->method === 'initialize') {
+            $declaredVersion = $request->protocolVersion();
+
+            if ($declaredVersion !== null) {
+                if (! in_array($declaredVersion, $context->supportedProtocolVersions, true)) {
+                    throw new JsonRpcException(
+                        message: 'Unsupported protocol version',
+                        code: ErrorCode::UNSUPPORTED_PROTOCOL_VERSION->value,
+                        requestId: $request->id,
+                        data: [
+                            'supported' => $context->supportedProtocolVersions,
+                            'requested' => $declaredVersion,
+                        ],
+                    );
+                }
+
+                $context->protocolVersion = $declaredVersion;
+            }
+
+            if ($request->method === 'initialize' && ! $context->isModern()) {
                 $this->handleInitializeMessage($request, $context);
 
                 return;
@@ -249,6 +293,8 @@ abstract class Server
             tools: $this->tools,
             resources: $this->resources,
             prompts: $this->prompts,
+            cacheTtlMs: $this->cacheTtlMs,
+            cacheScope: $this->cacheScope,
         );
     }
 
@@ -268,16 +314,39 @@ abstract class Server
         $response = $this->runMethodHandle($request, $context);
 
         if (! is_iterable($response)) {
-            $this->transport->send($response->toJson());
+            $this->transport->send($this->prepareResponse($request, $context, $response)->toJson());
 
             return;
         }
 
-        $this->transport->stream(function () use ($response): void {
+        $this->transport->stream(function () use ($request, $context, $response): void {
             foreach ($response as $message) {
-                $this->transport->send($message->toJson());
+                $this->transport->send($this->prepareResponse($request, $context, $message)->toJson());
             }
         });
+    }
+
+    /**
+     * Decorate results for modern clients with the fields the stateless revision requires.
+     */
+    protected function prepareResponse(JsonRpcRequest $request, ServerContext $context, JsonRpcResponse $response): JsonRpcResponse
+    {
+        if (! $context->isModern() || ! $response->isResult()) {
+            return $response;
+        }
+
+        $fields = ['resultType' => 'complete'];
+
+        if (in_array($request->method, static::CACHEABLE_METHODS, true)) {
+            $fields['ttlMs'] = $context->cacheTtlMs;
+            $fields['cacheScope'] = $context->cacheScope;
+        }
+
+        return $response
+            ->mergeResult($fields)
+            ->mergeResultMeta([
+                MetaKey::SERVER_INFO->value => $context->implementation->toArray(),
+            ]);
     }
 
     /**

--- a/src/Server/Methods/Discover.php
+++ b/src/Server/Methods/Discover.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Server\Methods;
+
+use Laravel\Mcp\Server\Contracts\Method;
+use Laravel\Mcp\Server\ServerContext;
+use Laravel\Mcp\Transport\JsonRpcRequest;
+use Laravel\Mcp\Transport\JsonRpcResponse;
+
+class Discover implements Method
+{
+    public function handle(JsonRpcRequest $request, ServerContext $context): JsonRpcResponse
+    {
+        return JsonRpcResponse::result($request->id, [
+            'supportedVersions' => $context->supportedProtocolVersions,
+            'capabilities' => $context->serverCapabilities,
+            'instructions' => $context->instructions,
+        ]);
+    }
+}

--- a/src/Server/Methods/Initialize.php
+++ b/src/Server/Methods/Initialize.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp\Server\Methods;
 
+use Laravel\Mcp\Enums\ProtocolVersion;
 use Laravel\Mcp\Exceptions\JsonRpcException;
 use Laravel\Mcp\Server\Contracts\Method;
 use Laravel\Mcp\Server\ServerContext;
@@ -28,7 +29,26 @@ class Initialize implements Method
             );
         }
 
-        $protocolVersion = $requestedVersion ?? $context->supportedProtocolVersions[0];
+        $latestLegacy = ProtocolVersion::latestLegacy($context->supportedProtocolVersions);
+
+        if ($latestLegacy === null) {
+            throw new JsonRpcException(
+                message: 'This server does not support initialization-based protocol versions',
+                code: -32602,
+                requestId: $request->id,
+                data: [
+                    'supported' => $context->supportedProtocolVersions,
+                    'requested' => $requestedVersion,
+                ]
+            );
+        }
+
+        // Modern revisions are stateless and cannot be negotiated via a handshake,
+        // so an initialize request never yields a version newer than the latest
+        // handshake-based revision the server supports.
+        $protocolVersion = $requestedVersion !== null && ! ProtocolVersion::isModern($requestedVersion)
+            ? $requestedVersion
+            : $latestLegacy;
 
         return JsonRpcResponse::result($request->id, [
             'protocolVersion' => $protocolVersion,

--- a/src/Server/Methods/ReadResource.php
+++ b/src/Server/Methods/ReadResource.php
@@ -8,6 +8,7 @@ use Generator;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use InvalidArgumentException;
+use Laravel\Mcp\Enums\ErrorCode;
 use Laravel\Mcp\Exceptions\JsonRpcException;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
@@ -39,7 +40,13 @@ class ReadResource implements Method
         try {
             $resource = $this->resolveResource($uri, $context);
         } catch (InvalidArgumentException $invalidArgumentException) {
-            throw new JsonRpcException($invalidArgumentException->getMessage(), -32002, $request->id);
+            // The 2026-07-28 revision aligns missing-resource errors with JSON-RPC's
+            // Invalid Params code; earlier revisions used the MCP-specific -32002.
+            throw new JsonRpcException(
+                $invalidArgumentException->getMessage(),
+                $context->isModern() ? ErrorCode::INVALID_PARAMS->value : ErrorCode::RESOURCE_NOT_FOUND_LEGACY->value,
+                $request->id,
+            );
         }
 
         $response = $this->callHandler(fn (): mixed => $this->invokeResource($resource, $uri), $request);

--- a/src/Server/Middleware/ValidateModernMcpRequest.php
+++ b/src/Server/Middleware/ValidateModernMcpRequest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Server\Middleware;
+
+use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Laravel\Mcp\Enums\ErrorCode;
+use Laravel\Mcp\Enums\MetaKey;
+use Laravel\Mcp\Enums\ProtocolVersion;
+use Laravel\Mcp\Transport\JsonRpcResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Validates the request metadata headers the 2026-07-28 Streamable HTTP
+ * revision requires: MCP-Protocol-Version, Mcp-Method, and Mcp-Name must
+ * mirror the corresponding JSON-RPC body fields.
+ */
+class ValidateModernMcpRequest
+{
+    /**
+     * Methods that must mirror a body field into the Mcp-Name header,
+     * mapped to the parameter carrying the name.
+     */
+    protected const NAMED_METHODS = [
+        'tools/call' => 'name',
+        'prompts/get' => 'name',
+        'resources/read' => 'uri',
+    ];
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $body = json_decode($request->getContent(), true);
+
+        if (! is_array($body)) {
+            return $next($request);
+        }
+
+        $meta = $body['params']['_meta'] ?? null;
+        $declaredVersion = is_array($meta) ? ($meta[MetaKey::PROTOCOL_VERSION->value] ?? null) : null;
+        $declaredVersion = is_string($declaredVersion) ? $declaredVersion : null;
+
+        $headerVersion = $request->headers->get('MCP-Protocol-Version');
+
+        $modern = ($declaredVersion !== null && ProtocolVersion::isModern($declaredVersion))
+            || ($headerVersion !== null && ProtocolVersion::isModern($headerVersion));
+
+        // Notifications have no defined header requirements in this revision, and
+        // legacy-era requests are validated by their own revision's rules.
+        if (! $modern || ! array_key_exists('id', $body)) {
+            return $next($request);
+        }
+
+        $requestId = is_string($body['id']) || is_int($body['id']) ? $body['id'] : null;
+
+        if ($headerVersion !== $declaredVersion) {
+            return $this->headerMismatch($requestId, sprintf(
+                'Header mismatch: MCP-Protocol-Version header value %s does not match body value %s',
+                $this->describe($headerVersion),
+                $this->describe($declaredVersion),
+            ));
+        }
+
+        $method = $body['method'] ?? null;
+        $headerMethod = $request->headers->get('Mcp-Method');
+
+        if (! is_string($method) || $headerMethod !== $method) {
+            return $this->headerMismatch($requestId, sprintf(
+                'Header mismatch: Mcp-Method header value %s does not match body value %s',
+                $this->describe($headerMethod),
+                $this->describe(is_string($method) ? $method : null),
+            ));
+        }
+
+        $nameParameter = self::NAMED_METHODS[$method] ?? null;
+
+        if ($nameParameter !== null) {
+            $bodyName = $body['params'][$nameParameter] ?? null;
+            $headerName = $this->decodeHeaderValue($request->headers->get('Mcp-Name'));
+
+            if (! is_string($bodyName) || $headerName !== $bodyName) {
+                return $this->headerMismatch($requestId, sprintf(
+                    'Header mismatch: Mcp-Name header value %s does not match body value %s',
+                    $this->describe($headerName),
+                    $this->describe(is_string($bodyName) ? $bodyName : null),
+                ));
+            }
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * Decode the Base64 sentinel format ("=?base64?{value}?=") when present.
+     */
+    protected function decodeHeaderValue(?string $value): ?string
+    {
+        if ($value === null || preg_match('/^=\?base64\?(.*)\?=$/s', $value, $matches) !== 1) {
+            return $value;
+        }
+
+        $decoded = base64_decode($matches[1], true);
+
+        return $decoded === false ? null : $decoded;
+    }
+
+    protected function headerMismatch(string|int|null $requestId, string $message): JsonResponse
+    {
+        return new JsonResponse(
+            JsonRpcResponse::error($requestId, ErrorCode::HEADER_MISMATCH->value, $message)->toArray(),
+            400,
+        );
+    }
+
+    protected function describe(?string $value): string
+    {
+        return $value === null ? '[missing]' : "'{$value}'";
+    }
+}

--- a/src/Server/Registrar.php
+++ b/src/Server/Registrar.php
@@ -20,6 +20,7 @@ use Laravel\Mcp\Server\Contracts\Transport;
 use Laravel\Mcp\Server\Http\Controllers\OAuthRegisterController;
 use Laravel\Mcp\Server\Middleware\AddWwwAuthenticateHeader;
 use Laravel\Mcp\Server\Middleware\ReorderJsonAccept;
+use Laravel\Mcp\Server\Middleware\ValidateModernMcpRequest;
 use Laravel\Mcp\Server\Transport\HttpTransport;
 use Laravel\Mcp\Server\Transport\StdioTransport;
 use Laravel\Passport\Passport;
@@ -56,6 +57,7 @@ class Registrar
         ))->middleware([
             ReorderJsonAccept::class,
             AddWwwAuthenticateHeader::class,
+            ValidateModernMcpRequest::class,
         ]);
 
         assert($route instanceof Route);

--- a/src/Server/ServerContext.php
+++ b/src/Server/ServerContext.php
@@ -6,6 +6,7 @@ namespace Laravel\Mcp\Server;
 
 use Illuminate\Container\Container;
 use Illuminate\Support\Collection;
+use Laravel\Mcp\Enums\ProtocolVersion;
 use Laravel\Mcp\Schema\Implementation;
 use Laravel\Mcp\Server\Contracts\HasUriTemplate;
 
@@ -28,8 +29,19 @@ class ServerContext
         protected array $tools,
         protected array $resources,
         protected array $prompts,
+        public ?string $protocolVersion = null,
+        public int $cacheTtlMs = 0,
+        public string $cacheScope = 'private',
     ) {
         //
+    }
+
+    /**
+     * Determine if the request being served declared a stateless, per-request-metadata revision.
+     */
+    public function isModern(): bool
+    {
+        return $this->protocolVersion !== null && ProtocolVersion::isModern($this->protocolVersion);
     }
 
     /**

--- a/src/Server/Transport/HttpTransport.php
+++ b/src/Server/Transport/HttpTransport.php
@@ -7,6 +7,8 @@ namespace Laravel\Mcp\Server\Transport;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Laravel\Mcp\Enums\ErrorCode;
+use Laravel\Mcp\Enums\ProtocolVersion;
 use Laravel\Mcp\Server\Contracts\Transport;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -68,7 +70,7 @@ class HttpTransport implements Transport
         }
 
         // Must be 202 - https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#sending-messages-to-the-server
-        $statusCode = $this->reply === null ? 202 : 200;
+        $statusCode = $this->reply === null ? 202 : $this->replyStatusCode();
         $response = response($this->reply, $statusCode, $this->getHeaders());
 
         assert($response instanceof Response);
@@ -102,6 +104,30 @@ class HttpTransport implements Transport
         }
 
         flush();
+    }
+
+    /**
+     * The 2026-07-28 revision maps protocol errors to HTTP statuses: unknown
+     * methods are 404 and version or header validation failures are 400.
+     */
+    protected function replyStatusCode(): int
+    {
+        $version = $this->request->headers->get('MCP-Protocol-Version');
+
+        if ($version === null || ! ProtocolVersion::isModern($version)) {
+            return 200;
+        }
+
+        $reply = json_decode((string) $this->reply, true);
+        $code = is_array($reply) ? ($reply['error']['code'] ?? null) : null;
+
+        return match ($code) {
+            ErrorCode::METHOD_NOT_FOUND->value => 404,
+            ErrorCode::HEADER_MISMATCH->value,
+            ErrorCode::MISSING_REQUIRED_CLIENT_CAPABILITY->value,
+            ErrorCode::UNSUPPORTED_PROTOCOL_VERSION->value => 400,
+            default => 200,
+        };
     }
 
     /**

--- a/src/Transport/JsonRpcRequest.php
+++ b/src/Transport/JsonRpcRequest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp\Transport;
 
+use Laravel\Mcp\Enums\MetaKey;
+use Laravel\Mcp\Enums\ProtocolVersion;
 use Laravel\Mcp\Exceptions\JsonRpcException;
 use Laravel\Mcp\Request;
 
@@ -75,6 +77,26 @@ class JsonRpcRequest
     public function meta(): ?array
     {
         return isset($this->params['_meta']) && is_array($this->params['_meta']) ? $this->params['_meta'] : null;
+    }
+
+    /**
+     * The protocol version declared in the request's [_meta], if any.
+     */
+    public function protocolVersion(): ?string
+    {
+        $version = $this->meta()[MetaKey::PROTOCOL_VERSION->value] ?? null;
+
+        return is_string($version) ? $version : null;
+    }
+
+    /**
+     * Determine if the request declares a stateless, per-request-metadata revision.
+     */
+    public function isModern(): bool
+    {
+        $version = $this->protocolVersion();
+
+        return $version !== null && ProtocolVersion::isModern($version);
     }
 
     public function toRequest(): Request

--- a/src/Transport/JsonRpcResponse.php
+++ b/src/Transport/JsonRpcResponse.php
@@ -59,6 +59,53 @@ class JsonRpcResponse implements Arrayable
     }
 
     /**
+     * Determine if this message carries a [result] member.
+     */
+    public function isResult(): bool
+    {
+        return array_key_exists('result', $this->content);
+    }
+
+    /**
+     * Merge the given fields into the [result] member without overriding existing keys.
+     *
+     * @param  array<string, mixed>  $fields
+     */
+    public function mergeResult(array $fields): static
+    {
+        if (! $this->isResult()) {
+            return $this;
+        }
+
+        $result = (array) $this->content['result'];
+
+        $clone = clone $this;
+        $clone->content['result'] = array_merge($fields, $result);
+
+        return $clone;
+    }
+
+    /**
+     * Merge the given keys into the [result._meta] member without overriding existing keys.
+     *
+     * @param  array<string, mixed>  $meta
+     */
+    public function mergeResultMeta(array $meta): static
+    {
+        if (! $this->isResult()) {
+            return $this;
+        }
+
+        $result = (array) $this->content['result'];
+        $result['_meta'] = array_merge($meta, (array) ($result['_meta'] ?? []));
+
+        $clone = clone $this;
+        $clone->content['result'] = $result;
+
+        return $clone;
+    }
+
+    /**
      * @return array<string, mixed>
      */
     public function toArray(): array

--- a/tests/Fixtures/Client/FakeTransport.php
+++ b/tests/Fixtures/Client/FakeTransport.php
@@ -19,6 +19,12 @@ class FakeTransport implements Transport
 
     public ?string $repeatResponse = null;
 
+    /**
+     * The canned reply for the modern [server/discover] probe. When null, the
+     * fake behaves like a legacy server and rejects the probe with -32601.
+     */
+    public ?string $discoverResponse = null;
+
     public float $timeoutSeconds = 30.0;
 
     public ?string $protocolVersion = null;
@@ -36,6 +42,31 @@ class FakeTransport implements Transport
     public function send(string $message): void
     {
         $this->sent[] = $message;
+
+        $decoded = json_decode($message, true);
+
+        if (is_array($decoded) && ($decoded['method'] ?? null) === 'server/discover') {
+            array_unshift($this->responses, $this->discoverReply($decoded['id'] ?? null));
+        }
+    }
+
+    protected function discoverReply(mixed $id): string
+    {
+        if ($this->discoverResponse !== null) {
+            $reply = json_decode($this->discoverResponse, true);
+            $reply['id'] = $id;
+
+            return json_encode($reply);
+        }
+
+        return json_encode([
+            'jsonrpc' => '2.0',
+            'id' => $id,
+            'error' => [
+                'code' => -32601,
+                'message' => 'The method [server/discover] was not found.',
+            ],
+        ]);
     }
 
     public function setTimeoutSeconds(float $seconds): void

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -65,6 +65,18 @@ function initializeResponse(): string
     ]);
 }
 
+function discoverNotFoundResponse(int $probe = 1): string
+{
+    return json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 'discover-'.$probe,
+        'error' => [
+            'code' => -32601,
+            'message' => 'The method [server/discover] was not found.',
+        ],
+    ]);
+}
+
 function pingResponse(int $id): string
 {
     return json_encode([

--- a/tests/Unit/Client/ClientTest.php
+++ b/tests/Unit/Client/ClientTest.php
@@ -20,19 +20,23 @@ it('performs the initialize handshake on connect', function (): void {
 
     expect($transport->connected)->toBeTrue();
     expect($client->connected())->toBeTrue();
-    expect($client->initializeResult()?->protocolVersion)->toBe(ProtocolVersion::LATEST->value);
+    expect($client->initializeResult()?->protocolVersion)->toBe(ProtocolVersion::LATEST_LEGACY->value);
     expect($client->initializeResult()?->serverInfo->name)->toBe('Test Server');
     expect($client->initializeResult()?->serverInfo->version)->toBe('1.0.0');
     expect($client->initializeResult()?->capabilities)->toBeArray();
     expect($client->initializeResult())->not->toBeNull();
     expect($client->initializeResult()?->instructions)->toBeNull();
 
-    $initialize = json_decode($transport->sent[0], true);
+    $discover = json_decode($transport->sent[0], true);
+    expect($discover['method'])->toBe('server/discover');
+    expect($discover['params']['_meta']['io.modelcontextprotocol/protocolVersion'])->toBe(ProtocolVersion::LATEST->value);
+
+    $initialize = json_decode($transport->sent[1], true);
     expect($initialize['method'])->toBe('initialize');
-    expect($initialize['params']['protocolVersion'])->toBe(ProtocolVersion::LATEST->value);
+    expect($initialize['params']['protocolVersion'])->toBe(ProtocolVersion::LATEST_LEGACY->value);
     expect($initialize['params']['clientInfo']['name'])->toBe('Acme MCP App');
 
-    $initialized = json_decode($transport->sent[1], true);
+    $initialized = json_decode($transport->sent[2], true);
     expect($initialized['method'])->toBe('notifications/initialized');
     expect($initialized)->not->toHaveKey('id');
 });
@@ -66,7 +70,7 @@ it('pings the server', function (): void {
     $client = new Client($transport);
     $client->ping();
 
-    $ping = json_decode($transport->sent[2], true);
+    $ping = json_decode($transport->sent[3], true);
     expect($ping['method'])->toBe('ping');
     expect($ping['id'])->toBe(2);
 });
@@ -93,7 +97,7 @@ it('does not reconnect when already connected', function (): void {
     $client->connect();
     $client->connect();
 
-    expect(count($transport->sent))->toBe(2);
+    expect(count($transport->sent))->toBe(3);
 });
 
 it('disconnects cleanly', function (): void {
@@ -275,7 +279,7 @@ it('responds to server-initiated ping requests with an empty result', function (
     $client = new Client($transport);
     $client->ping();
 
-    $pingReply = json_decode($transport->sent[3], true);
+    $pingReply = json_decode($transport->sent[4], true);
     expect($pingReply['id'])->toBe('server-ping-1');
     expect($pingReply['result'])->toBeArray()->toBeEmpty();
     expect($pingReply)->not->toHaveKey('error');
@@ -295,7 +299,7 @@ it('responds with method-not-found to unsupported server-initiated requests', fu
     $client = new Client($transport);
     $client->ping();
 
-    $errorReply = json_decode($transport->sent[3], true);
+    $errorReply = json_decode($transport->sent[4], true);
     expect($errorReply['id'])->toBe('sampling-1');
     expect($errorReply['error']['code'])->toBe(-32601);
     expect($errorReply['error']['message'])->toContain('sampling/createMessage');

--- a/tests/Unit/Client/ModernClientTest.php
+++ b/tests/Unit/Client/ModernClientTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Mcp\Client;
+use Laravel\Mcp\Enums\ProtocolVersion;
+use Laravel\Mcp\Exceptions\ClientException;
+use Tests\Fixtures\Client\FakeTransport;
+
+function discoverResponse(array $overrides = []): string
+{
+    return json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 'discover-1',
+        'result' => array_merge([
+            'resultType' => 'complete',
+            'supportedVersions' => ProtocolVersion::supported(),
+            'capabilities' => ['tools' => (object) []],
+            'instructions' => 'Test instructions.',
+            'ttlMs' => 0,
+            'cacheScope' => 'private',
+            '_meta' => [
+                'io.modelcontextprotocol/serverInfo' => ['name' => 'Modern Server', 'version' => '2.0.0'],
+            ],
+        ], $overrides),
+    ]);
+}
+
+it('negotiates the modern revision through server/discover without a handshake', function (): void {
+    $transport = new FakeTransport;
+    $transport->discoverResponse = discoverResponse();
+
+    $client = new Client($transport);
+    $client->connect();
+
+    expect($client->initializeResult()?->protocolVersion)->toBe(ProtocolVersion::LATEST->value)
+        ->and($client->initializeResult()?->serverInfo->name)->toBe('Modern Server')
+        ->and($client->initializeResult()?->instructions)->toBe('Test instructions.');
+
+    $methods = array_map(
+        fn (string $message): mixed => json_decode($message, true)['method'] ?? null,
+        $transport->sent,
+    );
+
+    expect($methods)->toBe(['server/discover'])
+        ->and($transport->protocolVersion)->toBe(ProtocolVersion::LATEST->value);
+});
+
+it('stamps protocol metadata into _meta on every modern request', function (): void {
+    $transport = new FakeTransport;
+    $transport->discoverResponse = discoverResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'result' => ['resultType' => 'complete', 'tools' => []],
+    ]);
+
+    (new Client($transport))->tools();
+
+    $listRequest = json_decode(end($transport->sent), true);
+    $meta = $listRequest['params']['_meta'];
+
+    expect($listRequest['method'])->toBe('tools/list')
+        ->and($meta['io.modelcontextprotocol/protocolVersion'])->toBe(ProtocolVersion::LATEST->value)
+        ->and($meta['io.modelcontextprotocol/clientInfo'])->toHaveKeys(['name', 'version'])
+        ->and($meta)->toHaveKey('io.modelcontextprotocol/clientCapabilities');
+});
+
+it('falls back to the legacy handshake when discover reports no mutual modern version', function (): void {
+    $transport = new FakeTransport;
+    $transport->discoverResponse = discoverResponse(['supportedVersions' => ['2099-01-01']]);
+    $transport->responses[] = initializeResponse();
+
+    $client = new Client($transport);
+    $client->connect();
+
+    expect($client->initializeResult()?->protocolVersion)->toBe(ProtocolVersion::LATEST_LEGACY->value);
+
+    $methods = array_map(
+        fn (string $message): mixed => json_decode($message, true)['method'] ?? null,
+        $transport->sent,
+    );
+
+    expect($methods)->toContain('initialize')
+        ->and($methods)->toContain('notifications/initialized');
+});
+
+it('skips the discover probe on reconnect once the server era is known to be legacy', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'protocolVersion' => '2025-11-25',
+            'capabilities' => new stdClass,
+            'serverInfo' => ['name' => 'Test Server', 'version' => '1.0.0'],
+        ],
+    ]);
+
+    $client = new Client($transport);
+    $client->connect();
+    $client->disconnect();
+    $client->connect();
+
+    $probes = array_filter(
+        $transport->sent,
+        fn (string $message): bool => (json_decode($message, true)['method'] ?? null) === 'server/discover',
+    );
+
+    expect($probes)->toHaveCount(1);
+});
+
+it('throws when a modern server returns an input_required result', function (): void {
+    $transport = new FakeTransport;
+    $transport->discoverResponse = discoverResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'result' => [
+            'resultType' => 'input_required',
+            'inputRequests' => [],
+            'requestState' => 'opaque',
+        ],
+    ]);
+
+    expect(fn () => (new Client($transport))->tools())
+        ->toThrow(ClientException::class, 'input_required');
+});

--- a/tests/Unit/Client/ModernClientTest.php
+++ b/tests/Unit/Client/ModernClientTest.php
@@ -124,6 +124,6 @@ it('throws when a modern server returns an input_required result', function (): 
         ],
     ]);
 
-    expect(fn () => (new Client($transport))->tools())
+    expect(fn (): \Illuminate\Support\Collection => (new Client($transport))->tools())
         ->toThrow(ClientException::class, 'input_required');
 });

--- a/tests/Unit/Client/PromptsTest.php
+++ b/tests/Unit/Client/PromptsTest.php
@@ -33,7 +33,7 @@ it('returns a collection of prompts keyed by name', function (): void {
         ->toBeInstanceOf(Prompt::class)
         ->name->toBe('summarize')
         ->description->toBe('Summarizes text')
-        ->and(json_decode($transport->sent[2], true))
+        ->and(json_decode($transport->sent[3], true))
         ->toHaveKey('method', 'prompts/list')
         ->not->toHaveKey('params');
 });
@@ -60,8 +60,8 @@ it('auto-paginates prompts/list until nextCursor is absent', function (): void {
     $prompts = (new Client($transport))->prompts();
 
     expect($prompts->keys()->all())->toBe(['first', 'second', 'third'])
-        ->and(json_decode($transport->sent[2], true))->not->toHaveKey('params')
-        ->and(json_decode($transport->sent[3], true))->toHaveKey('params.cursor', 'cursor-page-2');
+        ->and(json_decode($transport->sent[3], true))->not->toHaveKey('params')
+        ->and(json_decode($transport->sent[4], true))->toHaveKey('params.cursor', 'cursor-page-2');
 });
 
 it('stops paginating once the prompt limit is reached without fetching the next page', function (): void {
@@ -79,7 +79,7 @@ it('stops paginating once the prompt limit is reached without fetching the next 
     $prompts = (new Client($transport))->prompts(2);
 
     expect($prompts->keys()->all())->toBe(['a', 'b'])
-        ->and($transport->sent)->toHaveCount(3)
+        ->and($transport->sent)->toHaveCount(4)
         ->and($transport->responses)->toBeEmpty();
 });
 
@@ -196,7 +196,7 @@ it('throws when a server repeats a prompts/list cursor', function (): void {
 
     expect(fn (): Collection => (new Client($transport))->prompts())
         ->toThrow(ClientException::class, 'Repeated prompts/list cursor [cursor-page-2] received from server.')
-        ->and($transport->sent)->toHaveCount(4);
+        ->and($transport->sent)->toHaveCount(5);
 });
 
 it('throws when prompts/list returns a non-string cursor', function (mixed $nextCursor): void {
@@ -242,7 +242,7 @@ it('sends prompts/get by name and concatenates text content', function (): void 
         ->messages->toHaveCount(3)
         ->and($result->text())->toBe('Hello, John!')
         ->and((string) $result)->toBe('Hello, John!')
-        ->and(json_decode($transport->sent[2], true))
+        ->and(json_decode($transport->sent[3], true))
         ->toHaveKey('method', 'prompts/get')
         ->toHaveKey('params.name', 'greeting')
         ->toHaveKey('params.arguments', ['name' => 'John']);
@@ -259,7 +259,7 @@ it('encodes empty prompt arguments as an object on the wire', function (): void 
 
     (new Client($transport))->getPrompt('no-args');
 
-    expect(json_decode($transport->sent[2])->params->arguments)->toBeInstanceOf(stdClass::class);
+    expect(json_decode($transport->sent[3])->params->arguments)->toBeInstanceOf(stdClass::class);
 });
 
 it('skips messages whose content is not an object when extracting text', function (): void {

--- a/tests/Unit/Client/ResourcesTest.php
+++ b/tests/Unit/Client/ResourcesTest.php
@@ -44,7 +44,7 @@ it('returns a collection of resources keyed by uri', function (): void {
         ->description->toBeNull()
         ->mimeType->toBeNull()
         ->size->toBeNull()
-        ->and(json_decode($transport->sent[2], true))
+        ->and(json_decode($transport->sent[3], true))
         ->toHaveKey('method', 'resources/list')
         ->not->toHaveKey('params');
 });
@@ -74,8 +74,8 @@ it('auto-paginates resources/list until nextCursor is absent', function (): void
     $resources = (new Client($transport))->resources();
 
     expect($resources->keys()->all())->toBe(['file://first', 'file://second', 'file://third'])
-        ->and(json_decode($transport->sent[2], true))->not->toHaveKey('params')
-        ->and(json_decode($transport->sent[3], true))->toHaveKey('params.cursor', 'cursor-page-2');
+        ->and(json_decode($transport->sent[3], true))->not->toHaveKey('params')
+        ->and(json_decode($transport->sent[4], true))->toHaveKey('params.cursor', 'cursor-page-2');
 });
 
 it('stops paginating once the resource limit is reached without fetching the next page', function (): void {
@@ -97,7 +97,7 @@ it('stops paginating once the resource limit is reached without fetching the nex
     $resources = (new Client($transport))->resources(2);
 
     expect($resources->keys()->all())->toBe(['file://a', 'file://b'])
-        ->and($transport->sent)->toHaveCount(3)
+        ->and($transport->sent)->toHaveCount(4)
         ->and($transport->responses)->toBeEmpty();
 });
 
@@ -243,7 +243,7 @@ it('throws when a server repeats a resources/list cursor', function (): void {
 
     expect(fn (): Collection => (new Client($transport))->resources())
         ->toThrow(ClientException::class, 'Repeated resources/list cursor [cursor-page-2] received from server.')
-        ->and($transport->sent)->toHaveCount(4);
+        ->and($transport->sent)->toHaveCount(5);
 });
 
 it('throws when resources/list returns a non-string cursor', function (mixed $nextCursor): void {
@@ -305,7 +305,7 @@ it('sends resources/read by uri and returns text content', function (): void {
         ->contents->toHaveCount(2)
         ->and($result->content())->toBe('Hello, world!')
         ->and((string) $result)->toBe('Hello, world!')
-        ->and(json_decode($transport->sent[2], true))
+        ->and(json_decode($transport->sent[3], true))
         ->toHaveKey('method', 'resources/read')
         ->toHaveKey('params.uri', 'file://readme');
 });

--- a/tests/Unit/Client/ToolsTest.php
+++ b/tests/Unit/Client/ToolsTest.php
@@ -33,7 +33,7 @@ it('returns a collection of tools keyed by name', function (): void {
         ->toBeInstanceOf(Tool::class)
         ->name->toBe('add')
         ->description->toBe('Adds two numbers')
-        ->and(json_decode($transport->sent[2], true))
+        ->and(json_decode($transport->sent[3], true))
         ->toHaveKey('method', 'tools/list')
         ->not->toHaveKey('params');
 });
@@ -60,8 +60,8 @@ it('auto-paginates tools/list until nextCursor is absent', function (): void {
     $tools = (new Client($transport))->tools();
 
     expect($tools->keys()->all())->toBe(['first', 'second', 'third'])
-        ->and(json_decode($transport->sent[2], true))->not->toHaveKey('params')
-        ->and(json_decode($transport->sent[3], true))->toHaveKey('params.cursor', 'cursor-page-2');
+        ->and(json_decode($transport->sent[3], true))->not->toHaveKey('params')
+        ->and(json_decode($transport->sent[4], true))->toHaveKey('params.cursor', 'cursor-page-2');
 });
 
 it('stops paginating once limit is reached without fetching the next page', function (): void {
@@ -79,7 +79,7 @@ it('stops paginating once limit is reached without fetching the next page', func
     $tools = (new Client($transport))->tools(2);
 
     expect($tools->keys()->all())->toBe(['a', 'b'])
-        ->and($transport->sent)->toHaveCount(3)
+        ->and($transport->sent)->toHaveCount(4)
         ->and($transport->responses)->toBeEmpty();
 });
 
@@ -198,7 +198,7 @@ it('throws when a server repeats a tools/list cursor', function (): void {
 
     expect(fn (): Collection => (new Client($transport))->tools())
         ->toThrow(ClientException::class, 'Repeated tools/list cursor [cursor-page-2] received from server.')
-        ->and($transport->sent)->toHaveCount(4);
+        ->and($transport->sent)->toHaveCount(5);
 });
 
 it('throws when tools/list returns a non-string cursor', function (mixed $nextCursor): void {
@@ -244,7 +244,7 @@ it('calls a bound tool returned from tools()', function (): void {
     $tool = (new Client($transport))->tools()['say-hi'];
 
     expect($tool->call(['name' => 'John'])->text())->toBe('Hello, John!')
-        ->and(json_decode($transport->sent[3], true))
+        ->and(json_decode($transport->sent[4], true))
         ->toHaveKey('method', 'tools/call')
         ->toHaveKey('params.name', 'say-hi')
         ->toHaveKey('params.arguments', ['name' => 'John']);
@@ -274,7 +274,7 @@ it('sends tools/call by name and concatenates text content', function (): void {
         ->content->toHaveCount(3)
         ->and($result->text())->toBe('Hello, John!')
         ->and((string) $result)->toBe('Hello, John!')
-        ->and(json_decode($transport->sent[2], true))
+        ->and(json_decode($transport->sent[3], true))
         ->toHaveKey('method', 'tools/call')
         ->toHaveKey('params.name', 'say-hi')
         ->toHaveKey('params.arguments', ['name' => 'John']);
@@ -291,7 +291,7 @@ it('encodes empty arguments as an object on the wire', function (): void {
 
     (new Client($transport))->callTool('no-args');
 
-    expect(json_decode($transport->sent[2])->params->arguments)->toBeInstanceOf(stdClass::class);
+    expect(json_decode($transport->sent[3])->params->arguments)->toBeInstanceOf(stdClass::class);
 });
 
 it('preserves structuredContent and _meta from the server response', function (): void {

--- a/tests/Unit/Client/Transport/HttpTransportTest.php
+++ b/tests/Unit/Client/Transport/HttpTransportTest.php
@@ -120,7 +120,7 @@ it('omits the protocol version header on initialize and includes the negotiated 
     Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'tools/list' && $request->hasHeader('MCP-Protocol-Version', ProtocolVersion::V2025_06_18->value));
 });
 
-it('falls back to the latest protocol version when initialized without a negotiated version', function (): void {
+it('falls back to the latest legacy protocol version when initialized without a negotiated version', function (): void {
     Http::fake(['*' => Http::response(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => []]), 200, ['Content-Type' => 'application/json'])]);
 
     $transport = new HttpTransport('https://mcp.test/mcp');
@@ -128,7 +128,7 @@ it('falls back to the latest protocol version when initialized without a negotia
     $transport->receive();
     $transport->send(json_encode(['jsonrpc' => '2.0', 'id' => 2, 'method' => 'tools/list']));
 
-    Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'tools/list' && $request->hasHeader('MCP-Protocol-Version', ProtocolVersion::LATEST->value));
+    Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'tools/list' && $request->hasHeader('MCP-Protocol-Version', ProtocolVersion::LATEST_LEGACY->value));
 });
 
 it('sends a bearer Authorization header when a token is set', function (): void {
@@ -197,11 +197,12 @@ it('merges custom headers across multiple withHeaders calls', function (): void 
 
 it('sends custom headers when built via Client::web', function (): void {
     Http::fakeSequence()
+        ->push(discoverNotFoundResponse(), 200, ['Content-Type' => 'application/json'])
         ->push(json_encode([
             'jsonrpc' => '2.0',
             'id' => 1,
             'result' => [
-                'protocolVersion' => ProtocolVersion::LATEST->value,
+                'protocolVersion' => ProtocolVersion::LATEST_LEGACY->value,
                 'capabilities' => new stdClass,
                 'serverInfo' => ['name' => 'Test Server', 'version' => '1.0.0'],
             ],
@@ -340,11 +341,12 @@ it('throws when receiving with no queued message', function (): void {
 
 it('drives a full handshake and tools list over HTTP via Client::web', function (): void {
     Http::fakeSequence()
+        ->push(discoverNotFoundResponse(), 200, ['Content-Type' => 'application/json'])
         ->push(json_encode([
             'jsonrpc' => '2.0',
             'id' => 1,
             'result' => [
-                'protocolVersion' => ProtocolVersion::LATEST->value,
+                'protocolVersion' => ProtocolVersion::LATEST_LEGACY->value,
                 'capabilities' => new stdClass,
                 'serverInfo' => ['name' => 'Test Server', 'version' => '1.0.0'],
             ],
@@ -366,11 +368,12 @@ it('drives a full handshake and tools list over HTTP via Client::web', function 
 
     Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'tools/list' && $request->hasHeader('MCP-Session-Id', 'session-e2e'));
     Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'tools/list' && $request->hasHeader('Authorization', 'Bearer e2e-token'));
-    Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'tools/list' && $request->hasHeader('MCP-Protocol-Version', ProtocolVersion::LATEST->value));
+    Http::assertSent(fn ($request): bool => ($request['method'] ?? null) === 'tools/list' && $request->hasHeader('MCP-Protocol-Version', ProtocolVersion::LATEST_LEGACY->value));
 });
 
 it('throws when the server negotiates a protocol version the client does not support', function (): void {
     Http::fakeSequence()
+        ->push(discoverNotFoundResponse(), 200, ['Content-Type' => 'application/json'])
         ->push(json_encode([
             'jsonrpc' => '2.0',
             'id' => 1,
@@ -389,6 +392,7 @@ it('throws when the server negotiates a protocol version the client does not sup
 
 it('interoperates with a server negotiated down to 2025-06-18', function (): void {
     Http::fakeSequence()
+        ->push(discoverNotFoundResponse(), 200, ['Content-Type' => 'application/json'])
         ->push(json_encode([
             'jsonrpc' => '2.0',
             'id' => 1,
@@ -456,6 +460,7 @@ it('builds a WebClient from Client::web', function (): void {
 
 it('re-initializes and retries once after a 404 session expiry', function (): void {
     Http::fakeSequence()
+        ->push(discoverNotFoundResponse(), 200, ['Content-Type' => 'application/json'])
         ->push(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => [
             'protocolVersion' => ProtocolVersion::LATEST->value,
             'capabilities' => new stdClass,

--- a/tests/Unit/Enums/ProtocolVersionTest.php
+++ b/tests/Unit/Enums/ProtocolVersionTest.php
@@ -24,7 +24,21 @@ it('returns only string values', function (): void {
 
 it('supports only the versions that define the protocol version header as a client', function (): void {
     expect(ProtocolVersion::clientSupported())->toBe([
+        ProtocolVersion::V2026_07_28->value,
         ProtocolVersion::V2025_11_25->value,
         ProtocolVersion::V2025_06_18->value,
     ]);
+});
+
+it('identifies modern revisions', function (): void {
+    expect(ProtocolVersion::isModern('2026-07-28'))->toBeTrue();
+    expect(ProtocolVersion::isModern('2027-01-01'))->toBeTrue();
+    expect(ProtocolVersion::isModern('2025-11-25'))->toBeFalse();
+    expect(ProtocolVersion::isModern('2024-11-05'))->toBeFalse();
+});
+
+it('resolves the latest legacy version from a supported list', function (): void {
+    expect(ProtocolVersion::latestLegacy(ProtocolVersion::supported()))->toBe('2025-11-25');
+    expect(ProtocolVersion::latestLegacy(['2026-07-28']))->toBeNull();
+    expect(ProtocolVersion::latestLegacy(['2025-03-26', '2025-06-18']))->toBe('2025-06-18');
 });

--- a/tests/Unit/ModernProtocolTest.php
+++ b/tests/Unit/ModernProtocolTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Mcp\Enums\MetaKey;
+use Laravel\Mcp\Enums\ProtocolVersion;
+use Tests\Fixtures\ArrayTransport;
+use Tests\Fixtures\ExampleServer;
+
+function modernMeta(string $version = '2026-07-28'): array
+{
+    return [
+        MetaKey::PROTOCOL_VERSION->value => $version,
+        MetaKey::CLIENT_INFO->value => ['name' => 'Pest', 'version' => '1.0.0'],
+        MetaKey::CLIENT_CAPABILITIES->value => (object) [],
+    ];
+}
+
+function modernMessage(string $method, array $params = [], string $version = '2026-07-28'): string
+{
+    return json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 7,
+        'method' => $method,
+        'params' => array_merge($params, ['_meta' => modernMeta($version)]),
+    ]);
+}
+
+function handleModern(string $payload): array
+{
+    $transport = new ArrayTransport;
+    $server = new ExampleServer($transport);
+    $server->start();
+
+    ($transport->handler)($payload);
+
+    return json_decode((string) $transport->sent[0], true);
+}
+
+it('serves stateless requests without an initialize handshake', function (): void {
+    $response = handleModern(modernMessage('tools/list'));
+
+    expect($response['result']['resultType'])->toBe('complete')
+        ->and($response['result']['tools'])->not->toBeEmpty()
+        ->and($response['result']['_meta'][MetaKey::SERVER_INFO->value]['name'])->not->toBeEmpty();
+});
+
+it('stamps cacheable results with ttlMs and cacheScope for modern requests', function (): void {
+    $response = handleModern(modernMessage('tools/list'));
+
+    expect($response['result']['ttlMs'])->toBe(0)
+        ->and($response['result']['cacheScope'])->toBe('private');
+});
+
+it('does not stamp modern fields on non-cacheable modern results', function (): void {
+    $response = handleModern(modernMessage('tools/call', [
+        'name' => 'say-hi-tool',
+        'arguments' => ['name' => 'John'],
+    ]));
+
+    expect($response['result'])->not->toHaveKey('ttlMs')
+        ->and($response['result'])->not->toHaveKey('cacheScope')
+        ->and($response['result']['resultType'])->toBe('complete');
+});
+
+it('does not decorate legacy results with modern fields', function (): void {
+    $transport = new ArrayTransport;
+    $server = new ExampleServer($transport);
+    $server->start();
+
+    ($transport->handler)(json_encode(listToolsMessage()));
+
+    $response = json_decode((string) $transport->sent[0], true);
+
+    expect($response['result'])->not->toHaveKey('resultType')
+        ->and($response['result'])->not->toHaveKey('ttlMs')
+        ->and($response['result'])->not->toHaveKey('_meta');
+});
+
+it('implements server/discover', function (): void {
+    $response = handleModern(modernMessage('server/discover'));
+
+    expect($response['result']['supportedVersions'])->toBe(ProtocolVersion::supported())
+        ->and($response['result']['capabilities'])->toHaveKeys(['tools', 'resources', 'prompts'])
+        ->and($response['result']['instructions'])->toBeString()
+        ->and($response['result']['resultType'])->toBe('complete')
+        ->and($response['result']['ttlMs'])->toBe(0)
+        ->and($response['result']['_meta'][MetaKey::SERVER_INFO->value])->toHaveKeys(['name', 'version']);
+});
+
+it('rejects requests declaring an unsupported protocol version', function (): void {
+    $response = handleModern(modernMessage('tools/list', version: '1900-01-01'));
+
+    expect($response['error']['code'])->toBe(-32022)
+        ->and($response['error']['data']['supported'])->toBe(ProtocolVersion::supported())
+        ->and($response['error']['data']['requested'])->toBe('1900-01-01');
+});
+
+it('does not serve initialize to modern requests', function (): void {
+    $response = handleModern(modernMessage('initialize', [
+        'protocolVersion' => '2026-07-28',
+        'capabilities' => (object) [],
+        'clientInfo' => ['name' => 'Pest', 'version' => '1.0.0'],
+    ]));
+
+    expect($response['error']['code'])->toBe(-32601);
+});
+
+it('never negotiates a modern version through the legacy initialize handshake', function (): void {
+    $transport = new ArrayTransport;
+    $server = new ExampleServer($transport);
+    $server->start();
+
+    ($transport->handler)(json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'initialize',
+        'params' => [
+            'protocolVersion' => '2026-07-28',
+            'capabilities' => (object) [],
+            'clientInfo' => ['name' => 'Pest', 'version' => '1.0.0'],
+        ],
+    ]));
+
+    $response = json_decode((string) $transport->sent[0], true);
+
+    expect($response['result']['protocolVersion'])->toBe(ProtocolVersion::LATEST_LEGACY->value);
+});
+
+it('uses the invalid params code for missing resources on modern requests', function (): void {
+    $response = handleModern(modernMessage('resources/read', ['uri' => 'file://resources/missing']));
+
+    expect($response['error']['code'])->toBe(-32602);
+});
+
+it('keeps the legacy resource-not-found code for legacy requests', function (): void {
+    $transport = new ArrayTransport;
+    $server = new ExampleServer($transport);
+    $server->start();
+
+    ($transport->handler)(json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 9,
+        'method' => 'resources/read',
+        'params' => ['uri' => 'file://resources/missing'],
+    ]));
+
+    $response = json_decode((string) $transport->sent[0], true);
+
+    expect($response['error']['code'])->toBe(-32002);
+});

--- a/tests/Unit/Server/Middleware/ValidateModernMcpRequestTest.php
+++ b/tests/Unit/Server/Middleware/ValidateModernMcpRequestTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Laravel\Mcp\Server\Middleware\ValidateModernMcpRequest;
+use Symfony\Component\HttpFoundation\Response;
+
+function modernHttpRequest(array $body, array $headers = []): Request
+{
+    $request = Request::create('/mcp', 'POST', [], [], [], [], json_encode($body));
+
+    foreach ($headers as $name => $value) {
+        $request->headers->set($name, $value);
+    }
+
+    return $request;
+}
+
+function runMiddleware(Request $request): Response
+{
+    return (new ValidateModernMcpRequest)->handle(
+        $request,
+        fn (): Response => new Response('passed', 200),
+    );
+}
+
+function modernBody(string $method, array $params = []): array
+{
+    return [
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => $method,
+        'params' => array_merge($params, [
+            '_meta' => ['io.modelcontextprotocol/protocolVersion' => '2026-07-28'],
+        ]),
+    ];
+}
+
+it('passes legacy requests through untouched', function (): void {
+    $response = runMiddleware(modernHttpRequest([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/list',
+    ]));
+
+    expect($response->getContent())->toBe('passed');
+});
+
+it('passes valid modern requests through', function (): void {
+    $response = runMiddleware(modernHttpRequest(modernBody('tools/list'), [
+        'MCP-Protocol-Version' => '2026-07-28',
+        'Mcp-Method' => 'tools/list',
+    ]));
+
+    expect($response->getContent())->toBe('passed');
+});
+
+it('rejects a modern request whose protocol version header does not match the body', function (): void {
+    $response = runMiddleware(modernHttpRequest(modernBody('tools/list'), [
+        'MCP-Protocol-Version' => '2025-11-25',
+        'Mcp-Method' => 'tools/list',
+    ]));
+
+    $payload = json_decode((string) $response->getContent(), true);
+
+    expect($response->getStatusCode())->toBe(400)
+        ->and($payload['error']['code'])->toBe(-32020)
+        ->and($payload['error']['message'])->toContain('MCP-Protocol-Version');
+});
+
+it('rejects a modern request missing the protocol version header', function (): void {
+    $response = runMiddleware(modernHttpRequest(modernBody('tools/list'), [
+        'Mcp-Method' => 'tools/list',
+    ]));
+
+    expect($response->getStatusCode())->toBe(400);
+});
+
+it('rejects a modern request whose Mcp-Method header does not match the body', function (): void {
+    $response = runMiddleware(modernHttpRequest(modernBody('tools/list'), [
+        'MCP-Protocol-Version' => '2026-07-28',
+        'Mcp-Method' => 'prompts/list',
+    ]));
+
+    $payload = json_decode((string) $response->getContent(), true);
+
+    expect($response->getStatusCode())->toBe(400)
+        ->and($payload['error']['code'])->toBe(-32020)
+        ->and($payload['error']['message'])->toContain('Mcp-Method');
+});
+
+it('requires the Mcp-Name header on named methods', function (string $method, string $parameter): void {
+    $response = runMiddleware(modernHttpRequest(modernBody($method, [$parameter => 'target-name']), [
+        'MCP-Protocol-Version' => '2026-07-28',
+        'Mcp-Method' => $method,
+    ]));
+
+    $payload = json_decode((string) $response->getContent(), true);
+
+    expect($response->getStatusCode())->toBe(400)
+        ->and($payload['error']['code'])->toBe(-32020)
+        ->and($payload['error']['message'])->toContain('Mcp-Name');
+})->with([
+    'tools/call' => ['tools/call', 'name'],
+    'prompts/get' => ['prompts/get', 'name'],
+    'resources/read' => ['resources/read', 'uri'],
+]);
+
+it('accepts a matching Mcp-Name header', function (): void {
+    $response = runMiddleware(modernHttpRequest(modernBody('tools/call', ['name' => 'calculator']), [
+        'MCP-Protocol-Version' => '2026-07-28',
+        'Mcp-Method' => 'tools/call',
+        'Mcp-Name' => 'calculator',
+    ]));
+
+    expect($response->getContent())->toBe('passed');
+});
+
+it('decodes the Base64 sentinel format when comparing Mcp-Name', function (): void {
+    $name = 'héllo wörld';
+
+    $response = runMiddleware(modernHttpRequest(modernBody('tools/call', ['name' => $name]), [
+        'MCP-Protocol-Version' => '2026-07-28',
+        'Mcp-Method' => 'tools/call',
+        'Mcp-Name' => '=?base64?'.base64_encode($name).'?=',
+    ]));
+
+    expect($response->getContent())->toBe('passed');
+});
+
+it('skips validation for notifications', function (): void {
+    $response = runMiddleware(modernHttpRequest([
+        'jsonrpc' => '2.0',
+        'method' => 'notifications/cancelled',
+        'params' => [
+            '_meta' => ['io.modelcontextprotocol/protocolVersion' => '2026-07-28'],
+        ],
+    ]));
+
+    expect($response->getContent())->toBe('passed');
+});


### PR DESCRIPTION
## Summary

Implements the [MCP 2026-07-28 revision](https://modelcontextprotocol.io/specification/draft/changelog) (release candidate; final spec publishes July 28) while retaining full compatibility with all previously supported revisions. Servers and clients are now **dual-era**: they speak the new stateless, per-request-metadata protocol with modern peers and fall back to the `initialize` handshake with legacy peers, per the spec's [backward-compatibility rules](https://modelcontextprotocol.io/specification/draft/basic/versioning).

Draft until the final spec text lands — the protocol version string and field names follow the current draft exactly and will be re-verified against the published revision.

### Server

- Serves stateless requests that declare `io.modelcontextprotocol/protocolVersion` in `_meta` — no handshake, no session; `initialize` continues to work for legacy clients and now never negotiates a modern revision (SEP-2575)
- Implements the required `server/discover` method
- Decorates modern results with the required `resultType: "complete"` field and `io.modelcontextprotocol/serverInfo` result `_meta`
- Adds `ttlMs`/`cacheScope` (`CacheableResult`, SEP-2549) to the five cacheable methods plus `server/discover`, configurable per server via `$cacheTtlMs`/`$cacheScope`
- Validates the `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name` request metadata headers against the body (SEP-2243), including the Base64 sentinel encoding, rejecting mismatches with `HeaderMismatch` (`-32020`) and HTTP 400
- Maps modern protocol errors to the spec's HTTP statuses: unknown method → 404, `UnsupportedProtocolVersion` (`-32022`) / header validation → 400
- Missing-resource errors use `-32602` for modern requests (spec alignment), `-32002` for legacy

### Client

- Probes with `server/discover` first and falls back to the legacy handshake on any non-modern error, caching the server's era so reconnects skip the probe
- Stamps `protocolVersion`/`clientInfo`/`clientCapabilities` into `_meta` on every modern request and sends the required request metadata headers
- Surfaces modern JSON-RPC error bodies carried on HTTP 4xx responses (enables version-negotiation retry per spec)
- Treats results without `resultType` as complete; rejects `input_required` (MRTR is not yet supported, and the client advertises no capabilities that would allow it)

### New error/meta plumbing

`ProtocolVersion::V2026_07_28` + era helpers, `ErrorCode` and `MetaKey` enums, negotiated version threaded through `ServerContext` so any method can gate on `$context->isModern()`.

## Not included (follow-ups)

Multi Round-Trip Requests (elicitation), `subscriptions/listen`, `x-mcp-header` custom headers, JSON Schema 2020-12 input/output schema loosening, `_meta` trace-context conventions, and the OAuth DCR `application_type`/Client ID Metadata Document changes.

## Testing

- Full suite: **1,055 tests passing** (Pest), PHPStan level 8 clean, Pint clean
- New coverage: stateless serving and result decoration, `server/discover`, unsupported-version rejection, header-validation middleware (including Base64 sentinel), error-code changes, legacy-handshake capping, and client-side modern negotiation, `_meta` stamping, era caching, legacy fallback, and the `input_required` guard
- **End-to-end against the official MCP Inspector**, using a fresh Laravel app consuming this branch:
  - Inspector **v2 (`v2/main` branch, v2.0.0)** — the only inspector build with 2026-07-28 support (the npm release is still on SDK 1.29 / 2025-11-25): connected over Streamable HTTP in all three of its protocol-era modes. **Modern** (pinned 2026-07-28, sessionless) and **Auto** (probes `server/discover`) both negotiate `MCP 2026-07-28` and list/call tools with structured content; **Legacy** exercises the handshake path against the same endpoint
  - Released inspector **1.0.0** CLI (legacy era) over both stdio and HTTP: tools/list, tools/call, prompts/get, resources/read all pass
  - curl-level verification of the modern HTTP semantics: header/body mismatch → 400 `-32020`, missing `Mcp-Name` → 400 `-32020`, unknown method → 404 `-32601`, unknown version → 400 `-32022` with the `supported` list
  - The package's own client negotiated 2026-07-28 against the dual-era server with no handshake and round-tripped structured tool calls