### PR TITLE
Add the subscriptions listen stream

### DIFF
--- a/src/Enums/MetaKey.php
+++ b/src/Enums/MetaKey.php
@@ -9,4 +9,5 @@ enum MetaKey: string
     case PROTOCOL_VERSION = 'io.modelcontextprotocol/protocolVersion';
     case CLIENT_CAPABILITIES = 'io.modelcontextprotocol/clientCapabilities';
     case SERVER_INFO = 'io.modelcontextprotocol/serverInfo';
+    case SUBSCRIPTION_ID = 'io.modelcontextprotocol/subscriptionId';
 }

--- a/src/Server.php
+++ b/src/Server.php
@@ -25,6 +25,7 @@ use Laravel\Mcp\Server\Methods\CompletionComplete;
 use Laravel\Mcp\Server\Methods\Concerns\ResolvesResources;
 use Laravel\Mcp\Server\Methods\Discover;
 use Laravel\Mcp\Server\Methods\GetPrompt;
+use Laravel\Mcp\Server\Methods\Listen;
 use Laravel\Mcp\Server\Methods\ListPrompts;
 use Laravel\Mcp\Server\Methods\ListResources;
 use Laravel\Mcp\Server\Methods\ListResourceTemplates;
@@ -33,6 +34,7 @@ use Laravel\Mcp\Server\Methods\ReadResource;
 use Laravel\Mcp\Server\Prompt;
 use Laravel\Mcp\Server\Resource;
 use Laravel\Mcp\Server\ServerContext;
+use Laravel\Mcp\Server\Subscription;
 use Laravel\Mcp\Server\Testing\PendingTestResponse;
 use Laravel\Mcp\Server\Testing\TestResponse;
 use Laravel\Mcp\Server\Tool;
@@ -129,6 +131,7 @@ abstract class Server
         'prompts/get' => GetPrompt::class,
         'completion/complete' => CompletionComplete::class,
         'server/discover' => Discover::class,
+        'subscriptions/listen' => Listen::class,
     ];
 
     public function __construct(
@@ -267,7 +270,18 @@ abstract class Server
             tools: $this->tools,
             resources: $this->resources,
             prompts: $this->prompts,
+            notifications: $this->subscriptions(...),
         );
+    }
+
+    /**
+     * The notifications to deliver on an open subscription stream.
+     *
+     * @return iterable<Response>
+     */
+    protected function subscriptions(Subscription $subscription): iterable
+    {
+        return [];
     }
 
     /**

--- a/src/Server/Methods/Listen.php
+++ b/src/Server/Methods/Listen.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Server\Methods;
+
+use Generator;
+use Laravel\Mcp\Enums\MetaKey;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Content\Notification;
+use Laravel\Mcp\Server\Contracts\Method;
+use Laravel\Mcp\Server\ServerContext;
+use Laravel\Mcp\Server\Subscription;
+use Laravel\Mcp\Transport\JsonRpcRequest;
+use Laravel\Mcp\Transport\JsonRpcResponse;
+
+class Listen implements Method
+{
+    /**
+     * @return Generator<JsonRpcResponse>
+     */
+    public function handle(JsonRpcRequest $request, ServerContext $context): Generator
+    {
+        $subscription = Subscription::from($request->id, $request->get('notifications'), $context);
+
+        yield $this->stamped(JsonRpcResponse::notification(
+            'notifications/subscriptions/acknowledged',
+            ['notifications' => $subscription->notifications() ?: (object) []],
+        ), $subscription);
+
+        foreach ($context->notificationsFor($subscription) as $notification) {
+            $frame = $this->toNotification($notification, $subscription);
+
+            if (! $frame instanceof JsonRpcResponse) {
+                continue;
+            }
+
+            yield $this->stamped($frame, $subscription);
+        }
+
+        yield JsonRpcResponse::result($request->id, [
+            '_meta' => [MetaKey::SUBSCRIPTION_ID->value => $subscription->id],
+        ]);
+    }
+
+    protected function toNotification(mixed $notification, Subscription $subscription): ?JsonRpcResponse
+    {
+        if (! $notification instanceof Response || ! $notification->isNotification()) {
+            return null;
+        }
+
+        /** @var Notification $content */
+        $content = $notification->content();
+        $frame = $content->toArray();
+
+        $method = is_string($frame['method'] ?? null) ? $frame['method'] : '';
+        $params = is_array($frame['params'] ?? null) ? $frame['params'] : [];
+        $uri = is_string($params['uri'] ?? null) ? $params['uri'] : null;
+
+        return $subscription->wants($method, $uri)
+            ? JsonRpcResponse::notification($method, $params)
+            : null;
+    }
+
+    protected function stamped(JsonRpcResponse $response, Subscription $subscription): JsonRpcResponse
+    {
+        $frame = $response->toArray();
+        $method = is_string($frame['method'] ?? null) ? $frame['method'] : '';
+        $params = (array) ($frame['params'] ?? []);
+
+        $params['_meta'] = [
+            ...is_array($params['_meta'] ?? null) ? $params['_meta'] : [],
+            MetaKey::SUBSCRIPTION_ID->value => $subscription->id,
+        ];
+
+        return JsonRpcResponse::notification($method, $params);
+    }
+}

