### PR TITLE
Require the protocol metadata on every request

### DIFF
--- a/src/Enums/MetaKey.php
+++ b/src/Enums/MetaKey.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Enums;
+
+enum MetaKey: string
+{
+    case PROTOCOL_VERSION = 'io.modelcontextprotocol/protocolVersion';
+    case CLIENT_CAPABILITIES = 'io.modelcontextprotocol/clientCapabilities';
+}

--- a/src/Server.php
+++ b/src/Server.php
@@ -6,6 +6,7 @@ namespace Laravel\Mcp;
 
 use Illuminate\Container\Container;
 use Laravel\Mcp\Enums\ErrorCode;
+use Laravel\Mcp\Enums\MetaKey;
 use Laravel\Mcp\Enums\ProtocolVersion;
 use Laravel\Mcp\Exceptions\JsonRpcException;
 use Laravel\Mcp\Schema\Icon;
@@ -203,6 +204,8 @@ abstract class Server
                 );
             }
 
+            $this->validateProtocolMeta($request, $context);
+
             if (! isset($this->methods[$request->method])) {
                 throw new JsonRpcException(
                     "The method [{$request->method}] was not found.",
@@ -262,6 +265,43 @@ abstract class Server
     protected function icons(): array
     {
         return [];
+    }
+
+    /**
+     * @throws JsonRpcException
+     */
+    protected function validateProtocolMeta(JsonRpcRequest $request, ServerContext $context): void
+    {
+        $meta = $request->meta() ?? [];
+
+        $expected = [
+            MetaKey::PROTOCOL_VERSION->value => 'is_string',
+            MetaKey::CLIENT_CAPABILITIES->value => fn (mixed $value): bool => is_array($value) && ($value === [] || ! array_is_list($value)),
+        ];
+
+        foreach ($expected as $metaKey => $isValid) {
+            if (! array_key_exists($metaKey, $meta) || ! $isValid($meta[$metaKey])) {
+                throw new JsonRpcException(
+                    "Invalid params: The request [_meta] is missing the required [{$metaKey}] member.",
+                    ErrorCode::INVALID_PARAMS->value,
+                    $request->id,
+                );
+            }
+        }
+
+        $requestedVersion = $meta[MetaKey::PROTOCOL_VERSION->value];
+
+        if (! in_array($requestedVersion, $context->supportedProtocolVersions, true)) {
+            throw new JsonRpcException(
+                'Unsupported protocol version',
+                ErrorCode::UNSUPPORTED_PROTOCOL_VERSION->value,
+                $request->id,
+                [
+                    'supported' => $context->supportedProtocolVersions,
+                    'requested' => $requestedVersion,
+                ],
+            );
+        }
     }
 
     /**

--- a/src/Transport/JsonRpcRequest.php
+++ b/src/Transport/JsonRpcRequest.php
@@ -74,7 +74,7 @@ class JsonRpcRequest
      */
     public function meta(): ?array
     {
-        return isset($this->params['_meta']) && is_array($this->params['_meta']) ? $this->params['_meta'] : null;
+        return isset($this->params['_meta']) && self::isObject($this->params['_meta']) ? $this->params['_meta'] : null;
     }
 
     public function toRequest(): Request

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -43,6 +43,14 @@ expect()->extend('toBeOne', fn () => $this->toBe(1));
 |
 */
 
+function protocolMeta(): array
+{
+    return [
+        'io.modelcontextprotocol/protocolVersion' => '2026-07-28',
+        'io.modelcontextprotocol/clientCapabilities' => [],
+    ];
+}
+
 function initializeMessage(): array
 {
     return [
@@ -59,6 +67,9 @@ function discoverMessage(): array
         'jsonrpc' => '2.0',
         'id' => 456,
         'method' => 'server/discover',
+        'params' => [
+            '_meta' => protocolMeta(),
+        ],
     ];
 }
 
@@ -125,6 +136,9 @@ function listToolsMessage(): array
         'jsonrpc' => '2.0',
         'id' => 1,
         'method' => 'tools/list',
+        'params' => [
+            '_meta' => protocolMeta(),
+        ],
     ];
 }
 
