### PR TITLE
Document the migration to MCP 2026-07-28

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,218 @@
+# Upgrade Guide
+
+## Upgrading To 1.x From 0.x
+
+Laravel MCP 1.x implements MCP revision [`2026-07-28`](https://modelcontextprotocol.io/specification/2026-07-28). Existing server registrations, server classes, tools, prompts, resources, authentication middleware, and fluent server tests do not require structural changes.
+
+### MCP Client Compatibility
+
+**Likelihood Of Impact: High**
+
+Laravel MCP servers now support only MCP `2026-07-28`. Before upgrading a server, verify that every client connecting to it supports this protocol revision. Older clients that rely on `initialize`, `notifications/initialized`, `ping`, protocol sessions, or server-initiated requests cannot communicate with a Laravel MCP 1.x server.
+
+The Laravel MCP client remains compatible with `2025-11-25` and `2025-06-18` servers. It opens every connection with the `initialize` handshake, as the specification requires, and falls back to `server/discover` only when the server's response shows that the handshake is not supported. Legacy servers therefore cost no extra requests. Recognized protocol errors trigger the fallback, while timeouts, unavailable endpoints, and disconnected transports are surfaced as errors.
+
+You may pin the protocol version when the server type is known:
+
+```php
+use Laravel\Mcp\Enums\ProtocolVersion;
+use Laravel\Mcp\Facades\Mcp;
+
+Mcp::client('everything')->withProtocolVersion(ProtocolVersion::LATEST)->tools();
+Mcp::client('everything')->withProtocolVersion(ProtocolVersion::V2025_11_25)->tools();
+```
+
+Pinning `ProtocolVersion::LATEST` skips the handshake and goes straight to discovery, saving a round trip against a known `2026-07-28` server. Pinning an older version is rarely necessary because `initialize` negotiates the version in a single round trip. The resolved version is retained when reconnecting, although discovery connections perform discovery again. The client's `ping()` method remains available for legacy servers; Laravel MCP 1.x servers return a method-not-found error.
+
+For discovery connections, `initializeResult()` returns `null`. Use `discoverResult()` for the server's discovery response and `protocolVersion()` for the resolved protocol version.
+
+The `Laravel\Mcp\Server\Methods\Initialize` and `Laravel\Mcp\Server\Methods\Ping` classes have been removed. Applications that import these classes or register them in a custom `$methods` array should remove those registrations. Use the automatically registered `Laravel\Mcp\Server\Methods\Discover` method for modern server discovery.
+
+### Session APIs Have Been Removed
+
+**Likelihood Of Impact: Medium**
+
+MCP `2026-07-28` removes protocol-level sessions. Laravel MCP no longer issues or reads the `MCP-Session-Id` header. If your application uses the following APIs, update it as indicated:
+
+| Previous API | Upgrade path |
+| ------------ | ------------ |
+| `Request::sessionId()` | Pass an explicit state handle as a tool or prompt argument. |
+| `Request::setSessionId()` | Remove the call. |
+| `Server::generateSessionId()` | Remove the call. |
+| `SessionInitialized` event | Move the work into the tool, prompt, or resource that requires it. |
+| `Laravel\Mcp\Server\Contracts\Transport::sessionId()` | Remove the method and any reliance on session state. |
+| `Laravel\Mcp\Server\Contracts\Transport::send(string $message, ?string $sessionId)` | Use `send(string $message)`. |
+| `JsonRpcRequest::from(array $json, ?string $sessionId)` | Use `JsonRpcRequest::from(array $json)`. |
+| `JsonRpcRequest::__construct(..., ?string $sessionId)` | Remove the session argument. |
+| `Request::__construct(array $arguments, ?string $sessionId)` | The second argument is now `?array $meta`. |
+| `Laravel\Mcp\Server\Transport\HttpTransport::__construct($request, $sessionId)` | Use `HttpTransport::__construct($request)`. |
+| `Laravel\Mcp\Server\Transport\StdioTransport::__construct($sessionId)` | Use `StdioTransport::__construct()`. |
+
+Applications may remain stateful, but state must be represented explicitly rather than inferred from a connection. Treat state handles as identifiers, not authorization credentials, and authorize them against the current user on every request.
+
+Custom server transports should remove their reliance on session state. An implementation that retains an optional `$sessionId` argument on `send()` remains compatible with the contract, but Laravel MCP no longer supplies a session ID.
+
+### Custom Client Transports
+
+**Likelihood Of Impact: Low**
+
+Custom implementations of `Laravel\Mcp\Client\Contracts\Transport` must update their `send` method:
+
+```php
+public function send(string $message, array $headers = []): void;
+```
+
+The additional `$headers` contain generated header names and encoded values, such as `Mcp-Param-*` headers. Forward them unchanged. Custom HTTP transports are also responsible for generating the protocol headers described below from the current protocol version and JSON-RPC message. The first-party HTTP and stdio transports handle these requirements automatically.
+
+### Direct HTTP and JSON-RPC Integrations
+
+**Likelihood Of Impact: Low**
+
+No changes are required when using Laravel MCP's first-party server routes and client transports. Applications that send raw HTTP or JSON-RPC requests must account for the new stateless lifecycle.
+
+Every supported JSON-RPC method call must include the protocol version and client capabilities in `params._meta`. Client identity is optional but recommended:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/list",
+  "params": {
+    "_meta": {
+      "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+      "io.modelcontextprotocol/clientCapabilities": {},
+      "io.modelcontextprotocol/clientInfo": {
+        "name": "Acme Client",
+        "version": "1.0.0"
+      }
+    }
+  }
+}
+```
+
+A missing metadata member returns `-32602`, an unsupported protocol version returns `-32022`, and an operation that requires an undeclared client capability returns `-32021`.
+
+Non-`initialize` HTTP requests carrying an `id` must include `MCP-Protocol-Version` and `Mcp-Method`. Calls to `tools/call`, `prompts/get`, and `resources/read` must also include `Mcp-Name`; use the requested URI for `resources/read`. The mirrored headers must agree with the JSON-RPC body. Unsafe `Mcp-Name` and `Mcp-Param-*` values are encoded using the `=?base64?...?=` format. Requests should accept both `application/json` and `text/event-stream` responses.
+
+Laravel MCP rejects missing or contradictory headers with HTTP `400` and JSON-RPC error `-32020`. Method-not-found errors return HTTP `404`, internal errors return `500`, and other protocol errors return `400`. HTTP `GET` and `DELETE` requests to modern MCP endpoints return `405`.
+
+Interrupted SSE responses are not resumable. Reissue the operation with a new JSON-RPC request ID instead of using `Last-Event-ID`.
+
+### Response Metadata and Caching
+
+**Likelihood Of Impact: Low**
+
+Laravel MCP automatically adds `resultType` and server identity metadata to successful responses. Initial complete results from `server/discover`, `tools/list`, `prompts/list`, `resources/list`, `resources/templates/list`, and `resources/read` also contain `ttlMs` and `cacheScope`:
+
+```json
+{ "resultType": "complete", "ttlMs": 0, "cacheScope": "private", "tools": [] }
+```
+
+The package client accepts these fields automatically. Update strict response schemas, proxies, caches, and raw response assertions to accept them. Legacy results without `resultType` should be treated as complete results.
+
+The default cache settings are `ttlMs: 0` and `cacheScope: private`. They may be configured on the server:
+
+```php
+use Laravel\Mcp\Enums\CacheScope;
+use Laravel\Mcp\Server;
+
+class WeatherServer extends Server
+{
+    protected int $cacheTtlMs = 300000;
+
+    protected CacheScope $cacheScope = CacheScope::PUBLIC;
+}
+```
+
+Only use `CacheScope::PUBLIC` when every cacheable response is independent of the authenticated user, access token, and authorization context. The Laravel MCP client accepts cache hints but does not cache responses based on them.
+
+The error returned when `resources/read` cannot resolve a resource URI has also changed from `-32002` to `-32602`.
+
+### MCP Apps
+
+**Likelihood Of Impact: Low**
+
+Servers that register an `AppResource` continue to advertise MCP Apps support automatically. No changes are required for normal app resources or tools using `#[RendersApp]`.
+
+If your server manually advertises MCP Apps support, replace `Server::CAPABILITY_UI` with `Server::EXTENSION_UI` and register it as an extension:
+
+```php
+protected function boot(): void
+{
+    $this->addExtension(self::EXTENSION_UI);
+}
+```
+
+The advertisement now appears under `capabilities.extensions['io.modelcontextprotocol/ui']` instead of the top-level capabilities object.
+
+MCP Apps are an optional extension. Tools that render an app should continue returning meaningful core MCP content for clients that do not advertise the UI extension.
+
+### Change Notifications
+
+**Likelihood Of Impact: Low**
+
+Laravel MCP now supports change-notification streams through `subscriptions/listen`. This is an additive feature; Laravel MCP 0.x did not provide built-in `resources/subscribe` or `resources/unsubscribe` methods.
+
+Advertise each notification kind your server publishes and implement the `subscriptions` method:
+
+```php
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Subscription;
+
+protected function boot(): void
+{
+    $this->addCapability('tools.listChanged');
+}
+
+protected function subscriptions(Subscription $subscription): iterable
+{
+    yield Response::notification('notifications/tools/list_changed');
+}
+```
+
+External clients must request each notification kind and reopen the subscription after disconnecting. Laravel MCP filters unrequested notifications and adds the subscription metadata automatically. The Laravel MCP client does not currently expose a subscription-listening API.
+
+### Tool Parameter Headers
+
+**Likelihood Of Impact: Low**
+
+Tools may now mirror existing schema arguments into HTTP headers. This is an additive feature:
+
+```php
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Server\Tool;
+
+class ExecuteSql extends Tool
+{
+    protected array $parameterHeaders = ['region' => 'Region'];
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'region' => $schema->string()->required(),
+        ];
+    }
+}
+```
+
+Do not mirror credentials, tokens, or personally identifiable information. Base64 header encoding is not encryption.
+
+Mirrored parameters must resolve to `string`, `integer`, or `boolean` schema properties. Integer values must remain within JavaScript's safe integer range. Laravel MCP rejects unsupported schemas when building the tool definition.
+
+When receiving remote tools, the Laravel MCP client omits tools with invalid `x-mcp-header` annotations and logs a warning instead of failing the entire tool list.
+
+### Authentication and Testing
+
+**Likelihood Of Impact: Low**
+
+Passport, Sanctum, route middleware, bearer tokens, authorization logic, and `Request::user()` continue to work without API changes. Because requests are stateless, authentication and authorization are evaluated independently for every request.
+
+The documented fluent helpers for testing tools, prompts, resources, and completions remain unchanged. Raw HTTP and JSON-RPC tests must include the new metadata and headers and should account for the new HTTP statuses and response fields described above.
+
+### Before Deploying
+
+- [ ] Verify every external client supports MCP `2026-07-28`.
+- [ ] Test web and local servers with the official [MCP Inspector](https://github.com/modelcontextprotocol/inspector).
+- [ ] Audit custom transports and raw protocol integrations for per-request metadata and HTTP headers.
+- [ ] Confirm state handles are authorized against the current user on every request.
+- [ ] Confirm public cache hints are not used for user-specific or authorization-specific responses.

--- a/src/Client.php
+++ b/src/Client.php
@@ -40,6 +40,9 @@ class Client
 
     protected ?ProtocolVersion $protocolVersion = null;
 
+    /** @var array<string, array<string, mixed>> */
+    protected array $toolSchemas = [];
+
     public function __construct(
         protected Transport $transport,
         public ?Implementation $clientInfo = null,
@@ -145,7 +148,13 @@ class Client
     public function tools(?int $limit = null, ?iterable $default = null): Collection
     {
         try {
-            return (new ListTools(client: $this, limit: $limit))->handle($this->protocol);
+            $tools = (new ListTools(client: $this, limit: $limit))->handle($this->protocol);
+
+            foreach ($tools as $tool) {
+                $this->toolSchemas[$tool->name] = $tool->inputSchema;
+            }
+
+            return $tools;
         } catch (AuthorizationRequiredException $authorizationRequiredException) {
             if ($default === null) {
                 throw $authorizationRequiredException;
@@ -157,10 +166,15 @@ class Client
 
     /**
      * @param  array<string, mixed>  $arguments
+     * @param  array<string, mixed>|null  $inputSchema
      */
-    public function callTool(string $name, array $arguments = []): ToolResult
+    public function callTool(string $name, array $arguments = [], ?array $inputSchema = null): ToolResult
     {
-        return (new CallTool($name, $arguments))->handle($this->protocol);
+        return (new CallTool(
+            $name,
+            $arguments,
+            $inputSchema ?? $this->toolSchemas[$name] ?? [],
+        ))->handle($this->protocol);
     }
 
     /**

--- a/src/Client/Contracts/MirrorsParameters.php
+++ b/src/Client/Contracts/MirrorsParameters.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\Contracts;
+
+interface MirrorsParameters
+{
+    /**
+     * @return array<string, string>
+     */
+    public function requestHeaders(): array;
+}

--- a/src/Client/Contracts/Transport.php
+++ b/src/Client/Contracts/Transport.php
@@ -10,7 +10,10 @@ interface Transport
 
     public function disconnect(): void;
 
-    public function send(string $message): void;
+    /**
+     * @param  array<string, string>  $headers
+     */
+    public function send(string $message, array $headers = []): void;
 
     public function receive(): string;
 

--- a/src/Client/Methods/Tools/CallTool.php
+++ b/src/Client/Methods/Tools/CallTool.php
@@ -5,22 +5,38 @@ declare(strict_types=1);
 namespace Laravel\Mcp\Client\Methods\Tools;
 
 use Laravel\Mcp\Client\Contracts\Method;
+use Laravel\Mcp\Client\Contracts\MirrorsParameters;
 use Laravel\Mcp\Client\Protocol;
 use Laravel\Mcp\Client\Schema\ToolResult;
+use Laravel\Mcp\Support\ToolHeaders;
 
 /**
  * @implements Method<ToolResult>
  */
-class CallTool implements Method
+class CallTool implements Method, MirrorsParameters
 {
     /**
      * @param  array<string, mixed>  $arguments
+     * @param  array<string, mixed>  $inputSchema
      */
     public function __construct(
         protected string $name,
         protected array $arguments = [],
+        protected array $inputSchema = [],
     ) {
         //
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function requestHeaders(): array
+    {
+        if ($this->inputSchema === [] || ToolHeaders::invalid($this->inputSchema) !== null) {
+            return [];
+        }
+
+        return ToolHeaders::extract($this->inputSchema, $this->arguments);
     }
 
     public function method(): string

--- a/src/Client/Methods/Tools/ListTools.php
+++ b/src/Client/Methods/Tools/ListTools.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Laravel\Mcp\Client\Methods\Tools;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
 use Laravel\Mcp\Client;
 use Laravel\Mcp\Client\Contracts\Method;
 use Laravel\Mcp\Client\Methods\Concerns\PaginatesList;
 use Laravel\Mcp\Client\Primitives\Tool;
+use Laravel\Mcp\Support\ToolHeaders;
 
 /**
  * @implements Method<Collection<string, Tool>>
@@ -42,10 +44,19 @@ class ListTools implements Method
      */
     protected function hydrate(array $payloads): Collection
     {
-        return collect($payloads)->mapWithKeys(function (array $payload): array {
-            $tool = Tool::from($this->client, $payload);
+        return collect($payloads)
+            ->map(fn (array $payload): Tool => Tool::from($this->client, $payload))
+            ->reject(function (Tool $tool): bool {
+                $reason = ToolHeaders::invalid($tool->inputSchema);
 
-            return [$tool->name => $tool];
-        });
+                if ($reason === null) {
+                    return false;
+                }
+
+                Log::warning("Excluded the MCP tool [{$tool->name}] from the tool list because {$reason}.");
+
+                return true;
+            })
+            ->mapWithKeys(fn (Tool $tool): array => [$tool->name => $tool]);
     }
 }

--- a/src/Client/Primitives/Tool.php
+++ b/src/Client/Primitives/Tool.php
@@ -74,6 +74,6 @@ class Tool
             throw new ClientException("Tool [{$this->name}] is not bound to a client.");
         }
 
-        return $this->client->callTool($this->name, $arguments);
+        return $this->client->callTool($this->name, $arguments, $this->inputSchema);
     }
 }

--- a/src/Client/Protocol.php
+++ b/src/Client/Protocol.php
@@ -7,6 +7,7 @@ namespace Laravel\Mcp\Client;
 use Illuminate\Support\Arr;
 use JsonException;
 use Laravel\Mcp\Client\Contracts\Method;
+use Laravel\Mcp\Client\Contracts\MirrorsParameters;
 use Laravel\Mcp\Client\Contracts\Transport;
 use Laravel\Mcp\Client\Exceptions\RequestRejectedException;
 use Laravel\Mcp\Client\Methods\Discover;
@@ -209,7 +210,10 @@ class Protocol
         );
 
         try {
-            $this->transport->send($request->toJson());
+            $this->transport->send(
+                $request->toJson(),
+                $method instanceof MirrorsParameters ? $method->requestHeaders() : [],
+            );
 
             do {
                 $raw = $this->transport->receive();

--- a/src/Client/Transport/HttpTransport.php
+++ b/src/Client/Transport/HttpTransport.php
@@ -99,7 +99,10 @@ class HttpTransport implements Transport
         ];
     }
 
-    public function send(string $message): void
+    /**
+     * @param  array<string, string>  $headers
+     */
+    public function send(string $message, array $headers = []): void
     {
         $body = json_decode($message, true);
         $body = is_array($body) ? $body : [];
@@ -107,7 +110,7 @@ class HttpTransport implements Transport
         $hadSession = $this->sessionId !== null;
 
         try {
-            $response = Http::withHeaders($this->headers($body))
+            $response = Http::withHeaders($this->headers($body, $headers))
                 ->withBody($message, 'application/json')
                 ->timeout($this->timeoutSeconds)
                 ->withOptions(['stream' => true])
@@ -203,9 +206,10 @@ class HttpTransport implements Transport
 
     /**
      * @param  array<string, mixed>  $body
+     * @param  array<string, string>  $mirrored
      * @return array<string, string>
      */
-    protected function headers(array $body = []): array
+    protected function headers(array $body = [], array $mirrored = []): array
     {
         $headers = [
             'Accept' => 'application/json, text/event-stream',
@@ -220,7 +224,7 @@ class HttpTransport implements Transport
         }
 
         if ($this->usesDiscovery()) {
-            $headers = array_merge($headers, $this->mirroredHeaders($body));
+            $headers = array_merge($headers, $this->mirroredHeaders($body), $mirrored);
         }
 
         $token = $this->token instanceof Closure ? (string) ($this->token)() : $this->token;

--- a/src/Client/Transport/StdioTransport.php
+++ b/src/Client/Transport/StdioTransport.php
@@ -83,7 +83,10 @@ class StdioTransport implements Transport
         ];
     }
 
-    public function send(string $message): void
+    /**
+     * @param  array<string, string>  $headers
+     */
+    public function send(string $message, array $headers = []): void
     {
         if (! $this->input instanceof InputStream || ! $this->process?->isRunning()) {
             throw new ClientException('Transport is not connected.');

--- a/tests/Fixtures/Client/FakeTransport.php
+++ b/tests/Fixtures/Client/FakeTransport.php
@@ -14,6 +14,9 @@ class FakeTransport implements Transport
     /** @var array<int, string> */
     public array $sent = [];
 
+    /** @var array<int, array<string, string>> */
+    public array $sentHeaders = [];
+
     /** @var array<int, string> */
     public array $responses = [];
 
@@ -33,9 +36,10 @@ class FakeTransport implements Transport
         $this->connected = false;
     }
 
-    public function send(string $message): void
+    public function send(string $message, array $headers = []): void
     {
         $this->sent[] = $message;
+        $this->sentHeaders[] = $headers;
     }
 
     public function setTimeoutSeconds(float $seconds): void

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -157,6 +157,19 @@ function methodNotFoundResponse(int $id = 1): string
     ]);
 }
 