--- a/src/Server/ServerContext.php
+++ b/src/Server/ServerContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp\Server;
 
+use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Support\Collection;
 use Laravel\Mcp\Schema\Implementation;
@@ -28,8 +29,21 @@ class ServerContext
         protected array $tools,
         protected array $resources,
         protected array $prompts,
+        protected ?Closure $notifications = null,
     ) {
         //
+    }
+
+    /**
+     * @return iterable<mixed>
+     */
+    public function notificationsFor(Subscription $subscription): iterable
+    {
+        if (! $this->notifications instanceof Closure) {
+            return [];
+        }
+
+        return ($this->notifications)($subscription) ?? [];
     }
 
     /**
@@ -85,7 +99,11 @@ class ServerContext
 
     public function hasCapability(string $capability): bool
     {
-        return array_key_exists($capability, $this->serverCapabilities);
+        if (! str_contains($capability, '.')) {
+            return array_key_exists($capability, $this->serverCapabilities);
+        }
+
+        return data_get($this->serverCapabilities, $capability) === true;
     }
 
     /**

--- a/src/Server/Subscription.php
+++ b/src/Server/Subscription.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Server;
+
+use Laravel\Mcp\Server;
+
+class Subscription
+{
+    public const NOTIFICATIONS = [
+        'toolsListChanged' => 'notifications/tools/list_changed',
+        'promptsListChanged' => 'notifications/prompts/list_changed',
+        'resourcesListChanged' => 'notifications/resources/list_changed',
+        'resourceSubscriptions' => 'notifications/resources/updated',
+    ];
+
+    protected const CAPABILITIES = [
+        'toolsListChanged' => Server::CAPABILITY_TOOLS.'.listChanged',
+        'promptsListChanged' => Server::CAPABILITY_PROMPTS.'.listChanged',
+        'resourcesListChanged' => Server::CAPABILITY_RESOURCES.'.listChanged',
+        'resourceSubscriptions' => Server::CAPABILITY_RESOURCES.'.subscribe',
+    ];
+
+    /**
+     * @param  array<string, bool|array<int, string>>  $notifications
+     */
+    protected function __construct(
+        public readonly int|string $id,
+        protected array $notifications,
+    ) {
+        //
+    }
+
+    public static function from(int|string $id, mixed $requested, ServerContext $context): self
+    {
+        $requested = is_array($requested) ? $requested : [];
+        $honored = [];
+
+        foreach (self::NOTIFICATIONS as $field => $method) {
+            if (! $context->hasCapability(self::CAPABILITIES[$field])) {
+                continue;
+            }
+
+            $value = $requested[$field] ?? null;
+
+            if ($field === 'resourceSubscriptions') {
+                $uris = is_array($value) ? array_values(array_filter($value, is_string(...))) : [];
+
+                if ($uris !== []) {
+                    $honored[$field] = $uris;
+                }
+
+                continue;
+            }
+
+            if ($value === true) {
+                $honored[$field] = true;
+            }
+        }
+
+        return new self($id, $honored);
+    }
+
+    /**
+     * @return array<string, bool|array<int, string>>
+     */
+    public function notifications(): array
+    {
+        return $this->notifications;
+    }
+
+    public function wants(string $method, ?string $uri = null): bool
+    {
+        $field = array_search($method, self::NOTIFICATIONS, true);
+
+        if ($field === false || ! array_key_exists($field, $this->notifications)) {
+            return false;
+        }
+
+        if ($field !== 'resourceSubscriptions') {
+            return true;
+        }
+
+        /** @var array<int, string> $uris */
+        $uris = $this->notifications[$field];
+
+        return $uri !== null && in_array($uri, $uris, true);
+    }
+}

