### PR TITLE
Advertise MCP Apps through the extensions capability

### DIFF
--- a/resources/boost/skills/mcp-development/references/app.md
+++ b/resources/boost/skills/mcp-development/references/app.md
@@ -104,7 +104,7 @@ MCP Apps add interactive UI to the Model Context Protocol. The server returns se
 └─────────────────────────────────────────────┘
 ```
 
-The server automatically advertises `io.modelcontextprotocol/ui` capability when any `AppResource` is registered. The client declares support in `capabilities.extensions["io.modelcontextprotocol/ui"]` during the initialize handshake.
+The server automatically advertises `capabilities.extensions["io.modelcontextprotocol/ui"]` on `server/discover` when any `AppResource` is registered. Call `addExtension()` on the server to declare any other extension. The client declares its own support in the `io.modelcontextprotocol/clientCapabilities` member of each request's `_meta`.
 
 ---
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -58,7 +58,9 @@ abstract class Server
 
     public const CAPABILITY_COMPLETIONS = 'completions';
 
-    public const CAPABILITY_UI = 'io.modelcontextprotocol/ui';
+    public const CAPABILITY_EXTENSIONS = 'extensions';
+
+    public const EXTENSION_UI = 'io.modelcontextprotocol/ui';
 
     public const CACHEABLE_METHODS = [
         'server/discover',
@@ -83,7 +85,7 @@ abstract class Server
     protected array $supportedProtocolVersion = [];
 
     /**
-     * @var array<string, array<string, bool>|stdClass|string>
+     * @var array<string, array<string, array<string, mixed>|bool|stdClass>|stdClass|string>
      */
     protected array $capabilities = [
         self::CAPABILITY_TOOLS => [
@@ -166,6 +168,24 @@ abstract class Server
 
         // Represent empty capability as an object when JSON encoded
         $this->capabilities[$key] = (object) [];
+    }
+
+    /**
+     * Advertise support for an MCP extension.
+     *
+     * @param  array<string, mixed>  $settings
+     */
+    public function addExtension(string $identifier, array $settings = []): void
+    {
+        $extensions = $this->capabilities[self::CAPABILITY_EXTENSIONS] ?? [];
+
+        if (! is_array($extensions)) {
+            $extensions = [];
+        }
+
+        $extensions[$identifier] = $settings === [] ? (object) [] : $settings;
+
+        $this->capabilities[self::CAPABILITY_EXTENSIONS] = $extensions;
     }
 
     /**
@@ -421,17 +441,24 @@ abstract class Server
 
     protected function detectUiCapability(): void
     {
-        if (array_key_exists(self::CAPABILITY_UI, $this->capabilities)) {
+        if ($this->hasExtension(self::EXTENSION_UI)) {
             return;
         }
 
         foreach ($this->resources as $resource) {
             if (is_subclass_of($resource, AppResource::class)) {
-                $this->addCapability(self::CAPABILITY_UI);
+                $this->addExtension(self::EXTENSION_UI);
 
                 return;
             }
         }
+    }
+
+    public function hasExtension(string $identifier): bool
+    {
+        $extensions = $this->capabilities[self::CAPABILITY_EXTENSIONS] ?? [];
+
+        return is_array($extensions) && array_key_exists($identifier, $extensions);
     }
 
     /**

--- a/tests/Unit/Methods/DiscoverAppTest.php
+++ b/tests/Unit/Methods/DiscoverAppTest.php
@@ -9,7 +9,7 @@ use Laravel\Mcp\Server\AppResource;
 use Laravel\Mcp\Server\Resource;
 use Tests\Fixtures\ArrayTransport;
 
-it('auto-detects ui capability when ui resources are registered', function (): void {
+it('advertises the ui extension when app resources are registered', function (): void {
     $server = new class(new ArrayTransport) extends Server
     {
         protected array $resources = [
@@ -21,10 +21,11 @@ it('auto-detects ui capability when ui resources are registered', function (): v
 
     $context = $server->createContext();
 
-    expect($context->serverCapabilities)->toHaveKey('io.modelcontextprotocol/ui');
+    expect($context->serverCapabilities['extensions'])->toHaveKey('io.modelcontextprotocol/ui');
+    expect($server->hasExtension('io.modelcontextprotocol/ui'))->toBeTrue();
 });
 
-it('does not include ui capability when only regular resources are registered', function (): void {
+it('advertises no extensions when only regular resources are registered', function (): void {
     $server = new class(new ArrayTransport) extends Server
     {
         protected array $resources = [
@@ -36,7 +37,20 @@ it('does not include ui capability when only regular resources are registered', 
 
     $context = $server->createContext();
 
-    expect($context->serverCapabilities)->not->toHaveKey('io.modelcontextprotocol/ui');
+    expect($context->serverCapabilities)->not->toHaveKey('extensions');
+    expect($server->hasExtension('io.modelcontextprotocol/ui'))->toBeFalse();
+});
+
+it('advertises an extension with its settings object', function (): void {
+    $server = new class(new ArrayTransport) extends Server {};
+
+    $server->addExtension('io.modelcontextprotocol/ui', ['mimeTypes' => ['text/html;profile=mcp-app']]);
+    $server->addExtension('com.example/other');
+
+    $extensions = $server->createContext()->serverCapabilities['extensions'];
+
+    expect($extensions['io.modelcontextprotocol/ui'])->toBe(['mimeTypes' => ['text/html;profile=mcp-app']]);
+    expect($extensions['com.example/other'])->toEqual((object) []);
 });
 
 class AutoDetectAppResource extends AppResource


### PR DESCRIPTION
`2026-07-28` adds an `extensions` field to server capabilities, and MCP Apps is an extension. The package was advertising it as if it were a core capability.

Before:

```json
{ "capabilities": { "tools": {}, "io.modelcontextprotocol/ui": {} } }
```

After:

```json
{ "capabilities": { "tools": {}, "extensions": { "io.modelcontextprotocol/ui": {} } } }
```

Registering an `AppResource` still advertises it for you. Declaring one by hand, with its settings object, now looks like this:

```php
$server->addExtension('io.modelcontextprotocol/ui', ['mimeTypes' => ['text/html;profile=mcp-app']]);
```

> [!WARNING]
> BC break for clients reading `capabilities['io.modelcontextprotocol/ui']`. It now lives at `capabilities['extensions']['io.modelcontextprotocol/ui']`. `Server::CAPABILITY_UI` is replaced by `Server::EXTENSION_UI`.

No generic extensions API beyond `addExtension()`/`hasExtension()`: extensions are opt-in per the spec, and one advertisement method is all the Apps case needs. The deeper Apps conformance audit is not here, because the Apps extension is versioned separately from this revision and its spec is not part of it. What this PR does add is conformance tests pinning the parts the extension docs do fix: the `ui://` URI, the `text/html;profile=mcp-app` MIME type, and the `_meta.ui` payload carrying CSP, permissions, and domain.

### Spec

- [2026-07-28 changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
- [Extensions: negotiation](https://modelcontextprotocol.io/docs/extensions/overview#negotiation)
- [MCP Apps](https://modelcontextprotocol.io/extensions/apps/overview)

Credit to @JordanDalton, whose #275 mapped out the 2026-07-28 work.
