### PR TITLE
Remove server session state for the stateless transports

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -28,7 +28,6 @@ class Request implements Arrayable
      */
     public function __construct(
         protected array $arguments = [],
-        protected ?string $sessionId = null,
         protected ?array $meta = null,
         protected ?string $uri = null,
     ) {
@@ -100,11 +99,6 @@ class Request implements Arrayable
         return call_user_func($auth->userResolver(), $guard);
     }
 
-    public function sessionId(): ?string
-    {
-        return $this->sessionId;
-    }
-
     /**
      * @return array<string, mixed>|null
      */
@@ -124,11 +118,6 @@ class Request implements Arrayable
     public function setArguments(array $arguments): void
     {
         $this->arguments = $arguments;
-    }
-
-    public function setSessionId(?string $sessionId): void
-    {
-        $this->sessionId = $sessionId;
     }
 
     /**

--- a/src/Server.php
+++ b/src/Server.php
@@ -186,7 +186,7 @@ abstract class Server
             }
 
             $request = isset($jsonRequest['id'])
-                ? JsonRpcRequest::from($jsonRequest, $this->transport->sessionId())
+                ? JsonRpcRequest::from($jsonRequest)
                 : JsonRpcNotification::from($jsonRequest);
 
             if ($request instanceof JsonRpcNotification) {

--- a/src/Server/Contracts/Transport.php
+++ b/src/Server/Contracts/Transport.php
@@ -12,9 +12,7 @@ interface Transport
 
     public function run(); // @phpstan-ignore-line
 
-    public function send(string $message, ?string $sessionId = null): void;
-
-    public function sessionId(): ?string;
+    public function send(string $message): void;
 
     public function stream(Closure $stream): void;
 }

--- a/src/Server/McpServiceProvider.php
+++ b/src/Server/McpServiceProvider.php
@@ -91,7 +91,6 @@ class McpServiceProvider extends ServiceProvider
                 $currentRequest = $app->make('mcp.request');
 
                 $request->setArguments($currentRequest->all());
-                $request->setSessionId($currentRequest->sessionId());
                 $request->setMeta($currentRequest->meta());
             }
         });

--- a/src/Server/Registrar.php
+++ b/src/Server/Registrar.php
@@ -9,7 +9,6 @@ use Illuminate\Container\Container;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\Route as Router;
-use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Laravel\Mcp\Client;
 use Laravel\Mcp\Client\ClientManager;
@@ -48,11 +47,7 @@ class Registrar
 
         $route = Router::post($route, static fn (): mixed => static::startServer(
             $serverClass,
-            static fn (): HttpTransport => new HttpTransport(
-                $request = request(),
-                // @phpstan-ignore-next-line
-                (string) $request->header('MCP-Session-Id')
-            ),
+            static fn (): HttpTransport => new HttpTransport(request()),
         ))->middleware([
             ReorderJsonAccept::class,
             AddWwwAuthenticateHeader::class,
@@ -70,9 +65,7 @@ class Registrar
      */
     public function local(string $handle, string $serverClass): void
     {
-        $this->localServers[$handle] = fn (): mixed => static::startServer($serverClass, fn (): StdioTransport => new StdioTransport(
-            Str::uuid()->toString(),
-        ));
+        $this->localServers[$handle] = fn (): mixed => static::startServer($serverClass, fn (): StdioTransport => new StdioTransport);
     }
 
     /**

--- a/src/Server/Transport/FakeTransporter.php
+++ b/src/Server/Transport/FakeTransporter.php
@@ -17,7 +17,7 @@ class FakeTransporter implements Transport
         //
     }
 
-    public function send(string $message, ?string $sessionId = null): void
+    public function send(string $message): void
     {
         //
     }
@@ -25,11 +25,6 @@ class FakeTransporter implements Transport
     public function run(): Response|StreamedResponse
     {
         throw new LogicException('Not implemented.');
-    }
-
-    public function sessionId(): ?string
-    {
-        return uniqid();
     }
 
     public function stream(Closure $stream): void

--- a/src/Server/Transport/HttpTransport.php
+++ b/src/Server/Transport/HttpTransport.php
@@ -17,10 +17,8 @@ class HttpTransport implements Transport
      */
     public function __construct(
         protected Request $request,
-        protected string $sessionId,
         protected ?Closure $handler = null,
         protected ?string $reply = null,
-        protected ?string $replySessionId = null,
         protected ?Closure $stream = null,
     ) {
         //
@@ -31,14 +29,13 @@ class HttpTransport implements Transport
         $this->handler = $handler;
     }
 
-    public function send(string $message, ?string $sessionId = null): void
+    public function send(string $message): void
     {
         if ($this->stream instanceof Closure) {
             $this->sendStreamMessage($message);
         }
 
         $this->reply = $message;
-        $this->replySessionId = $sessionId;
     }
 
     public function run(): Response|StreamedResponse