+function toolCallResponse(int $id, string $text): string
+{
+    return (string) json_encode([
+        'jsonrpc' => '2.0',
+        'id' => $id,
+        'result' => [
+            'resultType' => 'complete',
+            'content' => [['type' => 'text', 'text' => $text]],
+            'isError' => false,
+        ],
+    ]);
+}
+
 function pingResponse(int $id): string
 {
     return json_encode([

--- a/tests/Unit/Client/ToolHeaderTest.php
+++ b/tests/Unit/Client/ToolHeaderTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Log;
+use Laravel\Mcp\Client;
+use Laravel\Mcp\Enums\ProtocolVersion;
+use Tests\Fixtures\Client\FakeTransport;
+
+function toolsListResponse(int $id, array $tools): string
+{
+    return (string) json_encode([
+        'jsonrpc' => '2.0',
+        'id' => $id,
+        'result' => ['resultType' => 'complete', 'tools' => $tools],
+    ]);
+}
+
+function annotatedTool(string $header = 'Region'): array
+{
+    return [
+        'name' => 'execute_sql',
+        'description' => 'Runs SQL',
+        'inputSchema' => [
+            'type' => 'object',
+            'properties' => [
+                'region' => ['type' => 'string', 'x-mcp-header' => $header],
+                'query' => ['type' => 'string'],
+            ],
+        ],
+    ];
+}
+
+it('mirrors annotated parameters into headers on a tool call', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = discoverResponse();
+    $transport->responses[] = toolsListResponse(2, [annotatedTool()]);
+    $transport->responses[] = toolCallResponse(3, 'done');
+
+    $client = (new Client($transport))->withProtocolVersion(ProtocolVersion::LATEST);
+    $client->tools();
+    $client->callTool('execute_sql', ['region' => 'us-west1', 'query' => 'select 1']);
+
+    expect($transport->sentHeaders[2])->toBe(['Mcp-Param-Region' => 'us-west1']);
+});
+
+it('sends no parameter headers for a tool it has not listed', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = discoverResponse();
+    $transport->responses[] = toolCallResponse(2, 'done');
+
+    (new Client($transport))->withProtocolVersion(ProtocolVersion::LATEST)->callTool('execute_sql', ['region' => 'us-west1']);
+
+    expect($transport->sentHeaders[1])->toBe([]);
+});
+
+it('excludes a tool whose annotation is invalid from the tool list', function (): void {
+    Log::spy();
+
+    $transport = new FakeTransport;
+    $transport->responses[] = discoverResponse();
+    $transport->responses[] = toolsListResponse(2, [
+        annotatedTool('Bad Header'),
+        ['name' => 'plain', 'description' => 'Fine', 'inputSchema' => ['type' => 'object']],
+    ]);
+
+    $tools = (new Client($transport))->withProtocolVersion(ProtocolVersion::LATEST)->tools();
+
+    expect($tools->keys()->all())->toBe(['plain']);
+
+    Log::shouldHaveReceived('warning')->once()->withArgs(
+        fn (string $message): bool => str_contains($message, 'execute_sql') && str_contains($message, 'not a valid header name token'),
+    );
+});
+
+it('mirrors parameters from the tool primitive without a listing round trip', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = discoverResponse();
+    $transport->responses[] = toolsListResponse(2, [annotatedTool()]);
+    $transport->responses[] = toolCallResponse(3, 'done');
+
+    $client = (new Client($transport))->withProtocolVersion(ProtocolVersion::LATEST);
+    $tool = $client->tools()->get('execute_sql');
+
+    (fn (): array => $this->toolSchemas = [])->call($client);
+
+    $tool->call(['region' => 'us-west1', 'query' => 'select 1']);
+
+    expect($transport->sentHeaders[2])->toBe(['Mcp-Param-Region' => 'us-west1']);
+});


### PR DESCRIPTION
Nine protocol changes land together with no single place that tells an upgrader what to do. This PR adds `UPGRADE.md`, with one section per breaking change and its replacement.

```php
// before
public function handle(Request $request): Response
{
    return Response::text($request->sessionId());
}

// after: no sessions, pass state as a tool argument
public function handle(Request $request): Response
{
    return Response::text($request->get('basket_id'));
}
```

It covers the removed handshake and `SessionInitialized`, required request `_meta`, `server/discover`, removed session APIs, mirrored HTTP headers and status codes, result types and caching hints, `InputRequired`, subscriptions, the Apps extension, mirrored tool parameters, client-era selection, client input handlers, and custom client transport changes.

The guide leaves two release checks unchecked: official Inspector coverage and Tier 1 client interoperability. Both require real external clients.

No code changes: this PR documents the breaking protocol migration.

### Spec

- [2026-07-28 changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
- [2026-07-28 specification](https://modelcontextprotocol.io/specification/2026-07-28)

Credit to @JordanDalton, whose #275 mapped out the 2026-07-28 work.