### PR TITLE
Add the multi round-trip request pattern

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -40,9 +40,6 @@ class Client
 
     protected ProtocolEra $era = ProtocolEra::AUTO;
 
-    /** @var array<string, Closure(array<string, mixed>): array<string, mixed>> */
-    protected array $inputHandlers = [];
-
     public function __construct(
         protected Transport $transport,
         public ?Implementation $clientInfo = null,
@@ -157,8 +154,6 @@ class Client
      */
     protected function onInput(string $method, Closure $handler): static
     {
-        $this->inputHandlers[$method] = $handler;
-
         $this->protocol->onInput($method, $handler);
 
         return $this;
@@ -280,10 +275,6 @@ class Client
         $this->clientInfo ??= $this->defaultClientInfo();
 
         $this->protocol = new Protocol($this->transport, $this->clientInfo, $this->era);
-
-        foreach ($this->inputHandlers as $method => $handler) {
-            $this->protocol->onInput($method, $handler);
-        }
     }
 
     public function __destruct()

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp;
 
+use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Support\Collection;
 use Laravel\Mcp\Client\ClientManager;
@@ -38,6 +39,9 @@ class Client
     protected ?string $name = null;
 
     protected ProtocolEra $era = ProtocolEra::AUTO;
+
+    /** @var array<string, Closure(array<string, mixed>): array<string, mixed>> */
+    protected array $inputHandlers = [];
 
     public function __construct(
         protected Transport $transport,
@@ -122,6 +126,42 @@ class Client
     public function era(): ?ProtocolEra
     {
         return $this->protocol->resolvedEra();
+    }
+
+    /**
+     * @param  Closure(array<string, mixed>): array<string, mixed>  $handler
+     */
+    public function onElicitation(Closure $handler): static
+    {
+        return $this->onInput('elicitation/create', $handler);
+    }
+
+    /**
+     * @param  Closure(array<string, mixed>): array<string, mixed>  $handler
+     */
+    public function onSampling(Closure $handler): static
+    {
+        return $this->onInput('sampling/createMessage', $handler);
+    }
+
+    /**
+     * @param  Closure(array<string, mixed>): array<string, mixed>  $handler
+     */
+    public function onListRoots(Closure $handler): static
+    {
+        return $this->onInput('roots/list', $handler);
+    }
+
+    /**
+     * @param  Closure(array<string, mixed>): array<string, mixed>  $handler
+     */
+    protected function onInput(string $method, Closure $handler): static
+    {
+        $this->inputHandlers[$method] = $handler;
+
+        $this->protocol->onInput($method, $handler);
+
+        return $this;
     }
 
     public function ping(): void
@@ -240,6 +280,10 @@ class Client
         $this->clientInfo ??= $this->defaultClientInfo();
 
         $this->protocol = new Protocol($this->transport, $this->clientInfo, $this->era);
+
+        foreach ($this->inputHandlers as $method => $handler) {
+            $this->protocol->onInput($method, $handler);
+        }
     }
 
     public function __destruct()

--- a/src/Client/Methods/RetriedRequest.php
+++ b/src/Client/Methods/RetriedRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\Methods;
+
+use Laravel\Mcp\Client\Contracts\Method;
+use Laravel\Mcp\Client\Protocol;
+
+/**
+ * @implements Method<array<string, mixed>>
+ */
+class RetriedRequest implements Method
+{
+    /**
+     * @param  Method<mixed>  $method
+     * @param  array<string, mixed>  $inputResponses
+     */
+    public function __construct(
+        protected Method $method,
+        protected array $inputResponses = [],
+        protected ?string $requestState = null,
+    ) {
+        //
+    }
+
+    public function method(): string
+    {
+        return $this->method->method();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function params(): array
+    {
+        return [
+            ...$this->method->params(),
+            ...$this->inputResponses === [] ? [] : ['inputResponses' => $this->inputResponses],
+            ...$this->requestState === null ? [] : ['requestState' => $this->requestState],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function handle(Protocol $protocol): array
+    {
+        return $protocol->dispatch($this);
+    }
+}

--- a/src/Client/Protocol.php
+++ b/src/Client/Protocol.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp\Client;
 
+use Closure;
 use Illuminate\Support\Arr;
 use JsonException;
 use Laravel\Mcp\Client\Contracts\Method;
@@ -12,15 +13,18 @@ use Laravel\Mcp\Client\Enums\ProtocolEra;
 use Laravel\Mcp\Client\Exceptions\UnexpectedResponseException;
 use Laravel\Mcp\Client\Methods\Discover;
 use Laravel\Mcp\Client\Methods\Initialize;
+use Laravel\Mcp\Client\Methods\RetriedRequest;
 use Laravel\Mcp\Client\Schema\DiscoverResult;
 use Laravel\Mcp\Client\Schema\InitializeResult;
 use Laravel\Mcp\Enums\ErrorCode;
 use Laravel\Mcp\Enums\MetaKey;
 use Laravel\Mcp\Enums\ProtocolVersion;
+use Laravel\Mcp\Enums\ResultType;
 use Laravel\Mcp\Exceptions\ClientException;
 use Laravel\Mcp\Exceptions\JsonRpcException;
 use Laravel\Mcp\Exceptions\SessionExpiredException;
 use Laravel\Mcp\Schema\Implementation;
+use Laravel\Mcp\Support\InputRequests;
 use Laravel\Mcp\Transport\JsonRpcNotification;
 use Laravel\Mcp\Transport\JsonRpcRequest;
 use Laravel\Mcp\Transport\JsonRpcResponse;
@@ -28,6 +32,11 @@ use Throwable;
 
 class Protocol
 {
+    public const MAX_INPUT_ROUNDS = 5;
+
+    /** @var array<string, Closure(array<string, mixed>): array<string, mixed>> */
+    protected array $inputHandlers = [];
+
     protected bool $connected = false;
 
     protected bool $connecting = false;
@@ -190,12 +199,91 @@ class Protocol
         }
 
         try {
-            return $this->attempt($method);
+            $result = $this->attempt($method);
         } catch (SessionExpiredException) {
             $this->connect();
 
-            return $this->attempt($method);
+            $result = $this->attempt($method);
         }
+
+        return $this->fulfillInputRequests($method, $result);
+    }
+
+    /**
+     * @param  Method<mixed>  $method
+     * @param  array<string, mixed>  $result
+     * @return array<string, mixed>
+     */
+    protected function fulfillInputRequests(Method $method, array $result, int $round = 0): array
+    {
+        if (($result['resultType'] ?? null) !== ResultType::INPUT_REQUIRED->value) {
+            return $result;
+        }
+
+        if ($round >= self::MAX_INPUT_ROUNDS) {
+            throw new ClientException('The server asked for input more than '.self::MAX_INPUT_ROUNDS.' times for the same request.');
+        }
+
+        $inputRequests = is_array($result['inputRequests'] ?? null) ? $result['inputRequests'] : [];
+        $inputResponses = [];
+
+        foreach ($inputRequests as $key => $inputRequest) {
+            $inputResponses[$key] = $this->fulfill(is_array($inputRequest) ? $inputRequest : []);
+        }
+
+        $retry = new RetriedRequest(
+            $method,
+            $inputResponses,
+            is_string($result['requestState'] ?? null) ? $result['requestState'] : null,
+        );
+
+        return $this->fulfillInputRequests($method, $this->attempt($retry), $round + 1);
+    }
+
+    /**
+     * @param  array<string, mixed>  $inputRequest
+     * @return array<string, mixed>
+     */
+    protected function fulfill(array $inputRequest): array
+    {
+        $method = $inputRequest['method'] ?? null;
+        $handler = is_string($method) ? ($this->inputHandlers[$method] ?? null) : null;
+
+        if (! $handler instanceof Closure) {
+            throw new ClientException("The server requested [{$method}], which this client has no handler for.");
+        }
+
+        $response = $handler(is_array($inputRequest['params'] ?? null) ? $inputRequest['params'] : []);
+
+        if (! is_array($response)) {
+            throw new ClientException("The handler for [{$method}] must return an array.");
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param  Closure(array<string, mixed>): array<string, mixed>  $handler
+     */
+    public function onInput(string $method, Closure $handler): void
+    {
+        $this->inputHandlers[$method] = $handler;
+    }
+
+    /**
+     * @return array<string, object>
+     */
+    protected function clientCapabilities(): array
+    {
+        $capabilities = [];
+
+        foreach (array_keys($this->inputHandlers) as $method) {
+            if (isset(InputRequests::CAPABILITIES[$method])) {
+                $capabilities[InputRequests::CAPABILITIES[$method]] = (object) [];
+            }
+        }
+
+        return $capabilities;
     }
 
     /**
@@ -284,7 +372,7 @@ class Protocol
 
         $params['_meta'] = [
             MetaKey::PROTOCOL_VERSION->value => ProtocolVersion::LATEST->value,
-            MetaKey::CLIENT_CAPABILITIES->value => (object) [],
+            MetaKey::CLIENT_CAPABILITIES->value => (object) $this->clientCapabilities(),
             MetaKey::CLIENT_INFO->value => $this->clientInfo->toArray(),
             ...is_array($params['_meta'] ?? null) ? $params['_meta'] : [],
         ];

--- a/src/Client/Protocol.php
+++ b/src/Client/Protocol.php
@@ -198,15 +198,22 @@ class Protocol
             $this->connect();
         }
 
+        return $this->fulfillInputRequests($method, $this->attemptOrReconnect($method));
+    }
+
+    /**
+     * @param  Method<mixed>  $method
+     * @return array<string, mixed>
+     */
+    protected function attemptOrReconnect(Method $method): array
+    {
         try {
-            $result = $this->attempt($method);
+            return $this->attempt($method);
         } catch (SessionExpiredException) {
             $this->connect();
 
-            $result = $this->attempt($method);
+            return $this->attempt($method);
         }
-
-        return $this->fulfillInputRequests($method, $result);
     }
 
     /**
@@ -237,7 +244,7 @@ class Protocol
             is_string($result['requestState'] ?? null) ? $result['requestState'] : null,
         );
 
-        return $this->fulfillInputRequests($method, $this->attempt($retry), $round + 1);
+        return $this->fulfillInputRequests($method, $this->attemptOrReconnect($retry), $round + 1);
     }
 
     /**

--- a/src/Enums/ResultType.php
+++ b/src/Enums/ResultType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Enums;
+
+enum ResultType: string
+{
+    case COMPLETE = 'complete';
+    case INPUT_REQUIRED = 'input_required';
+}

--- a/src/Request.php
+++ b/src/Request.php
@@ -25,11 +25,14 @@ class Request implements Arrayable
     /**
      * @param  array<string, mixed>  $arguments
      * @param  array<string, mixed>|null  $meta
+     * @param  array<string, mixed>  $inputResponses
      */
     public function __construct(
         protected array $arguments = [],
         protected ?array $meta = null,
         protected ?string $uri = null,
+        protected array $inputResponses = [],
+        protected ?string $requestState = null,
     ) {
         //
     }
@@ -110,6 +113,32 @@ class Request implements Arrayable
     public function uri(): ?string
     {
         return $this->uri;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function inputResponses(): array
+    {
+        return $this->inputResponses;
+    }
+
+    public function requestState(): ?string
+    {
+        return $this->requestState;
+    }
+
+    /**
+     * @param  array<string, mixed>  $inputResponses
+     */
+    public function setInputResponses(array $inputResponses): void
+    {
+        $this->inputResponses = $inputResponses;
+    }
+
+    public function setRequestState(?string $requestState): void
+    {
+        $this->requestState = $requestState;
     }
 
     /**

--- a/src/Server.php
+++ b/src/Server.php
@@ -8,6 +8,7 @@ use Illuminate\Container\Container;
 use Laravel\Mcp\Enums\ErrorCode;
 use Laravel\Mcp\Enums\MetaKey;
 use Laravel\Mcp\Enums\ProtocolVersion;
+use Laravel\Mcp\Enums\ResultType;
 use Laravel\Mcp\Exceptions\JsonRpcException;
 use Laravel\Mcp\Schema\Icon;
 use Laravel\Mcp\Schema\Implementation;
@@ -327,7 +328,7 @@ abstract class Server
     protected function completeResult(JsonRpcResponse $response, ServerContext $context): JsonRpcResponse
     {
         return $response->mergeResult(
-            ['resultType' => 'complete'],
+            ['resultType' => ResultType::COMPLETE->value],
             [MetaKey::SERVER_INFO->value => $context->implementation->toArray()],
         );
     }

--- a/src/Server/InputRequired.php
+++ b/src/Server/InputRequired.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Server;
+
+use InvalidArgumentException;
+use Laravel\Mcp\Enums\ResultType;
+use Laravel\Mcp\Support\InputRequests;
+
+class InputRequired
+{
+    /**
+     * @param  array<string, array<string, mixed>>  $inputRequests
+     */
+    public function __construct(
+        protected array $inputRequests = [],
+        protected ?string $requestState = null,
+    ) {
+        if ($this->inputRequests === [] && $this->requestState === null) {
+            throw new InvalidArgumentException('An input required result must carry input requests, request state, or both.');
+        }
+
+        foreach ($this->inputRequests as $key => $inputRequest) {
+            $method = $inputRequest['method'] ?? null;
+
+            if (! is_string($method) || ! array_key_exists($method, InputRequests::CAPABILITIES)) {
+                throw new InvalidArgumentException("Input request [{$key}] must use one of [".implode(', ', array_keys(InputRequests::CAPABILITIES)).'].');
+            }
+        }
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $inputRequests
+     */
+    public static function make(array $inputRequests = [], ?string $requestState = null): static
+    {
+        return new static($inputRequests, $requestState);
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function inputRequests(): array
+    {
+        return $this->inputRequests;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function requiredCapabilities(): array
+    {
+        return array_values(array_unique(array_map(
+            fn (array $inputRequest): string => InputRequests::CAPABILITIES[$inputRequest['method']],
+            $this->inputRequests,
+        )));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'resultType' => ResultType::INPUT_REQUIRED->value,
+            ...$this->inputRequests === [] ? [] : ['inputRequests' => $this->inputRequests],
+            ...$this->requestState === null ? [] : ['requestState' => $this->requestState],
+        ];
+    }
+}

--- a/src/Server/McpServiceProvider.php
+++ b/src/Server/McpServiceProvider.php
@@ -92,6 +92,8 @@ class McpServiceProvider extends ServiceProvider
 
                 $request->setArguments($currentRequest->all());
                 $request->setMeta($currentRequest->meta());
+                $request->setInputResponses($currentRequest->inputResponses());
+                $request->setRequestState($currentRequest->requestState());
             }
         });
     }

--- a/src/Server/Methods/CallTool.php
+++ b/src/Server/Methods/CallTool.php
@@ -11,6 +11,7 @@ use Laravel\Mcp\Response;
 use Laravel\Mcp\ResponseFactory;
 use Laravel\Mcp\Server\Contracts\Errable;
 use Laravel\Mcp\Server\Contracts\Method;
+use Laravel\Mcp\Server\InputRequired;
 use Laravel\Mcp\Server\Methods\Concerns\InteractsWithResponses;
 use Laravel\Mcp\Server\ServerContext;
 use Laravel\Mcp\Server\Tool;
@@ -48,6 +49,10 @@ class CallTool implements Errable, Method
 
         // @phpstan-ignore-next-line
         $response = $this->callHandler(fn (): mixed => Container::getInstance()->call([$tool, 'handle']), $request);
+
+        if ($response instanceof InputRequired) {
+            return $this->toInputRequiredResponse($request, $response);
+        }
 
         return is_iterable($response)
             ? $this->toJsonRpcStreamedResponse($request, $response, $this->serializable($tool))

--- a/src/Server/Methods/Concerns/InteractsWithResponses.php
+++ b/src/Server/Methods/Concerns/InteractsWithResponses.php
@@ -48,16 +48,23 @@ trait InteractsWithResponses
     }
 
     /**
-     * @param  iterable<Response|ResponseFactory|string>  $responses
+     * @param  iterable<InputRequired|Response|ResponseFactory|string>  $responses
      * @return Generator<JsonRpcResponse>
      */
     protected function toJsonRpcStreamedResponse(JsonRpcRequest $request, iterable $responses, callable $serializable): Generator
     {
         /** @var array<int, Response|ResponseFactory|string> $pendingResponses */
         $pendingResponses = [];
+        $inputRequired = null;
 
         try {
             foreach ($responses as $response) {
+                if ($response instanceof InputRequired) {
+                    $inputRequired = $response;
+
+                    break;
+                }
+
                 if ($response instanceof Response && $response->isNotification()) {
                     /** @var Notification $content */
                     $content = $response->content();
@@ -83,6 +90,12 @@ trait InteractsWithResponses
             }
 
             throw $this->toJsonRpcException($throwable, $request->id);
+        }
+
+        if ($inputRequired instanceof InputRequired) {
+            yield $this->toInputRequiredResponse($request, $inputRequired);
+
+            return;
         }
 
         yield $this->toJsonRpcResponse($request, $pendingResponses, $serializable);

--- a/src/Server/Methods/Concerns/InteractsWithResponses.php
+++ b/src/Server/Methods/Concerns/InteractsWithResponses.php
@@ -10,11 +10,14 @@ use Illuminate\Auth\AuthenticationException;
 use Illuminate\Support\Arr;
 use Illuminate\Validation\ValidationException;
 use InvalidArgumentException;
+use Laravel\Mcp\Enums\ErrorCode;
+use Laravel\Mcp\Enums\MetaKey;
 use Laravel\Mcp\Exceptions\JsonRpcException;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\ResponseFactory;
 use Laravel\Mcp\Server\Content\Notification;
 use Laravel\Mcp\Server\Contracts\Errable;
+use Laravel\Mcp\Server\InputRequired;
 use Laravel\Mcp\Support\ValidationMessages;
 use Laravel\Mcp\Transport\JsonRpcRequest;
 use Laravel\Mcp\Transport\JsonRpcResponse;
@@ -83,6 +86,29 @@ trait InteractsWithResponses
         }
 
         yield $this->toJsonRpcResponse($request, $pendingResponses, $serializable);
+    }
+
+    /**
+     * @throws JsonRpcException
+     */
+    protected function toInputRequiredResponse(JsonRpcRequest $request, InputRequired $inputRequired): JsonRpcResponse
+    {
+        $meta = $request->meta() ?? [];
+        $capabilities = $meta[MetaKey::CLIENT_CAPABILITIES->value] ?? [];
+        $capabilities = is_array($capabilities) ? $capabilities : [];
+
+        foreach ($inputRequired->requiredCapabilities() as $capability) {
+            if (! array_key_exists($capability, $capabilities)) {
+                throw new JsonRpcException(
+                    "The client did not declare the required [{$capability}] capability.",
+                    ErrorCode::MISSING_REQUIRED_CLIENT_CAPABILITY->value,
+                    $request->id,
+                    ['capability' => $capability],
+                );
+            }
+        }
+
+        return JsonRpcResponse::result($request->id, $inputRequired->toArray());
     }
 
     protected function callHandler(callable $handler, JsonRpcRequest $request): mixed

--- a/src/Server/Methods/GetPrompt.php
+++ b/src/Server/Methods/GetPrompt.php
@@ -11,6 +11,7 @@ use Laravel\Mcp\Exceptions\JsonRpcException;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\ResponseFactory;
 use Laravel\Mcp\Server\Contracts\Method;
+use Laravel\Mcp\Server\InputRequired;
 use Laravel\Mcp\Server\Methods\Concerns\InteractsWithResponses;
 use Laravel\Mcp\Server\Methods\Concerns\ResolvesPrompts;
 use Laravel\Mcp\Server\Prompt;
@@ -36,6 +37,10 @@ class GetPrompt implements Method
 
         // @phpstan-ignore-next-line
         $response = $this->callHandler(fn (): mixed => Container::getInstance()->call([$prompt, 'handle']), $request);
+
+        if ($response instanceof InputRequired) {
+            return $this->toInputRequiredResponse($request, $response);
+        }
 
         return is_iterable($response)
             ? $this->toJsonRpcStreamedResponse($request, $response, $this->serializable($prompt))

--- a/src/Server/Methods/ReadResource.php
+++ b/src/Server/Methods/ReadResource.php
@@ -16,6 +16,7 @@ use Laravel\Mcp\ResponseFactory;
 use Laravel\Mcp\Server\AppResource;
 use Laravel\Mcp\Server\Contracts\HasUriTemplate;
 use Laravel\Mcp\Server\Contracts\Method;
+use Laravel\Mcp\Server\InputRequired;
 use Laravel\Mcp\Server\Methods\Concerns\InteractsWithResponses;
 use Laravel\Mcp\Server\Methods\Concerns\ResolvesResources;
 use Laravel\Mcp\Server\Resource;
@@ -48,6 +49,10 @@ class ReadResource implements Method
         }
 
         $response = $this->callHandler(fn (): mixed => $this->invokeResource($resource, $uri), $request);
+
+        if ($response instanceof InputRequired) {
+            return $this->toInputRequiredResponse($request, $response);
+        }
 
         return is_iterable($response)
             ? $this->toJsonRpcStreamedResponse($request, $response, $this->serializable($resource, $uri))

--- a/src/Support/InputRequests.php
+++ b/src/Support/InputRequests.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Support;
+
+class InputRequests
+{
+    public const CAPABILITIES = [
+        'elicitation/create' => 'elicitation',
+        'sampling/createMessage' => 'sampling',
+        'roots/list' => 'roots',
+    ];
+}

--- a/src/Transport/JsonRpcRequest.php
+++ b/src/Transport/JsonRpcRequest.php
@@ -87,7 +87,12 @@ class JsonRpcRequest
             $arguments = [];
         }
 