@@ -76,11 +73,6 @@ class HttpTransport implements Transport
         return $response;
     }
 
-    public function sessionId(): ?string
-    {
-        return $this->sessionId;
-    }
-
     /**
      * Register a streaming callback.
      *
@@ -112,10 +104,6 @@ class HttpTransport implements Transport
         $headers = [
             'Content-Type' => $this->stream instanceof Closure ? 'text/event-stream' : 'application/json',
         ];
-
-        if ($this->replySessionId !== null) {
-            $headers['MCP-Session-Id'] = $this->replySessionId;
-        }
 
         if ($this->stream instanceof Closure) {
             $headers['X-Accel-Buffering'] = 'no';

--- a/src/Server/Transport/StdioTransport.php
+++ b/src/Server/Transport/StdioTransport.php
@@ -13,7 +13,6 @@ class StdioTransport implements Transport
      * @param  (Closure(string): void)|null  $handler
      */
     public function __construct(
-        protected string $sessionId,
         protected ?Closure $handler = null,
     ) {
         //
@@ -24,7 +23,7 @@ class StdioTransport implements Transport
         $this->handler = $handler;
     }
 
-    public function send(string $message, ?string $sessionId = null): void
+    public function send(string $message): void
     {
         fwrite(STDOUT, $message.PHP_EOL);
     }
@@ -44,11 +43,6 @@ class StdioTransport implements Transport
                 ($this->handler)($line);
             }
         }
-    }
-
-    public function sessionId(): string
-    {
-        return $this->sessionId;
     }
 
     public function stream(Closure $stream): void

--- a/src/Transport/JsonRpcRequest.php
+++ b/src/Transport/JsonRpcRequest.php
@@ -16,7 +16,6 @@ class JsonRpcRequest
         public int|string $id,
         public string $method,
         public array $params,
-        public ?string $sessionId = null
     ) {
         //
     }
@@ -26,7 +25,7 @@ class JsonRpcRequest
      *
      * @throws JsonRpcException
      */
-    public static function from(array $jsonRequest, ?string $sessionId = null): static
+    public static function from(array $jsonRequest): static
     {
         $requestId = $jsonRequest['id'];
 
@@ -50,7 +49,6 @@ class JsonRpcRequest
             id: $requestId,
             method: $jsonRequest['method'],
             params: $jsonRequest['params'] ?? [],
-            sessionId: $sessionId,
         );
     }
 
@@ -89,7 +87,7 @@ class JsonRpcRequest
             $arguments = [];
         }
 
