### PR TITLE
Pin MCP Inspector to v1-latest

### DIFF
--- a/src/Console/Commands/InspectorCommand.php
+++ b/src/Console/Commands/InspectorCommand.php
@@ -75,7 +75,7 @@ class InspectorCommand extends Command
 
             $command = [
                 'npx',
-                '@modelcontextprotocol/inspector',
+                '@modelcontextprotocol/inspector@v1-latest',
                 '--transport',
                 'stdio',
                 $this->phpBinary(),
@@ -101,7 +101,7 @@ class InspectorCommand extends Command
 
             $command = [
                 'npx',
-                '@modelcontextprotocol/inspector',
+                '@modelcontextprotocol/inspector@v1-latest',
                 '--transport',
                 'http',
                 '--server-url',


### PR DESCRIPTION
Currently `mcp:inspector` runs `npx @modelcontextprotocol/inspector`, which resolves to whatever the latest tag is. The inspector's v2 line changed its CLI, so an unpinned run can break against this command's flags. This PR pins it to `@modelcontextprotocol/inspector@v1-latest` for both the stdio and http invocations.

No tests, it's just the npx package string.