### PR TITLE
Complete every result with the server info metadata

### DIFF
--- a/src/Enums/MetaKey.php
+++ b/src/Enums/MetaKey.php
@@ -8,4 +8,5 @@ enum MetaKey: string
 {
     case PROTOCOL_VERSION = 'io.modelcontextprotocol/protocolVersion';
     case CLIENT_CAPABILITIES = 'io.modelcontextprotocol/clientCapabilities';
+    case SERVER_INFO = 'io.modelcontextprotocol/serverInfo';
 }

--- a/src/Server.php
+++ b/src/Server.php
@@ -216,7 +216,7 @@ abstract class Server
 
             $this->handleMessage($request, $context);
         } catch (JsonRpcException $e) {
-            $this->transport->send($e->toJsonRpcResponse()->toJson());
+            $this->send($e->toJsonRpcResponse(), $context);
         } catch (Throwable $e) {
             report($e);
 
@@ -226,13 +226,11 @@ abstract class Server
                 throw $e;
             }
 
-            $jsonRpcResponse = JsonRpcResponse::error(
+            $this->send(JsonRpcResponse::error(
                 $requestId,
                 ErrorCode::INTERNAL_ERROR->value,
                 'Something went wrong while processing the request.',
-            );
-
-            $this->transport->send($jsonRpcResponse->toJson());
+            ), $context);
         }
     }
 
@@ -312,16 +310,28 @@ abstract class Server
         $response = $this->runMethodHandle($request, $context);
 
         if (! is_iterable($response)) {
-            $this->transport->send($response->toJson());
+            $this->send($response, $context);
 
             return;
         }
 
