### PR TITLE
Advertise MCP Apps through the extensions capability

### DIFF
--- a/resources/boost/skills/mcp-development/references/app.md
+++ b/resources/boost/skills/mcp-development/references/app.md
@@ -104,7 +104,7 @@ MCP Apps add interactive UI to the Model Context Protocol. The server returns se
 └─────────────────────────────────────────────┘
 ```
 
-The server automatically advertises `io.modelcontextprotocol/ui` capability when any `AppResource` is registered. The client declares support in `capabilities.extensions["io.modelcontextprotocol/ui"]` during the initialize handshake.
+The server automatically advertises `capabilities.extensions["io.modelcontextprotocol/ui"]` on `server/discover` when any `AppResource` is registered. Add cases of the `Extension` enum to the server's `$extensions` property to declare any other extension. The client declares its own support in the `io.modelcontextprotocol/clientCapabilities` member of each request's `_meta`.
 
 ---
 

--- a/src/Enums/Extension.php
+++ b/src/Enums/Extension.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Enums;
+
+enum Extension: string
+{
+    case Ui = 'io.modelcontextprotocol/ui';
+}

--- a/src/Server.php
+++ b/src/Server.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Laravel\Mcp;
 
 use Illuminate\Container\Container;
+use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use Laravel\Mcp\Enums\ErrorCode;
+use Laravel\Mcp\Enums\Extension;
 use Laravel\Mcp\Enums\MetaKey;
 use Laravel\Mcp\Enums\ProtocolVersion;
 use Laravel\Mcp\Exceptions\JsonRpcException;
@@ -58,8 +60,6 @@ abstract class Server
 
     public const CAPABILITY_COMPLETIONS = 'completions';
 
-    public const CAPABILITY_UI = 'io.modelcontextprotocol/ui';
-
     public const CACHEABLE_METHODS = [
         'server/discover',
         'tools/list',
@@ -81,6 +81,11 @@ abstract class Server
      * @var array<int, string>
      */
     protected array $supportedProtocolVersion = [];
+
+    /**
+     * @var array<int, Extension>
+     */
+    protected array $extensions = [];
 
     /**
      * @var array<string, array<string, bool>|stdClass|string>
@@ -255,7 +260,7 @@ abstract class Server
 
         return new ServerContext(
             supportedProtocolVersions: $this->supportedProtocolVersion ?: ProtocolVersion::supported(),
-            serverCapabilities: $this->capabilities,
+            serverCapabilities: $this->resolvedCapabilities(),
             implementation: new Implementation(
                 name: $name !== null ? $name->value : $this->name,
                 version: $version !== null ? $version->value : $this->version,
@@ -418,18 +423,25 @@ abstract class Server
         return $response;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
+    protected function resolvedCapabilities(): array
+    {
+        $extensions = Arr::mapWithKeys(
+            $this->extensions,
+            fn (Extension $extension): array => [$extension->value => (object) []],
+        );
+
+        return $extensions === []
+            ? $this->capabilities
+            : [...$this->capabilities, 'extensions' => $extensions];
+    }
+
     protected function detectUiCapability(): void
     {
-        if (array_key_exists(self::CAPABILITY_UI, $this->capabilities)) {
-            return;
-        }
-
-        foreach ($this->resources as $resource) {
-            if (is_subclass_of($resource, AppResource::class)) {
-                $this->addCapability(self::CAPABILITY_UI);
-
-                return;
-            }
+        if (collect($this->resources)->contains(fn (Resource|string $resource): bool => is_subclass_of($resource, AppResource::class))) {
+            $this->extensions[] = Extension::Ui;
         }
     }
 

--- a/tests/Unit/Methods/DiscoverAppTest.php
+++ b/tests/Unit/Methods/DiscoverAppTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Laravel\Mcp\Enums\Extension;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server;
@@ -9,7 +10,7 @@ use Laravel\Mcp\Server\AppResource;
 use Laravel\Mcp\Server\Resource;
 use Tests\Fixtures\ArrayTransport;
 
-it('auto-detects ui capability when ui resources are registered', function (): void {
+it('advertises the ui extension when app resources are registered', function (): void {
     $server = new class(new ArrayTransport) extends Server
     {
         protected array $resources = [
@@ -19,12 +20,13 @@ it('auto-detects ui capability when ui resources are registered', function (): v
 
     $server->start();
 
-    $context = $server->createContext();
+    $extensions = $server->createContext()->serverCapabilities['extensions'];
 
-    expect($context->serverCapabilities)->toHaveKey('io.modelcontextprotocol/ui');
+    expect($extensions)->toHaveKey('io.modelcontextprotocol/ui');
+    expect($extensions['io.modelcontextprotocol/ui'])->toEqual((object) []);
 });
 
-it('does not include ui capability when only regular resources are registered', function (): void {
+it('advertises no extensions when only regular resources are registered', function (): void {
     $server = new class(new ArrayTransport) extends Server
     {
         protected array $resources = [
@@ -34,9 +36,20 @@ it('does not include ui capability when only regular resources are registered', 
 
     $server->start();
 
-    $context = $server->createContext();
+    expect($server->createContext()->serverCapabilities)->not->toHaveKey('extensions');
+});
 
-    expect($context->serverCapabilities)->not->toHaveKey('io.modelcontextprotocol/ui');
+it('advertises the extensions declared on the server', function (): void {
+    $server = new class(new ArrayTransport) extends Server
+    {
+        protected array $extensions = [
+            Extension::Ui,
+        ];
+    };
+
+    $extensions = $server->createContext()->serverCapabilities['extensions'];
+
+    expect($extensions)->toHaveKey('io.modelcontextprotocol/ui');
 });
 
 class AutoDetectAppResource extends AppResource


### PR DESCRIPTION
`2026-07-28` adds an `extensions` field to server capabilities, and MCP Apps is an extension. The package was advertising it as if it were a core capability.

Before:

```json
{ "capabilities": { "tools": {}, "io.modelcontextprotocol/ui": {} } }
```

After:

```json
{ "capabilities": { "tools": {}, "extensions": { "io.modelcontextprotocol/ui": {} } } }
```

Registering an `AppResource` still advertises it for you. Declaring one by hand, with its settings object, now looks like this:

```php
$server->addExtension('io.modelcontextprotocol/ui', ['mimeTypes' => ['text/html;profile=mcp-app']]);
```

> [!WARNING]
> BC break for clients reading `capabilities['io.modelcontextprotocol/ui']`. It now lives at `capabilities['extensions']['io.modelcontextprotocol/ui']`. `Server::CAPABILITY_UI` is replaced by `Server::EXTENSION_UI`.

No generic extensions API beyond `addExtension()`/`hasExtension()`: extensions are opt-in per the spec, and one advertisement method is all the Apps case needs. The deeper Apps conformance audit is not here, because the Apps extension is versioned separately from this revision and its spec is not part of it. What this PR does add is conformance tests pinning the parts the extension docs do fix: the `ui://` URI, the `text/html;profile=mcp-app` MIME type, and the `_meta.ui` payload carrying CSP, permissions, and domain.

### Spec

- [2026-07-28 changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
- [Extensions: negotiation](https://modelcontextprotocol.io/docs/extensions/overview#negotiation)
- [MCP Apps](https://modelcontextprotocol.io/extensions/apps/overview)

Credit to @JordanDalton, whose #275 mapped out the 2026-07-28 work.

