### PR TITLE
Add the server/discover method

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -20,13 +20,13 @@ use Laravel\Mcp\Server\Contracts\Method;
 use Laravel\Mcp\Server\Contracts\Transport;
 use Laravel\Mcp\Server\Methods\CallTool;
 use Laravel\Mcp\Server\Methods\CompletionComplete;
+use Laravel\Mcp\Server\Methods\Discover;
 use Laravel\Mcp\Server\Methods\GetPrompt;
 use Laravel\Mcp\Server\Methods\Initialize;
 use Laravel\Mcp\Server\Methods\ListPrompts;
 use Laravel\Mcp\Server\Methods\ListResources;
 use Laravel\Mcp\Server\Methods\ListResourceTemplates;
 use Laravel\Mcp\Server\Methods\ListTools;
-use Laravel\Mcp\Server\Methods\Ping;
 use Laravel\Mcp\Server\Methods\ReadResource;
 use Laravel\Mcp\Server\Prompt;
 use Laravel\Mcp\Server\Resource;
@@ -116,7 +116,7 @@ abstract class Server
         'prompts/list' => ListPrompts::class,
         'prompts/get' => GetPrompt::class,
         'completion/complete' => CompletionComplete::class,
-        'ping' => Ping::class,
+        'server/discover' => Discover::class,
     ];
 
     public function __construct(

--- a/src/Server/Methods/Discover.php
+++ b/src/Server/Methods/Discover.php
@@ -9,10 +9,14 @@ use Laravel\Mcp\Server\ServerContext;
 use Laravel\Mcp\Transport\JsonRpcRequest;
 use Laravel\Mcp\Transport\JsonRpcResponse;
 
-class Ping implements Method
+class Discover implements Method
 {
     public function handle(JsonRpcRequest $request, ServerContext $context): JsonRpcResponse
     {
-        return JsonRpcResponse::result($request->id, []);
+        return JsonRpcResponse::result($request->id, [
+            'supportedVersions' => $context->supportedProtocolVersions,
+            'capabilities' => $context->serverCapabilities ?: (object) [],
+            'instructions' => $context->instructions,
+        ]);
     }
 }

--- a/tests/Feature/Console/StartCommandTest.php
+++ b/tests/Feature/Console/StartCommandTest.php
@@ -82,20 +82,6 @@ it('can call a tool over http', function (): void {
     expect($response->json())->toEqual(expectedCallToolResponse());
 });
 
-it('can handle a ping over http', function (): void {
-    $sessionId = initializeHttpConnection($this);
-
-    $response = $this->postJson(
-        'test-mcp',
-        pingMessage(),
-        ['MCP-Session-Id' => $sessionId],
-    );
-
-    $response->assertStatus(200);
-
-    expect($response->json())->toEqual(expectedPingResponse());
-});
-
 it('can stream a tool response over http', function (): void {
     $sessionId = initializeHttpConnection($this);
 
@@ -126,6 +112,17 @@ it('can initialize a connection over stdio', function (): void {
     expect(true)->toBeTrue();
 });
 
+it('can discover a server over stdio', function (): void {
+    $process = remote(['mcp:start', 'test-mcp']);
+    $process->setInput(json_encode(discoverMessage()));
+
+    $process->run(function (string $type, string $output): void {
+        expect($type)->toEqual(Process::OUT);
+        expect(json_decode($output, true))->toEqual(expectedDiscoverResponse());
+    });
+    expect(true)->toBeTrue();
+});
+
 it('can list tools over stdio', function (): void {
     $process = remote(['mcp:start', 'test-mcp']);
     $process->setInput(json_encode(listToolsMessage()));
@@ -146,17 +143,6 @@ it('can call a tool over stdio', function (): void {
     $output = json_decode($process->getOutput(), true);
 
     expect($output)->toEqual(expectedCallToolResponse());
-});
-
-it('can handle a ping over stdio', function (): void {
-    $process = remote(['mcp:start', 'test-mcp']);
-    $process->setInput(json_encode(pingMessage()));
-
-    $process->run();
-
-    $output = json_decode($process->getOutput(), true);
-
-    expect($output)->toEqual(expectedPingResponse());
 });
 
 it('can stream a tool response over stdio', function (): void {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Filesystem\Filesystem;
+use Laravel\Mcp\Enums\ProtocolVersion;
 use Tests\Fixtures\ArrayTransport;
 use Tests\Fixtures\ExampleServer;
 use Tests\TestCase;
@@ -49,6 +50,35 @@ function initializeMessage(): array
         'id' => 456,
         'method' => 'initialize',
         'params' => [],
+    ];
+}
+
+function discoverMessage(): array
+{
+    return [
+        'jsonrpc' => '2.0',
+        'id' => 456,
+        'method' => 'server/discover',
+    ];
+}
+
+function expectedDiscoverResponse(): array
+{
+    $server = new ExampleServer(new ArrayTransport);
+
+    [$capabilities, $instructions] = (fn (): array => [
+        $this->capabilities,
+        $this->instructions,
+    ])->call($server);
+
+    return [
+        'jsonrpc' => '2.0',
+        'id' => 456,
+        'result' => [
+            'supportedVersions' => ProtocolVersion::supported(),
+            'capabilities' => $capabilities,
+            'instructions' => $instructions,
+        ],
     ];
 }
 
@@ -262,24 +292,6 @@ function expectedCallToolResponse(): array
             ]],
             'isError' => false,
         ],
-    ];
-}
-
-function pingMessage(): array
-{
-    return [
-        'jsonrpc' => '2.0',
-        'id' => 789,
-        'method' => 'ping',
-    ];
-}
-
-function expectedPingResponse(): array
-{
-    return [
-        'jsonrpc' => '2.0',
-        'id' => 789,
-        'result' => [],
     ];
 }
 