-        $this->transport->stream(function () use ($response): void {
+        $this->transport->stream(function () use ($response, $context): void {
             foreach ($response as $message) {
-                $this->transport->send($message->toJson());
+                $this->send($message, $context);
             }
         });
+    }
+
+    protected function send(JsonRpcResponse $response, ServerContext $context): void
+    {
+        if (array_key_exists('result', $response->content)) {
+            $result = (array) $response->content['result'];
+            $result['_meta'][MetaKey::SERVER_INFO->value] = $context->implementation->toArray();
+
+            $response->content['result'] = ['resultType' => 'complete', ...$result];
+        }
+
+        $this->transport->send($response->toJson());
     }
 
     /**

--- a/src/Transport/JsonRpcResponse.php
+++ b/src/Transport/JsonRpcResponse.php
@@ -14,7 +14,7 @@ class JsonRpcResponse implements Arrayable
     /**
      * @param  array<string, mixed>  $content
      */
-    public function __construct(protected array $content = []) {}
+    public function __construct(public array $content = []) {}
 
     /**
      * @param  array<string, mixed>  $result

--- a/tests/Feature/Console/StartCommandTest.php
+++ b/tests/Feature/Console/StartCommandTest.php
@@ -13,7 +13,17 @@ it('rejects the initialize handshake over http', function (): void {
 
     $response->assertStatus(200);
 
-    expect($response->json())->toEqual(expectedInitializeRejection());
+    expect($response->json())->toEqual([
+        'jsonrpc' => '2.0',
+        'id' => 456,
+        'error' => [
+            'code' => -32601,
+            'message' => 'The [initialize] handshake was removed in MCP 2026-07-28. Send the protocol version in the request [_meta] instead.',
+            'data' => [
+                'supported' => ['2026-07-28'],
+            ],
+        ],
+    ]);
 });
 
 it('does not return a session id over http', function (): void {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Filesystem\Filesystem;
-use Laravel\Mcp\Enums\ProtocolVersion;
 use Tests\Fixtures\ArrayTransport;
 use Tests\Fixtures\ExampleServer;
 use Tests\TestCase;
@@ -86,9 +85,16 @@ function expectedDiscoverResponse(): array
         'jsonrpc' => '2.0',
         'id' => 456,
         'result' => [
-            'supportedVersions' => ProtocolVersion::supported(),
+            'resultType' => 'complete',
+            'supportedVersions' => ['2026-07-28'],
             'capabilities' => $capabilities,
             'instructions' => $instructions,
+            '_meta' => [
+                'io.modelcontextprotocol/serverInfo' => [
+                    'name' => 'Laravel MCP Server',
+                    'version' => '0.0.1',
+                ],
+            ],
         ],
     ];
 }
@@ -115,21 +121,6 @@ function pingResponse(int $id): string
     ]);
 }
 
-function expectedInitializeRejection(): array
-{
-    return [
-        'jsonrpc' => '2.0',
-        'id' => 456,
-        'error' => [
-            'code' => -32601,
-            'message' => 'The [initialize] handshake was removed in MCP 2026-07-28. Send the protocol version in the request [_meta] instead.',
-            'data' => [
-                'supported' => ['2026-07-28'],
-            ],
-        ],
-    ];
-}
-
 function listToolsMessage(): array
 {
     return [
@@ -148,6 +139,7 @@ function expectedListToolsResponse(): array
         'jsonrpc' => '2.0',
         'id' => 1,
         'result' => [
+            'resultType' => 'complete',
             'tools' => [
                 [
                     'name' => 'say-hi-tool',
@@ -182,6 +174,12 @@ function expectedListToolsResponse(): array
                     'title' => 'Streaming Tool',
                 ],
             ],
+            '_meta' => [
+                'io.modelcontextprotocol/serverInfo' => [
+                    'name' => 'Laravel MCP Server',
+                    'version' => '0.0.1',
+                ],
+            ],
         ],
     ];
 }
@@ -204,6 +202,7 @@ function expectedListResourcesResponse(): array
         'jsonrpc' => '2.0',
         'id' => 1,
         'result' => [
+            'resultType' => 'complete',
             'resources' => [
                 [
                     'name' => 'last-log-line-resource',
@@ -225,6 +224,12 @@ function expectedListResourcesResponse(): array
                     'description' => 'The most recent meeting recording',
                     'uri' => 'file://resources/recent-meeting-recording.mp4',
                     'mimeType' => 'video/mp4',
+                ],
+            ],
+            '_meta' => [
+                'io.modelcontextprotocol/serverInfo' => [
+                    'name' => 'Laravel MCP Server',
+                    'version' => '0.0.1',
                 ],
             ],
         ],
@@ -266,11 +271,18 @@ function expectedReadResourceResponse(): array
         'jsonrpc' => '2.0',
         'id' => 123,
         'result' => [
+            'resultType' => 'complete',
             'contents' => [[
                 'text' => '2025-07-02 12:00:00 Error: Something went wrong.',
                 'uri' => 'file://resources/last-log-line-resource',
                 'mimeType' => 'text/plain',
             ]],
+            '_meta' => [
+                'io.modelcontextprotocol/serverInfo' => [
+                    'name' => 'Laravel MCP Server',
+                    'version' => '0.0.1',
+                ],
+            ],
         ],
     ];
 }
@@ -281,11 +293,18 @@ function expectedCallToolResponse(): array
         'jsonrpc' => '2.0',
         'id' => 1,
         'result' => [
+            'resultType' => 'complete',
             'content' => [[
                 'type' => 'text',
                 'text' => 'Hello, John Doe!',
             ]],
             'isError' => false,
+            '_meta' => [
+                'io.modelcontextprotocol/serverInfo' => [
+                    'name' => 'Laravel MCP Server',
+                    'version' => '0.0.1',
+                ],
+            ],
         ],
     ];
 }
@@ -322,8 +341,15 @@ function expectedStreamingToolResponse(int $count = 2): array
         'jsonrpc' => '2.0',
         'id' => 2,
         'result' => [
+            'resultType' => 'complete',
             'content' => [['type' => 'text', 'text' => "Finished streaming {$count} messages."]],
             'isError' => false,
+            '_meta' => [
+                'io.modelcontextprotocol/serverInfo' => [
+                    'name' => 'Laravel MCP Server',
+                    'version' => '0.0.1',
+                ],
+            ],
         ],
     ];
 

--- a/tests/Unit/ServerTest.php
+++ b/tests/Unit/ServerTest.php
@@ -25,7 +25,17 @@ it('rejects the initialize handshake', function (): void {
 
     $response = json_decode((string) $transport->sent[0], true);
 
-    expect($response)->toEqual(expectedInitializeRejection());
+    expect($response)->toEqual([
+        'jsonrpc' => '2.0',
+        'id' => 456,
+        'error' => [
+            'code' => -32601,
+            'message' => 'The [initialize] handshake was removed in MCP 2026-07-28. Send the protocol version in the request [_meta] instead.',
+            'data' => [
+                'supported' => ['2026-07-28'],
+            ],
+        ],
+    ]);
 });
 
 it('can handle a discover message', function (): void {
@@ -323,7 +333,43 @@ it('can handle a custom method message', function (): void {
         'jsonrpc' => '2.0',
         'id' => 12345,
         'result' => [
+            'resultType' => 'complete',
             'message' => 'Custom method executed successfully!',
+            '_meta' => [
+                'io.modelcontextprotocol/serverInfo' => [
+                    'name' => 'Laravel MCP Server',
+                    'version' => '0.0.1',
+                ],
+            ],
+        ],
+    ]);
+});
+
+it('keeps the result type and metadata a method supplied itself', function (): void {
+    $transport = new ArrayTransport;
+    $server = new ExampleServer($transport);
+
+    $server->addMethod('custom/method', OpinionatedMethodHandler::class);
+
+    $server->start();
+
+    $payload = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'custom/method',
+        'params' => ['_meta' => protocolMeta()],
+    ]);
+
+    ($transport->handler)($payload);
+
+    expect(json_decode((string) $transport->sent[0], true)['result'])->toEqual([
+        'resultType' => 'input_required',
+        '_meta' => [
+            'io.modelcontextprotocol/serverInfo' => [
+                'name' => 'Laravel MCP Server',
+                'version' => '0.0.1',
+            ],
+            'app/trace' => 'abc',
         ],
     ]);
 });
@@ -382,7 +428,14 @@ it('discovers an empty capability set as a json object', function (): void {
 
     $server->start();
 
-    ($transport->handler)(json_encode(discoverMessage()));
+    $payload = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 456,
+        'method' => 'server/discover',
+        'params' => ['_meta' => protocolMeta()],
+    ]);
+
+    ($transport->handler)($payload);
 
     expect((string) $transport->sent[0])->toContain('"capabilities":{}');
 });
@@ -564,5 +617,16 @@ class MixedIconServer extends Server
     protected function icons(): array
     {
         return [new Icon('https://example.com/from-method.png')];
+    }
+}
+
+class OpinionatedMethodHandler implements Method
+{
+    public function handle(JsonRpcRequest $request, ServerContext $context): JsonRpcResponse
+    {
+        return JsonRpcResponse::result($request->id, [
+            'resultType' => 'input_required',
+            '_meta' => ['app/trace' => 'abc'],
+        ]);
     }
 }


### PR DESCRIPTION
MCP `2026-07-28` requires every result to say whether it is final and which server produced it, and right now we send neither. A client on the new revision cannot tell a finished result from an intermediate one.

Today:

```json
{ "result": { "tools": [] } }
```

After:

```json
{
  "result": {
    "resultType": "complete",
    "tools": [],
    "_meta": {
      "io.modelcontextprotocol/serverInfo": { "name": "Laravel MCP Server", "version": "0.0.1" }
    }
  }
}
```

Nothing changes for the person writing a tool. Handlers keep returning `Response::text(...)` and the envelope is added on the way out.

Every outbound message now leaves through one method, which is how the two error paths get covered. They previously wrote to the transport directly and skipped the envelope entirely.

Two precedence calls worth a look. `resultType` is only a default, so a handler returning `input_required` keeps it (that lands in #288). Server identity is assigned rather than merged, so a handler cannot claim a different `serverInfo`, though any other `_meta` key it sets survives. Happy to flip the second one if you'd rather the handler win.

> [!WARNING]
> BC break for clients that compare whole result objects. Both members are required on every result in `2026-07-28`, so there is no way to track the revision without it.

Tests cover the precedence a handler keeps, notifications and errors staying untouched, and the envelope on every method the example server answers.

### Spec

- [2026-07-28 changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
- [Base protocol: `_meta` and results](https://modelcontextprotocol.io/specification/2026-07-28/basic/index#meta)

Credit to @JordanDalton, whose #275 mapped out the 2026-07-28 work.
