### PR TITLE
Align protocol error codes with MCP 2026-07-28

### DIFF
--- a/src/Enums/ErrorCode.php
+++ b/src/Enums/ErrorCode.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Enums;
+
+enum ErrorCode: int
+{
+    case PARSE_ERROR = -32700;
+    case INVALID_REQUEST = -32600;
+    case METHOD_NOT_FOUND = -32601;
+    case INVALID_PARAMS = -32602;
+    case INTERNAL_ERROR = -32603;
+    case HEADER_MISMATCH = -32020;
+    case MISSING_REQUIRED_CLIENT_CAPABILITY = -32021;
+    case UNSUPPORTED_PROTOCOL_VERSION = -32022;
+}

--- a/src/Server/Methods/ReadResource.php
+++ b/src/Server/Methods/ReadResource.php
@@ -8,6 +8,7 @@ use Generator;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use InvalidArgumentException;
+use Laravel\Mcp\Enums\ErrorCode;
 use Laravel\Mcp\Exceptions\JsonRpcException;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
@@ -39,7 +40,11 @@ class ReadResource implements Method
         try {
             $resource = $this->resolveResource($uri, $context);
         } catch (InvalidArgumentException $invalidArgumentException) {
-            throw new JsonRpcException($invalidArgumentException->getMessage(), -32002, $request->id);
+            throw new JsonRpcException(
+                $invalidArgumentException->getMessage(),
+                ErrorCode::INVALID_PARAMS->value,
+                $request->id,
+            );
         }
 
         $response = $this->callHandler(fn (): mixed => $this->invokeResource($resource, $uri), $request);

--- a/tests/Unit/Methods/ReadResourceTest.php
+++ b/tests/Unit/Methods/ReadResourceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Laravel\Mcp\Enums\ErrorCode;
 use Laravel\Mcp\Exceptions\JsonRpcException;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
@@ -60,6 +61,7 @@ it('returns a valid resource result for blob resources', function (): void {
 it('throws error when uri is missing', function (): void {
     $this->expectException(JsonRpcException::class);
     $this->expectExceptionMessage('Missing [uri] parameter.');
+    $this->expectExceptionCode(ErrorCode::INVALID_PARAMS->value);
 
     $readResource = new ReadResource;
     $context = $this->getServerContext();
@@ -75,6 +77,7 @@ it('throws error when uri is missing', function (): void {
 
 it('throws exception when resource is not found', function (): void {
     $this->expectException(JsonRpcException::class);
+    $this->expectExceptionCode(ErrorCode::INVALID_PARAMS->value);
 
     $readResource = new ReadResource;
     $context = $this->getServerContext();


### PR DESCRIPTION
MCP `2026-07-28` drops `-32002`. A `resources/read` with a missing or unknown URI now returns `-32602` (Invalid params).

Before:

```json
{ "code": -32002, "message": "Resource [file://resources/nope] not found." }
```

After:

```json
{ "code": -32602, "message": "Resource [file://resources/nope] not found." }
```

The new `ErrorCode` enum also holds the three codes the spec reserves: `HeaderMismatch` (`-32020`), `MissingRequiredClientCapability` (`-32021`), `UnsupportedProtocolVersion` (`-32022`). Later PRs in the stack use them.

> [!WARNING]
> BC break for clients pinned to `-32002`. The spec forbids emitting it, so the old code cannot stay.

Ships in `1.x`. Tests now assert the code.

### Spec

- [Changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog), minor change 6 (`-32002` becomes `-32602`) and 12 (code range policy, and the renumbering to `-32020`, `-32021`, `-32022`)
- [Error codes](https://modelcontextprotocol.io/specification/2026-07-28/basic/index#error-codes)
- [Resources: error handling](https://modelcontextprotocol.io/specification/2026-07-28/server/resources#error-handling)

Credit to @JordanDalton, whose #275 mapped out the 2026-07-28 work and where the `ErrorCode` enum comes from.
