### PR TITLE
Prompt for route parameter values in mcp:inspector

### DIFF
--- a/src/Console/Commands/InspectorCommand.php
+++ b/src/Console/Commands/InspectorCommand.php
@@ -7,6 +7,7 @@ namespace Laravel\Mcp\Console\Commands;
 use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Routing\Route;
+use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\Arr;
 use Laravel\Mcp\Server\Registrar;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -94,7 +95,7 @@ class InspectorCommand extends Command
                 ]),
             ];
         } else {
-            $serverUrl = url($route->uri());
+            $serverUrl = $this->serverUrl($route);
             if (parse_url($serverUrl, PHP_URL_SCHEME) === 'https') {
                 $env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
             }
@@ -156,6 +157,17 @@ class InspectorCommand extends Command
             ['host', null, InputOption::VALUE_OPTIONAL, 'The host the inspector should bind to'],
             ['port', null, InputOption::VALUE_OPTIONAL, 'The port the inspector should bind to'],
         ];
+    }
+
+    protected function serverUrl(Route $route): string
+    {
+        $parameters = [];
+
+        foreach ($route->parameterNames() as $parameter) {
+            $parameters[$parameter] = $this->components->ask("What value should be used for the [{$parameter}] route parameter?");
+        }
+
+        return app(UrlGenerator::class)->toRoute($route, $parameters, true);
     }
 
     protected function phpBinary(): string

--- a/src/Console/Commands/InspectorCommand.php
+++ b/src/Console/Commands/InspectorCommand.php
@@ -172,7 +172,11 @@ class InspectorCommand extends Command
         $parameters = [];
 
         foreach ($route->parameterNames() as $parameter) {
-            $parameters[$parameter] = $this->components->ask("What is the value for the [{$parameter}] route parameter?");
+            $value = trim((string) $this->components->ask("What is the value for the [{$parameter}] route parameter?"));
+
+            if ($value !== '') {
+                $parameters[$parameter] = $value;
+            }
         }
 
         return $this->laravel->make(UrlGenerator::class)->toRoute($route, $parameters, true);

--- a/src/Console/Commands/InspectorCommand.php
+++ b/src/Console/Commands/InspectorCommand.php
@@ -6,6 +6,7 @@ namespace Laravel\Mcp\Console\Commands;
 
 use Exception;
 use Illuminate\Console\Command;
+use Illuminate\Routing\Exceptions\UrlGenerationException;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\Arr;
@@ -95,7 +96,14 @@ class InspectorCommand extends Command
                 ]),
             ];
         } else {
-            $serverUrl = $this->serverUrl($route);
+            try {
+                $serverUrl = $this->serverUrl($route);
+            } catch (UrlGenerationException) {
+                $this->components->error('Every route parameter needs a value to inspect this server');
+
+                return static::FAILURE;
+            }
+
             if (parse_url($serverUrl, PHP_URL_SCHEME) === 'https') {
                 $env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
             }
@@ -164,10 +172,10 @@ class InspectorCommand extends Command
         $parameters = [];
 
         foreach ($route->parameterNames() as $parameter) {
-            $parameters[$parameter] = $this->components->ask("What value should be used for the [{$parameter}] route parameter?");
+            $parameters[$parameter] = $this->components->ask("What is the value for the [{$parameter}] route parameter?");
         }
 
-        return app(UrlGenerator::class)->toRoute($route, $parameters, true);
+        return $this->laravel->make(UrlGenerator::class)->toRoute($route, $parameters, true);
     }
 
     protected function phpBinary(): string

--- a/tests/Unit/Console/Commands/McpInspectorCommandTest.php
+++ b/tests/Unit/Console/Commands/McpInspectorCommandTest.php
@@ -2,10 +2,12 @@
 
 declare(strict_types=1);
 
+use Illuminate\Console\View\Components\Factory;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\UrlGenerator;
 use Laravel\Mcp\Console\Commands\InspectorCommand;
 use Laravel\Mcp\Server\Registrar;
