### PR TITLE
Add caching hints to every cacheable result

### DIFF
--- a/src/Enums/CacheScope.php
+++ b/src/Enums/CacheScope.php
@@ -6,6 +6,6 @@ namespace Laravel\Mcp\Enums;
 
 enum CacheScope: string
 {
-    case PUBLIC = 'public';
-    case PRIVATE = 'private';
+    case Public = 'public';
+    case Private = 'private';
 }

--- a/src/Enums/CacheScope.php
+++ b/src/Enums/CacheScope.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Enums;
+
+enum CacheScope: string
+{
+    case PUBLIC = 'public';
+    case PRIVATE = 'private';
+}

--- a/src/Server.php
+++ b/src/Server.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laravel\Mcp;
 
 use Illuminate\Container\Container;
+use InvalidArgumentException;
 use Laravel\Mcp\Enums\ErrorCode;
 use Laravel\Mcp\Enums\MetaKey;
 use Laravel\Mcp\Enums\ProtocolVersion;
@@ -12,6 +13,7 @@ use Laravel\Mcp\Exceptions\JsonRpcException;
 use Laravel\Mcp\Schema\Icon;
 use Laravel\Mcp\Schema\Implementation;
 use Laravel\Mcp\Server\AppResource;
+use Laravel\Mcp\Server\Attributes\Cacheable;
 use Laravel\Mcp\Server\Attributes\Instructions;
 use Laravel\Mcp\Server\Attributes\Name;
 use Laravel\Mcp\Server\Attributes\Version;
@@ -20,6 +22,7 @@ use Laravel\Mcp\Server\Contracts\Method;
 use Laravel\Mcp\Server\Contracts\Transport;
 use Laravel\Mcp\Server\Methods\CallTool;
 use Laravel\Mcp\Server\Methods\CompletionComplete;
+use Laravel\Mcp\Server\Methods\Concerns\ResolvesResources;
 use Laravel\Mcp\Server\Methods\Discover;
 use Laravel\Mcp\Server\Methods\GetPrompt;
 use Laravel\Mcp\Server\Methods\ListPrompts;
