### PR TITLE
Sort the WWW-Authenticate challenge outside authentication

### DIFF
--- a/src/Server/McpServiceProvider.php
+++ b/src/Server/McpServiceProvider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp\Server;
 
+use Illuminate\Contracts\Http\Kernel as HttpKernelContract;
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Mcp\Client\ClientManager;
@@ -15,6 +17,7 @@ use Laravel\Mcp\Console\Commands\MakeServerCommand;
 use Laravel\Mcp\Console\Commands\MakeToolCommand;
 use Laravel\Mcp\Console\Commands\StartCommand;
 use Laravel\Mcp\Request;
+use Laravel\Mcp\Server\Middleware\AddWwwAuthenticateHeader;
 
 class McpServiceProvider extends ServiceProvider
 {
@@ -31,6 +34,7 @@ class McpServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
+        $this->registerMiddlewarePriority();
         $this->registerMcpScope();
         $this->registerRoutes();
         $this->registerContainerCallbacks();
@@ -66,6 +70,36 @@ class McpServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../../config/mcp.php' => config_path('mcp.php'),
         ], 'mcp-config');
+    }
+
+    /**
+     * Ensure the WWW-Authenticate challenge is applied outside authentication.
+     *
+     * AddWwwAuthenticateHeader decorates a returned 401, so it only works from
+     * outside whatever produces one. Protecting an MCP route means adding an
+     * auth middleware, and Laravel sorts Authenticate to the front of the stack
+     * because it implements AuthenticatesRequests, which is in the framework's
+     * middleware priority list. This middleware is not in that list, so it
+     * cannot be sorted ahead of auth and ends up inside it, never seeing the
+     * rejection.
+     *
+     * The result is that the header is silently absent on exactly the
+     * OAuth-protected servers it exists for, with no error and a
+     * correctly-served metadata document to make it look fine.
+     */
+    protected function registerMiddlewarePriority(): void
+    {
+        if (! $this->app->bound(HttpKernelContract::class)) {
+            return;
+        }
+
+        $kernel = $this->app->make(HttpKernelContract::class);
+
+        if (! $kernel instanceof HttpKernel) {
+            return;
+        }
+
+        $kernel->prependToMiddlewarePriority(AddWwwAuthenticateHeader::class);
     }
 
     protected function registerRoutes(): void

--- a/tests/Unit/Server/McpServiceProviderTest.php
+++ b/tests/Unit/Server/McpServiceProviderTest.php
@@ -2,8 +2,12 @@
 
 declare(strict_types=1);
 
+use Illuminate\Auth\Middleware\Authenticate;
 use Laravel\Mcp\Server\McpServiceProvider;
+use Laravel\Mcp\Server\Middleware\AddWwwAuthenticateHeader;
+use Laravel\Mcp\Server\Registrar;
 use Laravel\Passport\Passport;
+use Tests\Fixtures\ExampleServer;
 
 it('registers mcp scope during boot', function (): void {
     if (! class_exists(Passport::class)) {
@@ -20,4 +24,36 @@ it('registers mcp scope during boot', function (): void {
 
     expect(Passport::$scopes)->toHaveKey('mcp:use');
     expect(Passport::$scopes['custom'])->toBe('Custom scope');
+});
+
+it('sorts the www-authenticate challenge outside authentication middleware', function (): void {
+    // AddWwwAuthenticateHeader decorates a returned 401, so it has to run
+    // outside whatever produces one. Laravel sorts Authenticate to the front of
+    // the stack because it implements AuthenticatesRequests, which is in the
+    // framework's middleware priority list. Without an entry of its own this
+    // middleware sorts *after* auth on any protected route, never sees the
+    // rejection, and the challenge is silently absent on exactly the
+    // OAuth-protected servers it exists for.
+    $registrar = new Registrar;
+
+    $route = $registrar->web('/priority/mcp', ExampleServer::class)->middleware('auth');
+
+    $resolved = app('router')->gatherRouteMiddleware($route);
+
+    $challenge = array_search(AddWwwAuthenticateHeader::class, $resolved, true);
+    $authenticate = array_search(Authenticate::class.':', $resolved, true);
+
+    if ($authenticate === false) {
+        $authenticate = array_key_first(array_filter(
+            $resolved,
+            fn (string $middleware): bool => str_starts_with($middleware, Authenticate::class),
+        ));
+    }
+
+    expect($challenge)->not->toBeFalse('AddWwwAuthenticateHeader is missing from the resolved middleware.');
+    expect($authenticate)->not->toBeNull('The auth middleware is missing from the resolved middleware.');
+    expect($challenge)->toBeLessThan(
+        $authenticate,
+        'AddWwwAuthenticateHeader must sort before the auth middleware, or it never sees the 401 it exists to decorate.',
+    );
 });


### PR DESCRIPTION
Fixes #278

`AddWwwAuthenticateHeader` decorates a **returned** 401:

```php
$response = $next($request);
if ($response->getStatusCode() !== 401) {
    return $response;
}
```

so it only works from outside whatever produces one. But protecting an MCP route means adding an auth middleware, and Laravel sorts `Authenticate` to the front of the stack because it implements `AuthenticatesRequests`, which is in the framework's middleware priority list. `AddWwwAuthenticateHeader` is not in that list, so it cannot be sorted ahead of auth.

For `Mcp::web('/mcp', MyServer::class)->middleware(['auth:api'])` the resolved order was:

```
0. Illuminate\Auth\Middleware\Authenticate:api
1. Illuminate\Routing\Middleware\SubstituteBindings
2. Laravel\Mcp\Server\Middleware\ReorderJsonAccept
3. Laravel\Mcp\Server\Middleware\AddWwwAuthenticateHeader   <-- inside auth
```

Auth produced the 401 at the outermost layer, so the response never travelled back out through the decorator, and the challenge was silently absent on exactly the OAuth-protected servers the middleware exists for.

It is quiet because nothing errors and `/.well-known/oauth-protected-resource/{path}` keeps serving correctly, so the setup looks healthy. Clients that hardcode the conventional metadata address still connect. Only a client that relies on `WWW-Authenticate` for discovery fails, per RFC 9728 §5.1 and the MCP authorization spec, and it fails with no diagnostic.

## The change

Registers the middleware in the HTTP kernel's priority list from `McpServiceProvider::boot()`, guarded so it is a no-op when the HTTP kernel is not bound or is not the concrete `Illuminate\Foundation\Http\Kernel` (console, custom kernels). Resolved order after:

```
0. Laravel\Mcp\Server\Middleware\AddWwwAuthenticateHeader   <-- outside auth
1. Illuminate\Auth\Middleware\Authenticate:api
2. Illuminate\Routing\Middleware\SubstituteBindings
3. Laravel\Mcp\Server\Middleware\ReorderJsonAccept
```

This only reorders middleware already present on a route, so routes that do not use `AddWwwAuthenticateHeader` are unaffected.

## Tests

Added a test that registers a web server with `auth` and asserts the challenge sorts ahead of the auth middleware. It is mutation-checked: with the provider change reverted and the test kept, it fails on

```
AddWwwAuthenticateHeader must sort before the auth middleware, or it never
sees the 401 it exists to decorate.
```

Full suite 1028 passed (2333 assertions), Pint clean, PHPStan no errors.

## Notes

I went with the priority registration as the smallest change. Two alternatives, in case you prefer either: catching `AuthenticationException` in the middleware rather than inspecting a returned response, or applying it as group middleware around the MCP routes. Happy to rework it.

Found on v0.9.1 against a production OAuth-protected server; `Registrar::web()` and the middleware are unchanged from v0.8.2 in the relevant respects.