@@ -178,6 +192,9 @@ function listResourcesMessage(): array
         'jsonrpc' => '2.0',
         'id' => 1,
         'method' => 'resources/list',
+        'params' => [
+            '_meta' => protocolMeta(),
+        ],
     ];
 }
 
@@ -225,6 +242,7 @@ function callToolMessage(): array
             'arguments' => [
                 'name' => 'John Doe',
             ],
+            '_meta' => protocolMeta(),
         ],
     ];
 }
@@ -237,6 +255,7 @@ function readResourceMessage(): array
         'method' => 'resources/read',
         'params' => [
             'uri' => 'file://resources/last-log-line-resource',
+            '_meta' => protocolMeta(),
         ],
     ];
 }
@@ -282,6 +301,7 @@ function callStreamingToolMessage(int $count = 2): array
             'arguments' => [
                 'count' => $count,
             ],
+            '_meta' => protocolMeta(),
         ],
     ];
 }

--- a/tests/Unit/ServerTest.php
+++ b/tests/Unit/ServerTest.php
@@ -43,6 +43,102 @@ it('can handle a discover message', function (): void {
     expect($response)->toEqual(expectedDiscoverResponse());
 });
 
+it('rejects a request without the required protocol metadata', function (array $meta, string $message): void {
+    $transport = new ArrayTransport;
+    $server = new ExampleServer($transport);
+
+    $server->start();
+
+    $payload = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/list',
+        'params' => ['_meta' => $meta],
+    ]);
+
+    ($transport->handler)($payload);
+
+    expect(json_decode((string) $transport->sent[0], true))->toEqual([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'error' => [
+            'code' => -32602,
+            'message' => $message,
+        ],
+    ]);
+})->with([
+    'missing version' => [
+        ['io.modelcontextprotocol/clientCapabilities' => []],
+        'Invalid params: The request [_meta] is missing the required [io.modelcontextprotocol/protocolVersion] member.',
+    ],
+    'missing capabilities' => [
+        ['io.modelcontextprotocol/protocolVersion' => '2026-07-28'],
+        'Invalid params: The request [_meta] is missing the required [io.modelcontextprotocol/clientCapabilities] member.',
+    ],
+    'null version' => [
+        [
+            'io.modelcontextprotocol/protocolVersion' => null,
+            'io.modelcontextprotocol/clientCapabilities' => [],
+        ],
+        'Invalid params: The request [_meta] is missing the required [io.modelcontextprotocol/protocolVersion] member.',
+    ],
+    'non-string version' => [
+        [
+            'io.modelcontextprotocol/protocolVersion' => 123,
+            'io.modelcontextprotocol/clientCapabilities' => [],
+        ],
+        'Invalid params: The request [_meta] is missing the required [io.modelcontextprotocol/protocolVersion] member.',
+    ],
+    'non-array capabilities' => [
+        [
+            'io.modelcontextprotocol/protocolVersion' => '2026-07-28',
+            'io.modelcontextprotocol/clientCapabilities' => 'nope',
+        ],
+        'Invalid params: The request [_meta] is missing the required [io.modelcontextprotocol/clientCapabilities] member.',
+    ],
+    'list capabilities' => [
+        [
+            'io.modelcontextprotocol/protocolVersion' => '2026-07-28',
+            'io.modelcontextprotocol/clientCapabilities' => ['elicitation'],
+        ],
+        'Invalid params: The request [_meta] is missing the required [io.modelcontextprotocol/clientCapabilities] member.',
+    ],
+]);
+
+it('rejects an unsupported protocol version', function (): void {
+    $transport = new ArrayTransport;
+    $server = new ExampleServer($transport);
+
+    $server->start();
+
+    $payload = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/list',
+        'params' => [
+            '_meta' => [
+                'io.modelcontextprotocol/protocolVersion' => '2025-11-25',
+                'io.modelcontextprotocol/clientCapabilities' => [],
+            ],
+        ],
+    ]);
+
+    ($transport->handler)($payload);
+
+    expect(json_decode((string) $transport->sent[0], true))->toEqual([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'error' => [
+            'code' => -32022,
+            'message' => 'Unsupported protocol version',
+            'data' => [
+                'supported' => ['2026-07-28'],
+                'requested' => '2025-11-25',
+            ],
+        ],
+    ]);
+});
+
 it('can add a capability', function (): void {
     $transport = new ArrayTransport;
     $server = new ExampleServer($transport);
@@ -126,7 +222,7 @@ it('can handle an unknown method', function (): void {
         'jsonrpc' => '2.0',
         'id' => 789,
         'method' => 'unknown/method',
-        'params' => [],
+        'params' => ['_meta' => protocolMeta()],
     ]);
 
     ($transport->handler)($payload);
@@ -171,6 +267,10 @@ it('returns protocol errors for invalid parameter shapes', function (mixed $para
     'tool arguments' => [[
         'name' => 'say-hi-tool',
         'arguments' => 'invalid',
+        '_meta' => [
+            'io.modelcontextprotocol/protocolVersion' => '2026-07-28',
+            'io.modelcontextprotocol/clientCapabilities' => [],
+        ],
     ], 'Invalid params: The [arguments] member must be an object.'],
 ]);
 
@@ -211,7 +311,7 @@ it('can handle a custom method message', function (): void {
         'jsonrpc' => '2.0',
         'id' => 12345,
         'method' => 'custom/method',
-        'params' => [],
+        'params' => ['_meta' => protocolMeta()],
     ]);
 
     ($transport->handler)($payload);
@@ -238,6 +338,7 @@ it('no longer answers a ping message', function (): void {
         'jsonrpc' => '2.0',
         'id' => 789,
         'method' => 'ping',
+        'params' => ['_meta' => protocolMeta()],
     ]);
 
     ($transport->handler)($payload);
@@ -257,7 +358,14 @@ it('lets a dual-era server serve initialize through addMethod', function (): voi
 
     $server->start();
 
-    ($transport->handler)(json_encode(initializeMessage()));
+    $payload = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 456,
+        'method' => 'initialize',
+        'params' => ['_meta' => protocolMeta()],
+    ]);
+
+    ($transport->handler)($payload);
 
     $response = json_decode((string) $transport->sent[0], true);
 
@@ -356,7 +464,7 @@ it('handles exceptions in debug mode', function (): void {
         'jsonrpc' => '2.0',
         'id' => 999,
         'method' => 'test/method',
-        'params' => [],
+        'params' => ['_meta' => protocolMeta()],
     ]);
 
     expect(function () use ($transport, $payload): void {
@@ -389,7 +497,7 @@ it('handles exceptions in production mode', function (): void {
         'jsonrpc' => '2.0',
         'id' => 999,
         'method' => 'test/method',
-        'params' => [],
+        'params' => ['_meta' => protocolMeta()],
     ]);
 
     ($transport->handler)($payload);


### PR DESCRIPTION
With no handshake, every request carries its own protocol version and client capabilities in `_meta`.

Before:

```json
{ "method": "tools/list" }
```

After:

```json
{
  "method": "tools/list",
  "params": {
    "_meta": {
      "io.modelcontextprotocol/protocolVersion": "2026-07-28",
      "io.modelcontextprotocol/clientCapabilities": {}
    }
  }
}
```

Missing or malformed members return `-32602`. An unknown version returns `-32022` with the supported list:

```json
{ "code": -32022, "message": "Unsupported protocol version", "data": { "supported": ["2026-07-28"], "requested": "2025-11-25" } }
```

> [!WARNING]
> BC break. Every request now needs both `_meta` members. The `2026-07-28` revision requires them, so tracking the revision requires the change.

`clientInfo` stays optional because the spec marks it SHOULD, not required. `Mcp-Method` and the other mirrored header validation come in #286. The `resultType` and server info on results are the next PR.

Tests cover missing, null, non-string, and list-shaped members, plus the unsupported version.

### Spec

- [2026-07-28 changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
- [Base protocol: `_meta`](https://modelcontextprotocol.io/specification/2026-07-28/basic/index#meta)

Credit to @JordanDalton, whose #275 mapped out the 2026-07-28 work.