--- a/tests/Feature/Server/SubscriptionsTest.php
+++ b/tests/Feature/Server/SubscriptionsTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Subscription;
+use Tests\Fixtures\ArrayTransport;
+use Tests\Fixtures\ExampleServer;
+
+function listenMessages(array $notifications, ?Closure $factory = null): array
+{
+    $transport = new ArrayTransport;
+    $server = ($factory ?? pushingServer([]))($transport);
+
+    $server->start();
+
+    ($transport->handler)((string) json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 7,
+        'method' => 'subscriptions/listen',
+        'params' => [
+            '_meta' => protocolMeta(),
+            'notifications' => $notifications,
+        ],
+    ]));
+
+    return array_map(fn (string $sent): array => json_decode($sent, true), $transport->sent);
+}
+
+function pushingServer(array $notifications): Closure
+{
+    return fn (ArrayTransport $transport): Server => new class($transport, $notifications) extends ExampleServer
+    {
+        /**
+         * @param  array<int, Response>  $pushed
+         */
+        public function __construct(ArrayTransport $transport, protected array $pushed = [])
+        {
+            parent::__construct($transport);
+        }
+
+        protected function boot(): void
+        {
+            $this->addCapability('tools.listChanged');
+            $this->addCapability('prompts.listChanged');
+            $this->addCapability('resources.listChanged');
+            $this->addCapability('resources.subscribe');
+        }
+
+        protected function subscriptions(Subscription $subscription): iterable
+        {
+            return $this->pushed;
+        }
+    };
+}
+
+it('acknowledges the subscription first and carries the subscription id', function (): void {
+    $messages = listenMessages(['toolsListChanged' => true]);
+
+    expect($messages[0]['method'])->toBe('notifications/subscriptions/acknowledged');
+    expect($messages[0]['params']['_meta']['io.modelcontextprotocol/subscriptionId'])->toBe(7);
+    expect($messages[0]['params']['notifications'])->toBe(['toolsListChanged' => true]);
+});
+
+it('closes the subscription gracefully with an empty result', function (): void {
+    $messages = listenMessages(['toolsListChanged' => true]);
+    $last = end($messages);
+
+    expect($last['id'])->toBe(7);
+    expect($last['result']['resultType'])->toBe('complete');
+    expect($last['result']['_meta']['io.modelcontextprotocol/subscriptionId'])->toBe(7);
+});
+
+it('acknowledges only the notifications it was asked for', function (): void {
+    $messages = listenMessages([
+        'toolsListChanged' => true,
+        'promptsListChanged' => false,
+        'resourceSubscriptions' => ['file://resources/last-log-line-resource'],
+    ]);
+
+    expect($messages[0]['params']['notifications'])->toBe([
+        'toolsListChanged' => true,
+        'resourceSubscriptions' => ['file://resources/last-log-line-resource'],
+    ]);
+});
+
+it('acknowledges nothing when the filter is empty', function (): void {
+    expect(listenMessages([])[0]['params']['notifications'])->toBe([]);
+});
+
+it('delivers a subscribed notification stamped with the subscription id', function (): void {
+    $messages = listenMessages(
+        ['toolsListChanged' => true],
+        pushingServer([Response::notification('notifications/tools/list_changed')]),
+    );
+
+    expect($messages[1]['method'])->toBe('notifications/tools/list_changed');
+    expect($messages[1]['params']['_meta']['io.modelcontextprotocol/subscriptionId'])->toBe(7);
+});
+
+it('withholds a notification the client did not subscribe to', function (): void {
+    $messages = listenMessages(
+        ['toolsListChanged' => true],
+        pushingServer([Response::notification('notifications/prompts/list_changed')]),
+    );
+
+    expect($messages)->toHaveCount(2);
+    expect($messages[1])->toHaveKey('result');
+});
+
+it('delivers a resource update only for a subscribed uri', function (): void {
+    $factory = pushingServer([
+        Response::notification('notifications/resources/updated', ['uri' => 'file://watched']),
+        Response::notification('notifications/resources/updated', ['uri' => 'file://ignored']),
+    ]);
+
+    $messages = listenMessages(['resourceSubscriptions' => ['file://watched']], $factory);
+
+    expect($messages)->toHaveCount(3);
+    expect($messages[1]['params']['uri'])->toBe('file://watched');
+});
+
+it('leaves caching hints off the subscription response', function (): void {
+    $messages = listenMessages(['toolsListChanged' => true]);
+    $last = end($messages);
+
+    expect($last['result'])->not->toHaveKey('ttlMs');
+    expect($last['result'])->not->toHaveKey('cacheScope');
+});
+
+it('refuses a notification the server does not advertise', function (): void {
+    $messages = listenMessages(
+        ['toolsListChanged' => true, 'resourceSubscriptions' => ['file://a']],
+        fn (ArrayTransport $transport): Server => new ExampleServer($transport),
+    );
+
+    expect($messages[0]['params']['notifications'])->toBe([]);
+});
+
+it('acknowledges an empty filter as a json object', function (): void {
+    $transport = new ArrayTransport;
+    $server = new ExampleServer($transport);
+
+    $server->start();
+
+    ($transport->handler)((string) json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 7,
+        'method' => 'subscriptions/listen',
+        'params' => ['_meta' => protocolMeta(), 'notifications' => ['toolsListChanged' => true]],
+    ]));
+
+    expect((string) $transport->sent[0])->toContain('"notifications":{}');
+});
+
+it('keeps the server subscription id when a notification carries its own meta', function (): void {
+    $messages = listenMessages(
+        ['toolsListChanged' => true],
+        pushingServer([
+            Response::notification('notifications/tools/list_changed', [
+                '_meta' => [
+                    'io.modelcontextprotocol/subscriptionId' => 99,
+                    'app/trace' => 'abc',
+                ],
+            ]),
+        ]),
+    );
+
+    expect($messages[1]['params']['_meta']['io.modelcontextprotocol/subscriptionId'])->toBe(7);
+    expect($messages[1]['params']['_meta']['app/trace'])->toBe('abc');
+});