+use Tests\Fixtures\ExampleServer;
 
 beforeEach(function (): void {
     $this->registrar = Mockery::mock(Registrar::class);
@@ -241,4 +243,25 @@ it('retrieves php binary path correctly', function (): void {
     // Should return either a path to php or 'php'
     expect($phpBinary)->toBeString();
     expect(strlen((string) $phpBinary))->toBeGreaterThan(0);
+});
+
+it('asks for route parameter values when building the server url', function (): void {
+    $route = (new Registrar)->web('mcp/{organisation:uuid}', ExampleServer::class);
+
+    $components = Mockery::mock(Factory::class);
+    $components->shouldReceive('ask')
+        ->once()
+        ->with('What value should be used for the [organisation] route parameter?')
+        ->andReturn('4f8a1c2e');
+
+    $command = new InspectorCommand;
+    $command->setLaravel($this->app);
+
+    (function () use ($components): void {
+        $this->components = $components;
+    })->call($command);
+
+    $serverUrl = (fn (): string => $this->serverUrl($route))->call($command);
+
+    expect($serverUrl)->toBe('http://localhost/mcp/4f8a1c2e');
 });

--- a/tests/Unit/Console/Commands/McpInspectorCommandTest.php
+++ b/tests/Unit/Console/Commands/McpInspectorCommandTest.php
@@ -251,17 +251,36 @@ it('asks for route parameter values when building the server url', function (): 
     $components = Mockery::mock(Factory::class);
     $components->shouldReceive('ask')
         ->once()
-        ->with('What value should be used for the [organisation] route parameter?')
+        ->with('What is the value for the [organisation] route parameter?')
         ->andReturn('4f8a1c2e');
 
     $command = new InspectorCommand;
     $command->setLaravel($this->app);
 
-    (function () use ($components): void {
-        $this->components = $components;
-    })->call($command);
+    (new ReflectionProperty($command, 'components'))->setValue($command, $components);
 
-    $serverUrl = (fn (): string => $this->serverUrl($route))->call($command);
+    $serverUrl = (new ReflectionMethod($command, 'serverUrl'))->invoke($command, $route);
 
     expect($serverUrl)->toBe('http://localhost/mcp/4f8a1c2e');
+});
+
+it('fails when a route parameter is left blank', function (): void {
+    $route = (new Registrar)->web('mcp/{organisation:uuid}', ExampleServer::class);
+
+    $this->registrar
+        ->shouldReceive('getLocalServer')
+        ->with('demo')
+        ->andReturn(null);
+
+    $this->registrar
+        ->shouldReceive('getWebServer')
+        ->with('demo')
+        ->andReturn($route);
+
+    $this->registrar->shouldReceive('servers')->andReturn(['demo' => $route]);
+
+    $this->artisan('mcp:inspector', ['handle' => 'demo'])
+        ->expectsQuestion('What is the value for the [organisation] route parameter?', null)
+        ->expectsOutputToContain('Every route parameter needs a value to inspect this server')
+        ->assertExitCode(1);
 });

--- a/tests/Unit/Console/Commands/McpInspectorCommandTest.php
+++ b/tests/Unit/Console/Commands/McpInspectorCommandTest.php
@@ -284,3 +284,24 @@ it('fails when a route parameter is left blank', function (): void {
         ->expectsOutputToContain('Every route parameter needs a value to inspect this server')
         ->assertExitCode(1);
 });
+
+it('fails when a route parameter only contains whitespace', function (): void {
+    $route = (new Registrar)->web('mcp/{organisation:uuid}', ExampleServer::class);
+
+    $this->registrar
+        ->shouldReceive('getLocalServer')
+        ->with('demo')
+        ->andReturn(null);
+
+    $this->registrar
+        ->shouldReceive('getWebServer')
+        ->with('demo')
+        ->andReturn($route);
+
+    $this->registrar->shouldReceive('servers')->andReturn(['demo' => $route]);
+
+    $this->artisan('mcp:inspector', ['handle' => 'demo'])
+        ->expectsQuestion('What is the value for the [organisation] route parameter?', '   ')
+        ->expectsOutputToContain('Every route parameter needs a value to inspect this server')
+        ->assertExitCode(1);
+});


### PR DESCRIPTION
When an MCP server is registered on a route that has parameters, for example `Mcp::web('mcp/{organisation}', AkriviaServer::class)`, `mcp:inspector` builds the server URL with `url($route->uri())`. That leaves the placeholder in place, so the inspector is handed `http://localhost/mcp/{organisation}` and has nothing it can connect to.

The command now asks for a value for each route parameter and generates the URL from the route itself. Routes without parameters behave exactly as before.

Fixes #293