--- a/tests/Unit/ServerTest.php
+++ b/tests/Unit/ServerTest.php
@@ -28,6 +28,21 @@ it('can handle an initialize message', function (): void {
     expect($response)->toEqual(expectedInitializeResponse());
 });
 
+it('can handle a discover message', function (): void {
+    $transport = new ArrayTransport;
+    $server = new ExampleServer($transport);
+
+    $server->start();
+
+    $payload = json_encode(discoverMessage());
+
+    ($transport->handler)($payload);
+
+    $response = json_decode((string) $transport->sent[0], true);
+
+    expect($response)->toEqual(expectedDiscoverResponse());
+});
+
 it('can add a capability', function (): void {
     $transport = new ArrayTransport;
     $server = new ExampleServer($transport);
@@ -213,19 +228,38 @@ it('can handle a custom method message', function (): void {
     ]);
 });
 
-it('can handle a ping message', function (): void {
+it('no longer answers a ping message', function (): void {
     $transport = new ArrayTransport;
     $server = new ExampleServer($transport);
 
     $server->start();
 
-    $payload = json_encode(pingMessage());
+    $payload = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 789,
+        'method' => 'ping',
+    ]);
 
     ($transport->handler)($payload);
 
     $response = json_decode((string) $transport->sent[0], true);
 
-    expect($response)->toEqual(expectedPingResponse());
+    expect($response['error']['code'])->toBe(-32601);
+});
+
+it('discovers an empty capability set as a json object', function (): void {
+    $transport = new ArrayTransport;
+    $server = new ExampleServer($transport);
+
+    (function (): void {
+        $this->capabilities = [];
+    })->call($server);
+
+    $server->start();
+
+    ($transport->handler)(json_encode(discoverMessage()));
+
+    expect((string) $transport->sent[0])->toContain('"capabilities":{}');
 });
 
 it('calls boot method on connect', function (): void {


### PR DESCRIPTION
MCP `2026-07-28` replaces the `initialize` handshake with a single stateless `server/discover` call, and drops `ping`.

Before:

```json
{ "method": "ping" }
```

After:

```json
{ "method": "server/discover" }
```

The response carries the supported versions, the server capabilities, and the instructions:

```json
{
  "supportedVersions": ["2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05"],
  "capabilities": { "tools": { "listChanged": true } },
  "instructions": "..."
}
```

> [!WARNING]
> BC break for clients that send `ping`. The `2026-07-28` revision removes it, so tracking the revision requires the change.

`initialize` still answers on this branch. Removing it, bumping the protocol version, and requiring per-request metadata come in the next three PRs. Tests cover discover over stdio, the rejected ping, and an empty capability set serializing as `{}`.

### Spec

- [2026-07-28 changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
- [`server/discover`](https://modelcontextprotocol.io/specification/2026-07-28/server/discover)

Credit to @JordanDalton, whose #275 mapped out the 2026-07-28 work.