### PR DESCRIPTION
`2026-07-28` removes `resources/subscribe` and the standalone GET stream. A client that wants change notifications opens one long-lived request instead and says exactly what it wants on it.

```json
{
  "method": "subscriptions/listen",
  "params": {
    "notifications": {
      "toolsListChanged": true,
      "resourceSubscriptions": ["file:///project/config.json"]
    }
  }
}
```

The server acknowledges the subset it will honor, then only sends those:

```json
{
  "method": "notifications/subscriptions/acknowledged",
  "params": {
    "_meta": { "io.modelcontextprotocol/subscriptionId": 1 },
    "notifications": { "toolsListChanged": true, "resourceSubscriptions": [...] }
  }
}
```

A server supplies what flows on the stream by overriding one method:

```php
protected function subscriptions(Subscription $subscription): iterable
{
    yield Response::notification('notifications/tools/list_changed');
}
```

Anything yielded that the client did not subscribe to is dropped, including a `resources/updated` for a URI outside `resourceSubscriptions`. Every message on the stream carries the subscription id, and the stream ends with the empty `subscriptions/listen` result that signals a graceful close rather than a dropped connection.

The package never implemented `resources/subscribe` or the GET stream, so nothing had to be removed here and this PR is additive.

Request-scoped notifications like `notifications/progress` keep flowing on their originating response stream, which is where they already were. The `subscriptions()` hook is a generator the server owns, so how it learns about changes, polling, a queue, a broker, is left to the application rather than assumed here. Tests cover acknowledgment ordering and content, the id stamping, the filtering in both directions, and the graceful close.

### Spec

- [2026-07-28 changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
- [Subscriptions](https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/subscriptions)

Credit to @JordanDalton, whose #275 mapped out the 2026-07-28 work.