-        return new Request($arguments, $this->meta());
+        return new Request(
+            $arguments,
+            $this->meta(),
+            inputResponses: is_array($this->params['inputResponses'] ?? null) ? $this->params['inputResponses'] : [],
+            requestState: is_string($this->params['requestState'] ?? null) ? $this->params['requestState'] : null,
+        );
     }
 
     /**

--- a/tests/Feature/Server/InputRequiredTest.php
+++ b/tests/Feature/Server/InputRequiredTest.php
@@ -117,3 +117,57 @@ it('refuses an input request the protocol does not define', function (): void {
     expect(fn (): InputRequired => InputRequired::make(['x' => ['method' => 'tools/call']]))
         ->toThrow(InvalidArgumentException::class, 'Input request [x] must use one of');
 });
+
+it('returns an input required result yielded from a streaming handler', function (): void {
+    $tool = new class extends Tool
+    {
+        protected string $name = 'stream-ask';
+
+        protected string $description = 'Logs, then asks for a name.';
+
+        public function handle(Request $request): Generator
+        {
+            yield Response::notification('notifications/progress', ['progress' => 1]);
+
+            yield InputRequired::make([
+                'who' => [
+                    'method' => 'elicitation/create',
+                    'params' => ['mode' => 'form', 'message' => 'Who are you?'],
+                ],
+            ]);
+        }
+    };
+
+    $server = new class(new ArrayTransport, $tool) extends Server
+    {
+        public function __construct(ArrayTransport $transport, Tool $tool)
+        {
+            parent::__construct($transport);
+
+            $this->tools = [$tool];
+        }
+    };
+
+    $transport = (fn (): ArrayTransport => $this->transport)->call($server);
+
+    $server->start();
+
+    ($transport->handler)((string) json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => 'stream-ask',
+            '_meta' => [
+                ...protocolMeta(),
+                'io.modelcontextprotocol/clientCapabilities' => ['elicitation' => []],
+            ],
+        ],
+    ]));
+
+    $final = json_decode((string) $transport->sent[array_key_last($transport->sent)], true);
+
+    expect(json_decode((string) $transport->sent[0], true)['method'])->toBe('notifications/progress');
+    expect($final['result']['resultType'])->toBe('input_required');
+    expect($final['result']['inputRequests']['who']['method'])->toBe('elicitation/create');
+});

--- a/tests/Feature/Server/InputRequiredTest.php
+++ b/tests/Feature/Server/InputRequiredTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\InputRequired;
+use Laravel\Mcp\Server\Tool;
+use Tests\Fixtures\ArrayTransport;
+
+function elicitingServer(): Server
+{
+    $tool = new class extends Tool
+    {
+        protected string $name = 'ask-name';
+
+        protected string $description = 'Asks for a name.';
+
+        public function handle(Request $request): Response|InputRequired
+        {
+            if ($request->inputResponses() === []) {
+                return InputRequired::make([
+                    'who' => [
+                        'method' => 'elicitation/create',
+                        'params' => [
+                            'mode' => 'form',
+                            'message' => 'Who are you?',
+                            'requestedSchema' => [
+                                'type' => 'object',
+                                'properties' => ['name' => ['type' => 'string']],
+                                'required' => ['name'],
+                            ],
+                        ],
+                    ],
+                ], requestState: 'state-for-'.$request->get('greeting'));
+            }
+
+            return Response::text(sprintf(
+                '%s, %s (%s)',
+                $request->get('greeting'),
+                $request->inputResponses()['who']['content']['name'],
+                $request->requestState(),
+            ));
+        }
+    };
+
+    return new class(new ArrayTransport, $tool) extends Server
+    {
+        public function __construct(ArrayTransport $transport, Tool $tool)
+        {
+            parent::__construct($transport);
+
+            $this->tools = [$tool];
+        }
+    };
+}
+
+function askName(array $params = [], ?array $capabilities = ['elicitation' => []]): array
+{
+    $server = elicitingServer();
+    $transport = (fn (): ArrayTransport => $this->transport)->call($server);
+
+    $server->start();
+
+    ($transport->handler)((string) json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => 'ask-name',
+            'arguments' => ['greeting' => 'Hello'],
+            '_meta' => [
+                ...protocolMeta(),
+                'io.modelcontextprotocol/clientCapabilities' => $capabilities,
+            ],
+            ...$params,
+        ],
+    ]));
+
+    return json_decode((string) $transport->sent[0], true);
+}
+
+it('returns an input required result', function (): void {
+    $response = askName();
+
+    expect($response['result']['resultType'])->toBe('input_required');
+    expect($response['result']['inputRequests']['who']['method'])->toBe('elicitation/create');
+    expect($response['result']['requestState'])->toBe('state-for-Hello');
+    expect($response['result'])->not->toHaveKey('content');
+});
+
+it('completes the request when the input responses come back', function (): void {
+    $response = askName([
+        'inputResponses' => ['who' => ['action' => 'accept', 'content' => ['name' => 'John']]],
+        'requestState' => 'state-for-Hello',
+    ]);
+
+    expect($response['result']['resultType'])->toBe('complete');
+    expect($response['result']['content'][0]['text'])->toBe('Hello, John (state-for-Hello)');
+});
+
+it('rejects input requests the client has no capability for', function (): void {
+    $response = askName(capabilities: []);
+
+    expect($response['error']['code'])->toBe(-32021);
+    expect($response['error']['message'])->toBe('The client did not declare the required [elicitation] capability.');
+    expect($response['error']['data'])->toBe(['capability' => 'elicitation']);
+});
+
+it('refuses an input required result with nothing in it', function (): void {
+    expect(fn (): InputRequired => InputRequired::make())
+        ->toThrow(InvalidArgumentException::class, 'must carry input requests, request state, or both');
+});
+
+it('refuses an input request the protocol does not define', function (): void {
+    expect(fn (): InputRequired => InputRequired::make(['x' => ['method' => 'tools/call']]))
+        ->toThrow(InvalidArgumentException::class, 'Input request [x] must use one of');
+});

--- a/tests/Unit/Client/InputRequestsTest.php
+++ b/tests/Unit/Client/InputRequestsTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Mcp\Client;
+use Laravel\Mcp\Exceptions\ClientException;
+use Tests\Fixtures\Client\FakeTransport;
+
+function inputRequiredResponse(int $id, string $state = 'opaque-state'): string
+{
+    return (string) json_encode([
+        'jsonrpc' => '2.0',
+        'id' => $id,
+        'result' => [
+            'resultType' => 'input_required',
+            'inputRequests' => [
+                'who' => [
+                    'method' => 'elicitation/create',
+                    'params' => ['mode' => 'form', 'message' => 'Who are you?'],
+                ],
+            ],
+            'requestState' => $state,
+        ],
+    ]);
+}
+
+function toolCallResponse(int $id, string $text): string
+{
+    return (string) json_encode([
+        'jsonrpc' => '2.0',
+        'id' => $id,
+        'result' => [
+            'resultType' => 'complete',
+            'content' => [['type' => 'text', 'text' => $text]],
+            'isError' => false,
+        ],
+    ]);
+}
+
+it('retries the request with the gathered input and the echoed state', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = discoverResponse();
+    $transport->responses[] = inputRequiredResponse(2);
+    $transport->responses[] = toolCallResponse(3, 'Hello, John');
+
+    $result = (new Client($transport))
+        ->onElicitation(fn (array $params): array => ['action' => 'accept', 'content' => ['name' => 'John']])
+        ->callTool('say-hi');
+
+    expect($result->text())->toBe('Hello, John');
+
+    $first = json_decode($transport->sent[1], true);
+    $retry = json_decode($transport->sent[2], true);
+
+    expect($first['params'])->not->toHaveKey('inputResponses');
+    expect($retry['method'])->toBe('tools/call');
+    expect($retry['id'])->toBe(3)->not->toBe($first['id']);
+    expect($retry['params']['requestState'])->toBe('opaque-state');
+    expect($retry['params']['inputResponses']['who'])->toBe(['action' => 'accept', 'content' => ['name' => 'John']]);
+});
+
+it('declares only the capabilities it has handlers for', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = discoverResponse();
+    $transport->responses[] = toolCallResponse(2, 'hi');
+
+    (new Client($transport))
+        ->onElicitation(fn (array $params): array => [])
+        ->onListRoots(fn (array $params): array => ['roots' => []])
+        ->callTool('say-hi');
+
+    $capabilities = json_decode($transport->sent[1], true)['params']['_meta']['io.modelcontextprotocol/clientCapabilities'];
+
+    expect($capabilities)->toBe(['elicitation' => [], 'roots' => []]);
+});
+
+it('fails when the server asks for input it has no handler for', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = discoverResponse();
+    $transport->responses[] = inputRequiredResponse(2);
+
+    expect(fn (): mixed => (new Client($transport))->callTool('say-hi'))
+        ->toThrow(ClientException::class, 'The server requested [elicitation/create], which this client has no handler for.');
+});
+
+it('gives up when the server keeps asking for input', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = discoverResponse();
+
+    foreach (range(2, 8) as $id) {
+        $transport->responses[] = inputRequiredResponse($id);
+    }
+
+    $client = (new Client($transport))->onElicitation(fn (array $params): array => []);
+
+    expect(fn (): mixed => $client->callTool('say-hi'))
+        ->toThrow(ClientException::class, 'asked for input more than 5 times');
+});
+
+it('omits the request state when the server sent none', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = discoverResponse();
+    $transport->responses[] = (string) json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => ['resultType' => 'input_required', 'requestState' => null, 'inputRequests' => []],
+    ]);
+    $transport->responses[] = toolCallResponse(3, 'hi');
+
+    (new Client($transport))->callTool('say-hi');
+
+    expect(json_decode($transport->sent[2], true)['params'])
+        ->not->toHaveKey('requestState')
+        ->not->toHaveKey('inputResponses');
+});

--- a/tests/Unit/Client/InputRequestsTest.php
+++ b/tests/Unit/Client/InputRequestsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Laravel\Mcp\Client;
 use Laravel\Mcp\Exceptions\ClientException;
+use Laravel\Mcp\Exceptions\SessionExpiredException;
 use Tests\Fixtures\Client\FakeTransport;
 
 function inputRequiredResponse(int $id, string $state = 'opaque-state'): string
@@ -112,4 +113,34 @@ it('omits the request state when the server sent none', function (): void {
     expect(json_decode($transport->sent[2], true)['params'])
         ->not->toHaveKey('requestState')
         ->not->toHaveKey('inputResponses');
+});
+
+it('reconnects when the session expires between input rounds', function (): void {
+    $transport = new class extends FakeTransport
+    {
+        public int $expireOnSend = 0;
+
+        public function send(string $message): void
+        {
+            parent::send($message);
+
+            if (count($this->sent) === $this->expireOnSend) {
+                throw new SessionExpiredException('Session expired.');
+            }
+        }
+    };
+
+    $transport->expireOnSend = 3;
+    $transport->responses[] = discoverResponse();
+    $transport->responses[] = inputRequiredResponse(2);
+    $transport->responses[] = discoverResponse(4);
+    $transport->responses[] = toolCallResponse(5, 'Hello, John');
+
+    $result = (new Client($transport))
+        ->onElicitation(fn (array $params): array => ['action' => 'accept', 'content' => ['name' => 'John']])
+        ->callTool('say-hi');
+
+    expect($result->text())->toBe('Hello, John');
+    expect(json_decode($transport->sent[3], true)['method'])->toBe('server/discover');
+    expect(json_decode($transport->sent[4], true)['params']['inputResponses']['who']['content']['name'])->toBe('John');
 });


### PR DESCRIPTION
A server that needs something from the user, an elicitation, a sampling call, a roots listing, used to send its own JSON-RPC request back down the stream. `2026-07-28` removes that. The server returns instead, says what it needs, and the client asks again.

A tool that needs a name:

```php
public function handle(Request $request): Response|InputRequired
{
    if ($request->inputResponses() === []) {
        return InputRequired::make([
            'who' => [
                'method' => 'elicitation/create',
                'params' => ['mode' => 'form', 'message' => 'Who are you?', 'requestedSchema' => $schema],
            ],
        ], requestState: $this->sign($request->all()));
    }

    return Response::text('Hello, '.$request->inputResponses()['who']['content']['name']);
}
```

The client fills it in and retries on its own:

```php
Mcp::client('everything')
    ->onElicitation(fn (array $params) => ['action' => 'accept', 'content' => ['name' => 'John']])
    ->callTool('say-hi');
```

The retry carries a new JSON-RPC id, the `inputResponses` map, and the exact `requestState` the server sent, or no `requestState` at all when the server sent none. Registering a handler is what declares the matching client capability in `_meta`, and the server refuses to ask for a capability the client did not declare, with `-32021`. `InputRequired` is only wired into `tools/call`, `prompts/get`, and `resources/read`.

> [!WARNING]
> BC break for anyone relying on server-initiated requests. A `2026-07-28` server must not send `elicitation/create`, `sampling/createMessage`, or `roots/list` as its own JSON-RPC request, so that path is gone. Use `InputRequired` instead.

`requestState` is deliberately an opaque string the package never inspects: signing or encrypting it is the server author's job, and the spec requires that of anything where tampering matters. The client stops after five input rounds for the same request rather than looping forever. Tests cover the round trip in both directions, the capability refusal, the state echo, and the round limit.

### Spec

- [2026-07-28 changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
- [Multi Round-Trip Requests](https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr)
- [SEP-2322](https://modelcontextprotocol.io/seps/2322-MRTR)

Credit to @JordanDalton, whose #275 mapped out the 2026-07-28 work.
