### PR TITLE
Fix missing WWW-Authenticate challenge on authenticated MCP routes

### DIFF
--- a/src/Server/McpServiceProvider.php
+++ b/src/Server/McpServiceProvider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp\Server;
 
+use Illuminate\Contracts\Http\Kernel as HttpKernelContract;
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Mcp\Client\ClientManager;
@@ -15,6 +17,8 @@ use Laravel\Mcp\Console\Commands\MakeServerCommand;
 use Laravel\Mcp\Console\Commands\MakeToolCommand;
 use Laravel\Mcp\Console\Commands\StartCommand;
 use Laravel\Mcp\Request;
+use Laravel\Mcp\Server\Middleware\AddWwwAuthenticateHeader;
+use Laravel\Mcp\Server\Middleware\ReorderJsonAccept;
 
 class McpServiceProvider extends ServiceProvider
 {
@@ -32,6 +36,7 @@ class McpServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->registerMcpScope();
+        $this->registerMiddlewarePriority();
         $this->registerRoutes();
         $this->registerContainerCallbacks();
         $this->registerClientDisconnect();
@@ -66,6 +71,19 @@ class McpServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../../config/mcp.php' => config_path('mcp.php'),
         ], 'mcp-config');
+    }
+
+    protected function registerMiddlewarePriority(): void
+    {
+        $this->callAfterResolving(HttpKernelContract::class, function (mixed $kernel): void {
+            if (! $kernel instanceof HttpKernel) {
+                return;
+            }
+
+            // Both middleware wrap the MCP route, so they must run outside of any prioritized authentication middleware...
+            $kernel->prependToMiddlewarePriority(AddWwwAuthenticateHeader::class);
+            $kernel->prependToMiddlewarePriority(ReorderJsonAccept::class);
+        });
     }
 
     protected function registerRoutes(): void

--- a/tests/Feature/Server/MiddlewarePriorityTest.php
+++ b/tests/Feature/Server/MiddlewarePriorityTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Auth\Middleware\Authenticate;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Support\Facades\Route;
+use Laravel\Mcp\Facades\Mcp;
+use Laravel\Mcp\Server\Registrar;
+use Tests\Fixtures\ExampleServer;
+
+function registerAuthenticatedMcpRoute(): void
+{
+    Route::middleware(SubstituteBindings::class)->group(function (): void {
+        Mcp::web('protected-mcp', ExampleServer::class)->middleware(Authenticate::class);
+    });
+}
+
+it('adds the OAuth challenge to the 401 of an authenticated MCP route', function (): void {
+    app(Registrar::class)->oauthRoutes();
+
+    registerAuthenticatedMcpRoute();
+
+    $response = $this->postJson('protected-mcp', []);
+
+    $response->assertStatus(401);
+    $response->assertHeader(
+        'WWW-Authenticate',
+        'Bearer realm="mcp", resource_metadata="'.url('/.well-known/oauth-protected-resource/protected-mcp').'"'
+    );
+});
+
+it('reorders the accept header before authenticating an MCP route', function (): void {
+    registerAuthenticatedMcpRoute();
+
+    $response = $this->post('protected-mcp', [], ['Accept' => 'text/event-stream, application/json']);
+
+    $response->assertStatus(401);
+    $response->assertJson(['message' => 'Unauthenticated.']);
+});


### PR DESCRIPTION
Fixes #278.                                                                                                                                                                                                                            
                                                                                                                                                                                                                                         
`AddWwwAuthenticateHeader` decorates a returned 401, so it has to run outside of whatever produces one. `SortedMiddleware` hoists the middleware present in the priority list above the ones missing from it, `Authenticate` is in that list, the MCP middleware are not, so the authentication middleware ends up outermost and its 401 never travels back out through the decorator. The response carries no `WWW-Authenticate` challenge, which is what an RFC 9728 client reads to discover the authorization server.                                                                                                                                                                                     
                                                                                                                                                                                                                                         
Worth noting it does not reproduce with `auth` alone on the route: `SortedMiddleware` only moves a prioritized middleware above a previously encountered one. It takes a second prioritized middleware ahead of the MCP ones, `SubstituteBindings`, `StartSession`, `ThrottleRequests`, i.e. any MCP route sitting inside a route group. That is also why the existing tests miss it: they attach the middleware to a closure route that returns the 401 itself.    
                                                                                                                                                                                                                                         
`ReorderJsonAccept` is prioritized for the same reason: a client sending `Accept: text/event-stream, application/json` is authenticated before the header is reordered, so `wantsJson()` is false and the `AuthenticationException` renders as a redirect to `route('login')` instead of a 401.