-        return new Request($arguments, $this->sessionId, $this->meta());
+        return new Request($arguments, $this->meta());
     }
 
     /**

--- a/tests/Feature/Console/StartCommandTest.php
+++ b/tests/Feature/Console/StartCommandTest.php
@@ -36,6 +36,26 @@ it('does not return a session id over http', function (): void {
     expect($response->json())->toEqual(expectedDiscoverResponse());
 });
 
+it('ignores an inbound session id header', function (): void {
+    $response = $this->postJson('test-mcp', listToolsMessage(), ['MCP-Session-Id' => 'stale-session']);
+
+    $response->assertStatus(200);
+    $response->assertHeaderMissing('MCP-Session-Id');
+
+    expect($response->json())->toEqual(expectedListToolsResponse());
+});
+
+it('handles consecutive requests without any prior handshake', function (): void {
+    $first = $this->postJson('test-mcp', listToolsMessage());
+    $second = $this->postJson('test-mcp', callToolMessage());
+
+    $first->assertStatus(200);
+    $second->assertStatus(200);
+
+    expect($first->json())->toEqual(expectedListToolsResponse());
+    expect($second->json())->toEqual(expectedCallToolResponse());
+});
+
 it('can list resources over http', function (): void {
     $response = $this->postJson('test-mcp', listResourcesMessage());
 

--- a/tests/Feature/Server/HttpTransportStreamTest.php
+++ b/tests/Feature/Server/HttpTransportStreamTest.php
@@ -4,7 +4,7 @@ use Illuminate\Testing\TestResponse;
 use Laravel\Mcp\Server\Transport\HttpTransport;
 
 it('streams iterable responses returned from the stream callback', function (): void {
-    $transport = new HttpTransport(request(), 'test-session');
+    $transport = new HttpTransport(request());
 
     $transport->stream(fn (): iterable => [
         '{"jsonrpc":"2.0","id":1,"result":[]}',
@@ -21,7 +21,7 @@ it('streams iterable responses returned from the stream callback', function (): 
 });
 
 it('streams generator responses returned from the stream callback', function (): void {
-    $transport = new HttpTransport(request(), 'test-session');
+    $transport = new HttpTransport(request());
 
     $transport->stream(function (): Generator {
         yield '{"jsonrpc":"2.0","id":3,"result":[]}';
@@ -40,7 +40,7 @@ it('streams generator responses returned from the stream callback', function ():
 it('streams generator responses when Octane is flagged', function (): void {
     $_SERVER['LARAVEL_OCTANE'] = '1';
 
-    $transport = new HttpTransport(request(), 'test-session');
+    $transport = new HttpTransport(request());
 
     $transport->stream(function (): Generator {
         yield '{"jsonrpc":"2.0","id":5,"result":[]}';
@@ -57,7 +57,7 @@ it('streams generator responses when Octane is flagged', function (): void {
 });
 
 it('does not double emit when stream callback echoes directly', function (): void {
-    $transport = new HttpTransport(request(), 'test-session');
+    $transport = new HttpTransport(request());
 
     $transport->stream(function (): void {
         echo 'data: {"jsonrpc":"2.0","id":99,"result":[]}';

--- a/tests/Fixtures/ArrayTransport.php
+++ b/tests/Fixtures/ArrayTransport.php
@@ -3,7 +3,6 @@
 namespace Tests\Fixtures;
 
 use Closure;
-use Illuminate\Support\Str;
 use Laravel\Mcp\Server\Contracts\Transport;
 
 class ArrayTransport implements Transport
@@ -11,13 +10,6 @@ class ArrayTransport implements Transport
     public $handler;
 
     public array $sent = [];
-
-    public ?string $sessionId = null;
-
-    public function __construct()
-    {
-        $this->sessionId = Str::uuid()->toString();
-    }
 
     public function onReceive(Closure $handler): void
     {
@@ -29,14 +21,9 @@ class ArrayTransport implements Transport
         //
     }
 
-    public function send(string $message, ?string $sessionId = null): void
+    public function send(string $message): void
     {
         $this->sent[] = $message;
-    }
-
-    public function sessionId(): ?string
-    {
-        return $this->sessionId;
     }
 
     public function stream(Closure $stream): void

--- a/tests/Unit/Methods/ReadResourceTest.php
+++ b/tests/Unit/Methods/ReadResourceTest.php
@@ -344,7 +344,7 @@ it('extracts variables from URI template and passes to handler', function (strin
     ],
 ]);
 
-it('preserves sessionId and meta from the original request for template resources', function (): void {
+it('preserves meta from the original request for template resources', function (): void {
     $template = new class extends Resource implements HasUriTemplate
     {
         public function uriTemplate(): UriTemplate
@@ -355,7 +355,6 @@ it('preserves sessionId and meta from the original request for template resource
         public function handle(Request $request): Response
         {
             return Response::json([
-                'sessionId' => $request->sessionId(),
                 'meta' => $request->meta(),
                 'arguments' => $request->all(),
             ]);
@@ -366,7 +365,6 @@ it('preserves sessionId and meta from the original request for template resource
         'resources' => [$template],
     ]);
 
-    $sessionId = 'test-session-123';
     $meta = ['progressToken' => 'abc123'];
     $jsonRpcRequest = new JsonRpcRequest(
         id: 1,
@@ -376,7 +374,6 @@ it('preserves sessionId and meta from the original request for template resource
             'arguments' => ['format' => 'json'],
             '_meta' => $meta,
         ],
-        sessionId: $sessionId
     );
 
     $container = Container::getInstance();
@@ -389,8 +386,7 @@ it('preserves sessionId and meta from the original request for template resource
 
         $responseData = json_decode((string) $payload['result']['contents'][0]['text'], true);
 
-        expect($responseData['sessionId'])->toBe($sessionId)
-            ->and($responseData['meta'])->toBe($meta)
+        expect($responseData['meta'])->toBe($meta)
             ->and($responseData['arguments'])->toHaveKey('userId', '42')
             ->and($responseData['arguments'])->toHaveKey('format', 'json');
     } finally {

--- a/tests/Unit/RequestTest.php
+++ b/tests/Unit/RequestTest.php
@@ -118,7 +118,6 @@ it('throws ValidationException with custom messages and attributes', function ()
 it('can get uri when set via constructor', function (): void {
     $request = new Request(
         arguments: ['name' => 'Alice'],
-        sessionId: 'session-123',
         meta: ['key' => 'value'],
         uri: 'file://resources/example'
     );
@@ -129,7 +128,6 @@ it('can get uri when set via constructor', function (): void {
 it('returns null for uri when not set via constructor', function (): void {
     $request = new Request(
         arguments: ['name' => 'Alice'],
-        sessionId: 'session-123',
         meta: ['key' => 'value']
     );
 

--- a/tests/Unit/Server/Transport/StdioTransportTest.php
+++ b/tests/Unit/Server/Transport/StdioTransportTest.php
@@ -5,14 +5,8 @@ declare(strict_types=1);
 use Laravel\Mcp\Server\Contracts\Transport;
 use Laravel\Mcp\Server\Transport\StdioTransport;
 
-it('creates stdio transport with session id', function (): void {
-    $transport = new StdioTransport('test-session-123');
-
-    expect($transport->sessionId())->toBe('test-session-123');
-});
-
 it('sets receive handler', function (): void {
-    $transport = new StdioTransport('test-session');
+    $transport = new StdioTransport;
 
     $handlerCalled = false;
     $handler = function (string $message) use (&$handlerCalled): void {
@@ -29,7 +23,7 @@ it('sets receive handler', function (): void {
 });
 
 it('sends message to stdout', function (): void {
-    $transport = new StdioTransport('test-session');
+    $transport = new StdioTransport;
 
     // Capture output
     ob_start();
@@ -54,7 +48,7 @@ it('sends message to stdout', function (): void {
 });
 
 it('executes stream callback', function (): void {
-    $transport = new StdioTransport('test-session');
+    $transport = new StdioTransport;
 
     $streamExecuted = false;
     $stream = function () use (&$streamExecuted): void {
@@ -67,7 +61,7 @@ it('executes stream callback', function (): void {
 });
 
 it('handles run method with handler', function (): void {
-    $transport = new StdioTransport('test-session');
+    $transport = new StdioTransport;
 
     $messages = [];
     $handler = function (string $message) use (&$messages): void {
@@ -88,7 +82,7 @@ it('handles run method with handler', function (): void {
 });
 
 it('implements transport interface', function (): void {
-    $transport = new StdioTransport('test-session');
+    $transport = new StdioTransport;
 
     expect($transport)->toBeInstanceOf(Transport::class);
 });

--- a/tests/Unit/Transport/FakeTransporterTest.php
+++ b/tests/Unit/Transport/FakeTransporterTest.php
@@ -8,16 +8,6 @@ it('throws when running since it is not implemented', function (): void {
     $transporter->run();
 })->throws(LogicException::class, 'Not implemented.');
 
-it('generates a non-empty, unique session id', function (): void {
-    $transporter = new FakeTransporter;
-
-    $id1 = $transporter->sessionId();
-    $id2 = $transporter->sessionId();
-
-    expect($id1)->toBeString()->not->toBe('')->and($id2)->toBeString()->not->toBe('');
-    expect($id1)->not->toBe($id2);
-});
-
 it('accepts onReceive handler without side effects', function (): void {
     $transporter = new FakeTransporter;
 
@@ -33,7 +23,6 @@ it('send is a no-op and does not throw', function (): void {
     $transporter = new FakeTransporter;
 
     $transporter->send('{"ping":true}');
-    $transporter->send('{"ping":true}', 'custom-session');
 
     expect(true)->toBeTrue();
 });

--- a/tests/Unit/Transport/JsonRpcRequestTest.php
+++ b/tests/Unit/Transport/JsonRpcRequestTest.php
@@ -25,17 +25,6 @@ it('can create a message from valid json', function (): void {
         ->and($request->params)->toEqual(['name' => 'echo', 'arguments' => ['message' => 'Hello, world!']]);
 });
 
-it('stores session id when provided', function (): void {
-    $sessionId = 'i-am-your-session-luke';
-    $request = JsonRpcRequest::from([
-        'jsonrpc' => '2.0',
-        'id' => 1,
-        'method' => 'tools/call',
-    ], $sessionId);
-
-    expect($request->sessionId)->toBe($sessionId);
-});
-
 it('throws exception for missing jsonrpc version', function (): void {
     $this->expectException(JsonRpcException::class);
     $this->expectExceptionMessage('Invalid Request: The [jsonrpc] member must be exactly [2.0].');


### PR DESCRIPTION
A `2026-07-28` server has no session to hold onto. Each message stands alone, so the session id that used to travel with a request has nothing left to identify.

Before:

```php
public function handle(Request $request): Response
{
    return Response::text($request->sessionId());
}
```

After:

```php
public function handle(Request $request): Response
{
    return Response::text('one request, no session');
}
```

The server transports no longer read or emit `MCP-Session-Id`, and `JsonRpcRequest` no longer carries a session id into `Request`.

> [!WARNING]
> BC break. `Request::sessionId()` and `Request::setSessionId()` are gone, `Transport::send()` lost its `$sessionId` argument, `Transport::sessionId()` is removed, and `HttpTransport`/`StdioTransport` no longer take a session id constructor argument. Custom transports need updating.

`Last-Event-ID` and SSE event ids needed no removal because the package never implemented them, and `GET`/`DELETE` on an MCP route already answer `405`. Tests cover the missing response header, an inbound session header being ignored, and consecutive requests with no prior handshake.

### Spec

- [2026-07-28 changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
- [Transports](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports)

Credit to @JordanDalton, whose #275 mapped out the 2026-07-28 work.