@@ -45,6 +48,7 @@ use Throwable;
 abstract class Server
 {
     use HasIcons;
+    use ResolvesResources;
 
     public const CAPABILITY_TOOLS = 'tools';
 
@@ -55,6 +59,15 @@ abstract class Server
     public const CAPABILITY_COMPLETIONS = 'completions';
 
     public const CAPABILITY_UI = 'io.modelcontextprotocol/ui';
+
+    public const CACHEABLE_METHODS = [
+        'server/discover',
+        'tools/list',
+        'prompts/list',
+        'resources/list',
+        'resources/templates/list',
+        'resources/read',
+    ];
 
     protected string $name = 'Laravel MCP Server';
 
@@ -310,28 +323,74 @@ abstract class Server
         $response = $this->runMethodHandle($request, $context);
 
         if (! is_iterable($response)) {
-            $this->send($response, $context);
+            $this->send($response, $context, $request);
 
             return;
         }
 
-        $this->transport->stream(function () use ($response, $context): void {
+        $this->transport->stream(function () use ($request, $response, $context): void {
             foreach ($response as $message) {
-                $this->send($message, $context);
+                $this->send($message, $context, $request);
             }
         });
     }
 
-    protected function send(JsonRpcResponse $response, ServerContext $context): void
+    protected function send(JsonRpcResponse $response, ServerContext $context, ?JsonRpcRequest $request = null): void
     {
-        if (array_key_exists('result', $response->content)) {
+        if ($request instanceof JsonRpcRequest && array_key_exists('result', $response->content)) {
             $result = (array) $response->content['result'];
             $result['_meta'][MetaKey::SERVER_INFO->value] = $context->implementation->toArray();
 
-            $response->content['result'] = ['resultType' => 'complete', ...$result];
+            $response->content['result'] = [
+                'resultType' => 'complete',
+                ...$this->resolveCacheHints($request, $context),
+                ...$result,
+            ];
         }
 
         $this->transport->send($response->toJson());
+    }
+
+    /**
+     * @return array<string, Cacheable>
+     */
+    protected function cacheHints(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<string, int|string>
+     */
+    protected function resolveCacheHints(JsonRpcRequest $request, ServerContext $context): array
+    {
+        if (! in_array($request->method, self::CACHEABLE_METHODS, true)) {
+            return [];
+        }
+
+        if (isset($request->params['inputResponses']) || isset($request->params['requestState'])) {
+            return [];
+        }
+
+        $cacheable = $this->resourceCacheable($request, $context)
+            ?? $this->cacheHints()[$request->method]
+            ?? $this->resolveAttribute(Cacheable::class)
+            ?? new Cacheable;
+
+        return $cacheable->toArray();
+    }
+
+    protected function resourceCacheable(JsonRpcRequest $request, ServerContext $context): ?Cacheable
+    {
+        if ($request->method !== 'resources/read') {
+            return null;
+        }
+
+        try {
+            return $this->resolveResource($request->get('uri'), $context)->cacheable();
+        } catch (InvalidArgumentException) {
+            return null;
+        }
     }
 
     /**

--- a/src/Server/Attributes/Cacheable.php
+++ b/src/Server/Attributes/Cacheable.php
@@ -12,7 +12,7 @@ class Cacheable
 {
     public function __construct(
         public int $ttlMs = 0,
-        public CacheScope $scope = CacheScope::PRIVATE,
+        public CacheScope $scope = CacheScope::Private,
     ) {
         //
     }

--- a/src/Server/Attributes/Cacheable.php
+++ b/src/Server/Attributes/Cacheable.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Server\Attributes;
+
+use Attribute;
+use Laravel\Mcp\Enums\CacheScope;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Cacheable
+{
+    public function __construct(
+        public int $ttlMs = 0,
+        public CacheScope $scope = CacheScope::PRIVATE,
+    ) {
+        //
+    }
+
+    /**
+     * @return array{ttlMs: int, cacheScope: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'ttlMs' => max(0, $this->ttlMs),
+            'cacheScope' => $this->scope->value,
+        ];
+    }
+}

--- a/src/Server/Resource.php
+++ b/src/Server/Resource.php
@@ -6,6 +6,7 @@ namespace Laravel\Mcp\Server;
 
 use Illuminate\Support\Str;
 use Laravel\Mcp\Server\Annotations\Annotation;
+use Laravel\Mcp\Server\Attributes\Cacheable;
 use Laravel\Mcp\Server\Attributes\MimeType;
 use Laravel\Mcp\Server\Attributes\Uri;
 use Laravel\Mcp\Server\Concerns\HasAnnotations;
@@ -32,6 +33,11 @@ abstract class Resource extends Primitive
         return $attribute !== null
             ? $attribute->value
             : ($this->uri !== '' ? $this->uri : $this->defaultUriScheme.'://resources/'.Str::kebab(class_basename($this)));
+    }
+
+    public function cacheable(): ?Cacheable
+    {
+        return $this->resolveAttribute(Cacheable::class);
     }
 
     public function mimeType(): string

--- a/tests/Feature/Server/CachingTest.php
+++ b/tests/Feature/Server/CachingTest.php
@@ -69,14 +69,14 @@ it('leaves caching hints off a request retried with input responses', function (
 ]);
 
 it('uses the hint the server attribute declares', function (): void {
-    $result = resultFor(listToolsMessage(), fn (ArrayTransport $transport): Server => new #[Cacheable(ttlMs: 300000, scope: CacheScope::PUBLIC)] class($transport) extends ExampleServer {})['result'];
+    $result = resultFor(listToolsMessage(), fn (ArrayTransport $transport): Server => new #[Cacheable(ttlMs: 300000, scope: CacheScope::Public)] class($transport) extends ExampleServer {})['result'];
 
     expect($result['ttlMs'])->toBe(300000);
     expect($result['cacheScope'])->toBe('public');
 });
 
 it('prefers the per method hint over the server attribute', function (): void {
-    $server = fn (ArrayTransport $transport): Server => new #[Cacheable(ttlMs: 300000, scope: CacheScope::PUBLIC)] class($transport) extends ExampleServer
+    $server = fn (ArrayTransport $transport): Server => new #[Cacheable(ttlMs: 300000, scope: CacheScope::Public)] class($transport) extends ExampleServer
     {
         protected function cacheHints(): array
         {

--- a/tests/Feature/Server/CachingTest.php
+++ b/tests/Feature/Server/CachingTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Mcp\Enums\CacheScope;
+use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Attributes\Cacheable;
+use Tests\Fixtures\ArrayTransport;
+use Tests\Fixtures\CacheableResource;
+use Tests\Fixtures\ExampleServer;
+
+function resultFor(array $message, ?Closure $factory = null): array
+{
+    $transport = new ArrayTransport;
+    $server = $factory instanceof Closure ? $factory($transport) : new ExampleServer($transport);
+
+    $server->start();
+
+    ($transport->handler)((string) json_encode($message));
+
+    return json_decode((string) $transport->sent[0], true);
+}
+
+it('adds caching hints to every cacheable result', function (string $method, array $params): array {
+    $result = resultFor([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => $method,
+        'params' => ['_meta' => protocolMeta(), ...$params],
+    ])['result'];
+
+    expect($result['ttlMs'])->toBe(0);
+    expect($result['cacheScope'])->toBe('private');
+
+    return $result;
+})->with([
+    'server/discover' => ['server/discover', []],
+    'tools/list' => ['tools/list', []],
+    'prompts/list' => ['prompts/list', []],
+    'resources/list' => ['resources/list', []],
+    'resources/templates/list' => ['resources/templates/list', []],
+    'resources/read' => ['resources/read', ['uri' => 'file://resources/last-log-line-resource']],
+]);
+
+it('leaves caching hints off a result that is not cacheable', function (): void {
+    $result = resultFor(callToolMessage())['result'];
+
+    expect($result)->not->toHaveKey('ttlMs');
+    expect($result)->not->toHaveKey('cacheScope');
+});
+
+it('leaves caching hints off a request retried with input responses', function (array $params): void {
+    $result = resultFor([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'resources/read',
+        'params' => [
+            '_meta' => protocolMeta(),
+            'uri' => 'file://resources/last-log-line-resource',
+            ...$params,
+        ],
+    ])['result'];
+
+    expect($result)->not->toHaveKey('ttlMs');
+    expect($result)->not->toHaveKey('cacheScope');
+})->with([
+    'inputResponses' => [['inputResponses' => ['login' => ['action' => 'accept']]]],
+    'requestState' => [['requestState' => 'eyJ...']],
+]);
+
+it('uses the hint the server attribute declares', function (): void {
+    $result = resultFor(listToolsMessage(), fn (ArrayTransport $transport): Server => new #[Cacheable(ttlMs: 300000, scope: CacheScope::PUBLIC)] class($transport) extends ExampleServer {})['result'];
+
+    expect($result['ttlMs'])->toBe(300000);
+    expect($result['cacheScope'])->toBe('public');
+});
+
+it('prefers the per method hint over the server attribute', function (): void {
+    $server = fn (ArrayTransport $transport): Server => new #[Cacheable(ttlMs: 300000, scope: CacheScope::PUBLIC)] class($transport) extends ExampleServer
+    {
+        protected function cacheHints(): array
+        {
+            return ['tools/list' => new Cacheable(ttlMs: 60000)];
+        }
+    };
+
+    expect(resultFor(listToolsMessage(), $server)['result'])
+        ->ttlMs->toBe(60000)
+        ->cacheScope->toBe('private');
+
+    $listPrompts = ['jsonrpc' => '2.0', 'id' => 1, 'method' => 'prompts/list', 'params' => ['_meta' => protocolMeta()]];
+
+    expect(resultFor($listPrompts, $server)['result'])
+        ->ttlMs->toBe(300000)
+        ->cacheScope->toBe('public');
+});
+
+it('prefers the resource attribute over the server hints', function (): void {
+    $server = function (ArrayTransport $transport): Server {
+        $server = new #[Cacheable(ttlMs: 300000)] class($transport) extends ExampleServer
+        {
+            protected function cacheHints(): array
+            {
+                return ['resources/read' => new Cacheable(ttlMs: 60000)];
+            }
+        };
+
+        $server->resources[] = CacheableResource::class;
+
+        return $server;
+    };
+
+    expect(resultFor(readResourceMessage('file://resources/cacheable-resource'), $server)['result'])
+        ->ttlMs->toBe(120000)
+        ->cacheScope->toBe('public');
+
+    expect(resultFor(readResourceMessage('file://resources/last-log-line-resource'), $server)['result'])
+        ->ttlMs->toBe(60000)
+        ->cacheScope->toBe('private');
+});
+
+it('never emits a negative ttl', function (): void {
+    $result = resultFor(listToolsMessage(), fn (ArrayTransport $transport): Server => new #[Cacheable(ttlMs: -1)] class($transport) extends ExampleServer {})['result'];
+
+    expect($result['ttlMs'])->toBe(0);
+});
+
+it('returns tools in the same order on every request', function (): void {
+    $names = fn (): array => array_column(resultFor(listToolsMessage())['result']['tools'], 'name');
+
+    expect($names())->toBe($names())->and($names())->not->toBeEmpty();
+});

--- a/tests/Fixtures/CacheableResource.php
+++ b/tests/Fixtures/CacheableResource.php
@@ -8,7 +8,7 @@ use Laravel\Mcp\Enums\CacheScope;
 use Laravel\Mcp\Server\Attributes\Cacheable;
 use Laravel\Mcp\Server\Resource;
 
-#[Cacheable(ttlMs: 120000, scope: CacheScope::PUBLIC)]
+#[Cacheable(ttlMs: 120000, scope: CacheScope::Public)]
 class CacheableResource extends Resource
 {
     public function description(): string

--- a/tests/Fixtures/CacheableResource.php
+++ b/tests/Fixtures/CacheableResource.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Laravel\Mcp\Enums\CacheScope;
+use Laravel\Mcp\Server\Attributes\Cacheable;
+use Laravel\Mcp\Server\Resource;
+
+#[Cacheable(ttlMs: 120000, scope: CacheScope::PUBLIC)]
+class CacheableResource extends Resource
+{
+    public function description(): string
+    {
+        return 'A resource that declares its own caching hint';
+    }
+
+    public function handle(): string
+    {
+        return 'Cacheable contents.';
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -103,6 +103,8 @@ function expectedDiscoverResponse(): array
         'id' => 456,
         'result' => [
             'resultType' => 'complete',
+            'ttlMs' => 0,
+            'cacheScope' => 'private',
             'supportedVersions' => ['2026-07-28'],
             'capabilities' => $capabilities,
             'instructions' => $instructions,
@@ -157,6 +159,8 @@ function expectedListToolsResponse(): array
         'id' => 1,
         'result' => [
             'resultType' => 'complete',
+            'ttlMs' => 0,
+            'cacheScope' => 'private',
             'tools' => [
                 [
                     'name' => 'say-hi-tool',
@@ -220,6 +224,8 @@ function expectedListResourcesResponse(): array
         'id' => 1,
         'result' => [
             'resultType' => 'complete',
+            'ttlMs' => 0,
+            'cacheScope' => 'private',
             'resources' => [
                 [
                     'name' => 'last-log-line-resource',
@@ -269,14 +275,14 @@ function callToolMessage(): array
     ];
 }
 
-function readResourceMessage(): array
+function readResourceMessage(string $uri = 'file://resources/last-log-line-resource'): array
 {
     return [
         'jsonrpc' => '2.0',
         'id' => 123,
         'method' => 'resources/read',
         'params' => [
-            'uri' => 'file://resources/last-log-line-resource',
+            'uri' => $uri,
             '_meta' => protocolMeta(),
         ],
     ];
@@ -289,6 +295,8 @@ function expectedReadResourceResponse(): array
         'id' => 123,
         'result' => [
             'resultType' => 'complete',
+            'ttlMs' => 0,
+            'cacheScope' => 'private',
             'contents' => [[
                 'text' => '2025-07-02 12:00:00 Error: Something went wrong.',
                 'uri' => 'file://resources/last-log-line-resource',


### PR DESCRIPTION
Clients had nothing to tell them how long a tool list stays good for, so they either refetched constantly or guessed. `2026-07-28` makes servers say.

Every cacheable result now carries the hint:

```json
{
  "resultType": "complete",
  "ttlMs": 300000,
  "cacheScope": "public",
  "tools": [...]
}
```

Hints go on `server/discover`, `tools/list`, `prompts/list`, `resources/list`, `resources/templates/list`, and `resources/read`. They are left off `tools/call`, which the spec does not make cacheable, and off any request carrying `inputResponses` or `requestState`, which the spec says must not be cached.

The default is `ttlMs: 0` with `cacheScope: private`, which asks clients to treat every result as immediately stale and never share it across authorization contexts. Nothing needs configuring to be spec-correct.

### Configuring it

The spec models caching per response, not per server, so there are three places to set it and the most specific one wins.

A resource owns its own `resources/read` response, so it can carry the hint directly:

```php
#[Cacheable(ttlMs: 120_000, scope: CacheScope::Public)]
class WeatherResource extends Resource {}
```

A server declares a blanket default, and overrides it per method for the responses that span many primitives:

```php
#[Cacheable(ttlMs: 300_000, scope: CacheScope::Public)]
class WeatherServer extends Server
{
    protected function cacheHints(): array
    {
        return ['tools/list' => new Cacheable(ttlMs: 60_000)];
    }
}
```

Resolution order is resource attribute, then the `cacheHints()` map, then the server attribute, then the package default. There is no knob on `Tool`: `tools/call` is not cacheable, and a single tool does not own the shared `tools/list` response.

A negative `ttlMs` is clamped to `0`, since the spec requires servers to emit `>= 0`. Scope is never mixed within a paginated list, because it is resolved per method rather than per page.

> [!WARNING]
> BC break in the response shape. Cacheable results gain `ttlMs` and `cacheScope`, so anything asserting on an exact result payload needs updating. Clients that treated a tool list as valid forever should now respect the TTL, which defaults to 0.

Tool order was already deterministic, since it follows registration order, so this adds a test that pins that rather than sorting and changing existing output. Tests cover each cacheable method, both exclusions, the three-level resolution order, and the negative-TTL clamp.

### Spec

- [2026-07-28 changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
- [Caching](https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching)

Credit to @JordanDalton, whose #275 mapped out the 2026-07-28 work.
