### PR TITLE
Mirror annotated tool parameters into request headers

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -36,6 +36,7 @@ use Laravel\Mcp\Server\ServerContext;
 use Laravel\Mcp\Server\Testing\PendingTestResponse;
 use Laravel\Mcp\Server\Testing\TestResponse;
 use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Transport\HttpTransport;
 use Laravel\Mcp\Transport\JsonRpcNotification;
 use Laravel\Mcp\Transport\JsonRpcRequest;
 use Laravel\Mcp\Transport\JsonRpcResponse;
@@ -267,7 +268,19 @@ abstract class Server
             tools: $this->tools,
             resources: $this->resources,
             prompts: $this->prompts,
+            validateToolHeaders: $this->validateToolHeaders(...),
         );
+    }
+
+    protected function validateToolHeaders(Tool $tool, JsonRpcRequest $request): void
+    {
+        if (! $this->transport instanceof HttpTransport) {
+            return;
+        }
+
+        $inputSchema = $tool->toArray()['inputSchema'] ?? [];
+
+        $this->transport->validateToolHeaders($inputSchema, $request->toRequest()->all(), $request->id);
     }
 
     /**

--- a/src/Server/Methods/CallTool.php
+++ b/src/Server/Methods/CallTool.php
@@ -46,6 +46,8 @@ class CallTool implements Errable, Method
                     $request->id,
                 ));
 
+        $context->validateToolHeaders($tool, $request);
+
         // @phpstan-ignore-next-line
         $response = $this->callHandler(fn (): mixed => Container::getInstance()->call([$tool, 'handle']), $request);
 

--- a/src/Server/ServerContext.php
+++ b/src/Server/ServerContext.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp\Server;
 
+use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Support\Collection;
 use Laravel\Mcp\Schema\Implementation;
 use Laravel\Mcp\Server\Contracts\HasUriTemplate;
+use Laravel\Mcp\Transport\JsonRpcRequest;
 
 class ServerContext
 {
@@ -28,8 +30,16 @@ class ServerContext
         protected array $tools,
         protected array $resources,
         protected array $prompts,
+        protected ?Closure $validateToolHeaders = null,
     ) {
         //
+    }
+
+    public function validateToolHeaders(Tool $tool, JsonRpcRequest $request): void
+    {
+        if ($this->validateToolHeaders instanceof Closure) {
+            ($this->validateToolHeaders)($tool, $request);
+        }
     }
 
     /**

--- a/src/Server/Tool.php
+++ b/src/Server/Tool.php
@@ -7,14 +7,24 @@ namespace Laravel\Mcp\Server;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\JsonSchema\JsonSchema as JsonSchemaFactory;
+use Illuminate\Support\Arr;
+use InvalidArgumentException;
 use Laravel\Mcp\Server\Attributes\RendersApp;
 use Laravel\Mcp\Server\Concerns\HasAnnotations;
 use Laravel\Mcp\Server\Tools\Annotations\ToolAnnotation;
 use Laravel\Mcp\Server\Ui\Enums\Visibility;
+use Laravel\Mcp\Support\ToolHeaders;
 
 abstract class Tool extends Primitive
 {
     use HasAnnotations;
+
+    /**
+     * Argument paths to mirror into an [Mcp-Param-{name}] HTTP header, keyed by path.
+     *
+     * @var array<string, string>
+     */
+    protected array $parameterHeaders = [];
 
     /**
      * @return array<string, mixed>
@@ -32,6 +42,31 @@ abstract class Tool extends Primitive
     public function outputSchema(JsonSchema $schema): array
     {
         return [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $schema
+     * @return array<string, mixed>
+     */
+    protected function withParameterHeaders(array $schema): array
+    {
+        foreach ($this->parameterHeaders as $path => $header) {
+            $key = 'properties.'.implode('.properties.', explode('.', $path));
+
+            if (! Arr::has($schema, $key)) {
+                throw new InvalidArgumentException("Tool [{$this->name()}] mirrors the unknown argument [{$path}] into a header.");
+            }
+
+            Arr::set($schema, $key.'.'.ToolHeaders::ANNOTATION, $header);
+        }
+
+        $reason = ToolHeaders::invalid($schema);
+
+        if ($reason !== null) {
+            throw new InvalidArgumentException("Tool [{$this->name()}] cannot mirror arguments into headers because {$reason}.");
+        }
+
+        return $schema;
     }
 
     /**
@@ -68,6 +103,7 @@ abstract class Tool extends Primitive
         )->toArray();
 
         $schema['properties'] ??= (object) [];
+        $schema = $this->withParameterHeaders($schema);
 
         $result = [
             'name' => $this->name(),

--- a/src/Server/Transport/HttpTransport.php
+++ b/src/Server/Transport/HttpTransport.php
@@ -8,7 +8,9 @@ use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Laravel\Mcp\Enums\ErrorCode;
+use Laravel\Mcp\Exceptions\JsonRpcException;
 use Laravel\Mcp\Server\Contracts\Transport;
+use Laravel\Mcp\Support\ToolHeaders;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class HttpTransport implements Transport
@@ -102,6 +104,33 @@ class HttpTransport implements Transport
     public function stream(Closure $stream): void
     {
         $this->stream = $stream;
+    }
+
+    public function validateToolHeaders(mixed $inputSchema, mixed $arguments, int|string $id): void
+    {
+        if (! is_array($inputSchema) || ! is_array($arguments)) {
+            return;
+        }
+
+        foreach (ToolHeaders::extract($inputSchema, $arguments) as $header => $expected) {
+            $actual = $this->request->header($header);
+
+            if (! is_string($actual) || $actual === '') {
+                throw new JsonRpcException(
+                    "Header mismatch: The [{$header}] header is required.",
+                    ErrorCode::HEADER_MISMATCH->value,
+                    $id,
+                );
+            }
+
+            if ($actual !== $expected) {
+                throw new JsonRpcException(
+                    "Header mismatch: The [{$header}] header value [{$actual}] does not match the request body value [{$expected}].",
+                    ErrorCode::HEADER_MISMATCH->value,
+                    $id,
+                );
+            }
+        }
     }
 
     protected function sendStreamMessage(string $message): void

--- a/src/Support/ToolHeaders.php
+++ b/src/Support/ToolHeaders.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Support;
+
+use Laravel\Mcp\Exceptions\ClientException;
+use Laravel\Mcp\Transport\HeaderValue;
+
+class ToolHeaders
+{
+    public const ANNOTATION = 'x-mcp-header';
+
+    public const PREFIX = 'Mcp-Param-';
+
+    protected const SAFE_INTEGER = 9007199254740991;
+
+    /**
+     * @param  array<string, mixed>  $inputSchema
+     */
+    public static function invalid(array $inputSchema): ?string
+    {
+        $seen = [];
+
+        foreach (self::annotated($inputSchema) as $path => $name) {
+            if (! is_string($name) || preg_match('/^[!#$%&\'*+\-.^_`|~0-9A-Za-z]+$/D', $name) !== 1) {
+                return 'the ['.self::ANNOTATION."] value on [{$path}] is not a valid header name token";
+            }
+
+            $lowered = strtolower($name);
+
+            if (isset($seen[$lowered])) {
+                return 'the ['.self::ANNOTATION."] value [{$name}] is used more than once";
+            }
+
+            $seen[$lowered] = true;
+        }
+
+        foreach (self::annotatedSchemas($inputSchema) as $path => $schema) {
+            $type = $schema['type'] ?? null;
+
+            if (! in_array($type, ['string', 'integer', 'boolean'], true)) {
+                return 'the ['.self::ANNOTATION."] annotation on [{$path}] must sit on a string, integer, or boolean";
+            }
+        }
+
+        if (self::unreachable($inputSchema)) {
+            return 'an ['.self::ANNOTATION.'] annotation sits outside the statically reachable properties';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $inputSchema
+     * @param  array<string, mixed>  $arguments
+     * @return array<string, string>
+     */
+    public static function extract(array $inputSchema, array $arguments): array
+    {
+        $headers = [];
+
+        foreach (self::annotated($inputSchema) as $path => $name) {
+            $value = self::valueAt($arguments, explode('.', $path));
+            if ($value === null) {
+                continue;
+            }
+
+            if (! self::encodable($value)) {
+                throw new ClientException(
+                    "The [{$path}] argument is annotated with [".self::ANNOTATION.'] but its value cannot be mirrored into a header.',
+                );
+            }
+
+            $headers[self::PREFIX.$name] = (string) new HeaderValue(self::stringify($value));
+        }
+
+        return $headers;
+    }
+
+    /**
+     * @param  array<string, mixed>  $inputSchema
+     * @return array<string, mixed>
+     */
+    protected static function annotated(array $inputSchema, string $prefix = ''): array
+    {
+        $names = [];
+
+        foreach (self::properties($inputSchema) as $key => $schema) {
+            $path = $prefix === '' ? (string) $key : $prefix.'.'.$key;
+
+            if (array_key_exists(self::ANNOTATION, $schema)) {
+                $names[$path] = $schema[self::ANNOTATION];
+            }
+
+            $names = [...$names, ...self::annotated($schema, $path)];
+        }
+
+        return $names;
+    }
+
+    /**
+     * @param  array<string, mixed>  $inputSchema
+     * @return array<string, array<string, mixed>>
+     */
+    protected static function annotatedSchemas(array $inputSchema, string $prefix = ''): array
+    {
+        $schemas = [];
+
+        foreach (self::properties($inputSchema) as $key => $schema) {
+            $path = $prefix === '' ? (string) $key : $prefix.'.'.$key;
+
+            if (array_key_exists(self::ANNOTATION, $schema)) {
+                $schemas[$path] = $schema;
+            }
+
+            $schemas = [...$schemas, ...self::annotatedSchemas($schema, $path)];
+        }
+
+        return $schemas;
+    }
+
+    /**
+     * @param  array<string, mixed>  $schema
+     * @return array<array-key, array<string, mixed>>
+     */
+    protected static function properties(array $schema): array
+    {
+        $properties = $schema['properties'] ?? null;
+
+        if (! is_array($properties)) {
+            return [];
+        }
+
+        return array_filter($properties, is_array(...));
+    }
+
+    /**
+     * @param  array<string, mixed>  $schema
+     */
+    protected static function unreachable(array $schema): bool
+    {
+        foreach ($schema as $key => $value) {
+            if ($key === self::ANNOTATION) {
+                return true;
+            }
+
+            if (! is_array($value)) {
+                continue;
+            }
+
+            if ($key !== 'properties') {
+                if (self::containsAnnotation($value)) {
+                    return true;
+                }
+
+                continue;
+            }
+
+            foreach ($value as $child) {
+                if (! is_array($child)) {
+                    continue;
+                }
+
+                unset($child[self::ANNOTATION]);
+
+                if (self::unreachable($child)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $schema
+     */
+    protected static function containsAnnotation(array $schema): bool
+    {
+        foreach ($schema as $key => $value) {
+            if ($key === self::ANNOTATION) {
+                return true;
+            }
+
+            if (is_array($value) && self::containsAnnotation($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     * @param  array<int, string>  $path
+     */
+    protected static function valueAt(array $arguments, array $path): mixed
+    {
+        $value = $arguments;
+
+        foreach ($path as $segment) {
+            if (! is_array($value) || ! array_key_exists($segment, $value)) {
+                return null;
+            }
+
+            $value = $value[$segment];
+        }
+
+        return $value;
+    }
+
+    protected static function encodable(mixed $value): bool
+    {
+        if (is_bool($value) || is_string($value)) {
+            return true;
+        }
+
+        return is_int($value) && abs($value) <= self::SAFE_INTEGER;
+    }
+
+    protected static function stringify(string|int|bool $value): string
+    {
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        return (string) $value;
+    }
+}

--- a/tests/Feature/Server/Middleware/ValidateMcpHeadersTest.php
+++ b/tests/Feature/Server/Middleware/ValidateMcpHeadersTest.php
@@ -2,10 +2,47 @@
 
 declare(strict_types=1);
 
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Contracts\Transport;
 use Laravel\Mcp\Server\Methods\ListTools;
+use Laravel\Mcp\Server\Registrar;
 use Laravel\Mcp\Server\ServerContext;
+use Laravel\Mcp\Server\Tool;
 use Laravel\Mcp\Transport\JsonRpcRequest;
 use Laravel\Mcp\Transport\JsonRpcResponse;
+use Tests\Fixtures\ArrayTransport;
+
+function parameterHeaderServer(): string
+{
+    $server = new class(new ArrayTransport) extends Server
+    {
+        public function __construct(Transport $transport)
+        {
+            parent::__construct($transport);
+
+            $this->tools = [new class extends Tool
+            {
+                protected string $name = 'parameter-header-tool';
+
+                protected array $parameterHeaders = ['region' => 'Region'];
+
+                public function schema(JsonSchema $schema): array
+                {
+                    return ['region' => $schema->string()->required()];
+                }
+
+                public function handle(): Response
+                {
+                    return Response::text('ok');
+                }
+            }];
+        }
+    };
+
+    return $server::class;
+}
 
 it('accepts a request whose headers mirror the body', function (): void {
     $response = $this->postJson('test-mcp', $message = callToolMessage(), mcpHeaders($message));
@@ -46,6 +83,40 @@ it('rejects a request whose header contradicts the body', function (): void {
         'code' => -32020,
         'message' => "Header mismatch: The [Mcp-Name] header value [some-other-tool] does not match the request body value [{$message['params']['name']}].",
     ]);
+});
+
+it('rejects a mirrored tool argument without its header', function (): void {
+    app(Registrar::class)->web('parameter-header-mcp', parameterHeaderServer());
+
+    $message = callToolMessage();
+    $message['params']['name'] = 'parameter-header-tool';
+    $message['params']['arguments'] = ['region' => 'us-west1'];
+
+    $response = $this->postJson('parameter-header-mcp', $message, mcpHeaders($message));
+
+    $response->assertStatus(400);
+
+    expect($response->json('error'))->toEqual([
+        'code' => -32020,
+        'message' => 'Header mismatch: The [Mcp-Param-Region] header is required.',
+    ]);
+});
+
+it('rejects a mirrored tool argument whose header contradicts the body', function (): void {
+    app(Registrar::class)->web('parameter-header-mismatch-mcp', parameterHeaderServer());
+
+    $message = callToolMessage();
+    $message['params']['name'] = 'parameter-header-tool';
+    $message['params']['arguments'] = ['region' => 'us-west1'];
+
+    $response = $this->postJson('parameter-header-mismatch-mcp', $message, [
+        ...mcpHeaders($message),
+        'Mcp-Param-Region' => 'eu-west1',
+    ]);
+
+    $response->assertStatus(400);
+
+    expect($response->json('error.code'))->toBe(-32020);
 });
 
 it('rejects a protocol version header that contradicts the body meta', function (): void {

--- a/tests/Unit/Support/ToolHeadersTest.php
+++ b/tests/Unit/Support/ToolHeadersTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Exceptions\ClientException;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Support\ToolHeaders;
+
+function schemaWith(array $properties): array
+{
+    return ['type' => 'object', 'properties' => $properties];
+}
+
+it('accepts a valid annotation', function (): void {
+    expect(ToolHeaders::invalid(schemaWith([
+        'region' => ['type' => 'string', 'x-mcp-header' => 'Region'],
+        'query' => ['type' => 'string'],
+    ])))->toBeNull();
+});
+
+it('accepts an annotation on a nested property', function (): void {
+    expect(ToolHeaders::invalid(schemaWith([
+        'target' => ['type' => 'object', 'properties' => [
+            'region' => ['type' => 'string', 'x-mcp-header' => 'Region'],
+        ]],
+    ])))->toBeNull();
+});
+
+it('rejects an invalid annotation', function (array $properties, string $reason): void {
+    expect(ToolHeaders::invalid(schemaWith($properties)))->toContain($reason);
+})->with([
+    'empty' => [['a' => ['type' => 'string', 'x-mcp-header' => '']], 'not a valid header name token'],
+    'space' => [['a' => ['type' => 'string', 'x-mcp-header' => 'My Header']], 'not a valid header name token'],
+    'newline' => [['a' => ['type' => 'string', 'x-mcp-header' => "Bad\nName"]], 'not a valid header name token'],
+    'not a string' => [['a' => ['type' => 'string', 'x-mcp-header' => 12]], 'not a valid header name token'],
+    'number type' => [['a' => ['type' => 'number', 'x-mcp-header' => 'A']], 'must sit on a string, integer, or boolean'],
+    'array type' => [['a' => ['type' => 'array', 'x-mcp-header' => 'A']], 'must sit on a string, integer, or boolean'],
+    'duplicate' => [[
+        'a' => ['type' => 'string', 'x-mcp-header' => 'Region'],
+        'b' => ['type' => 'string', 'x-mcp-header' => 'region'],
+    ], 'is used more than once'],
+]);
+
+it('rejects an annotation that is not statically reachable', function (): void {
+    expect(ToolHeaders::invalid([
+        'type' => 'object',
+        'properties' => [
+            'rows' => ['type' => 'array', 'items' => [
+                'type' => 'object',
+                'properties' => ['region' => ['type' => 'string', 'x-mcp-header' => 'Region']],
+            ]],
+        ],
+    ]))->toContain('outside the statically reachable properties');
+});
+
+it('extracts and encodes the annotated values', function (): void {
+    $schema = schemaWith([
+        'region' => ['type' => 'string', 'x-mcp-header' => 'Region'],
+        'limit' => ['type' => 'integer', 'x-mcp-header' => 'Limit'],
+        'dry' => ['type' => 'boolean', 'x-mcp-header' => 'Dry'],
+        'label' => ['type' => 'string', 'x-mcp-header' => 'Label'],
+        'query' => ['type' => 'string'],
+    ]);
+
+    expect(ToolHeaders::extract($schema, [
+        'region' => 'us-west1',
+        'limit' => 42,
+        'dry' => false,
+        'label' => 'Hello, 世界',
+        'query' => 'select 1',
+    ]))->toBe([
+        'Mcp-Param-Region' => 'us-west1',
+        'Mcp-Param-Limit' => '42',
+        'Mcp-Param-Dry' => 'false',
+        'Mcp-Param-Label' => '=?base64?'.base64_encode('Hello, 世界').'?=',
+    ]);
+});
+
+it('omits a header when the argument is absent or null', function (): void {
+    $schema = schemaWith([
+        'region' => ['type' => 'string', 'x-mcp-header' => 'Region'],
+        'zone' => ['type' => 'string', 'x-mcp-header' => 'Zone'],
+    ]);
+
+    expect(ToolHeaders::extract($schema, ['zone' => null]))->toBe([]);
+});
+
+it('extracts a nested value at its exact path', function (): void {
+    $schema = schemaWith([
+        'target' => ['type' => 'object', 'properties' => [
+            'region' => ['type' => 'string', 'x-mcp-header' => 'Region'],
+        ]],
+    ]);
+
+    expect(ToolHeaders::extract($schema, ['target' => ['region' => 'eu-west1']]))
+        ->toBe(['Mcp-Param-Region' => 'eu-west1']);
+});
+
+it('mirrors a declared tool argument into the schema annotation', function (): void {
+    $tool = new class extends Tool
+    {
+        protected string $name = 'execute-sql';
+
+        protected string $description = 'Runs SQL';
+
+        protected array $parameterHeaders = ['region' => 'Region'];
+
+        public function schema(JsonSchema $schema): array
+        {
+            return [
+                'region' => $schema->string()->required(),
+                'query' => $schema->string()->required(),
+            ];
+        }
+
+        public function handle(): Response
+        {
+            return Response::text('ok');
+        }
+    };
+
+    $schema = $tool->toArray()['inputSchema'];
+
+    expect($schema['properties']['region']['x-mcp-header'])->toBe('Region');
+    expect($schema['properties']['query'])->not->toHaveKey('x-mcp-header');
+    expect(ToolHeaders::invalid($schema))->toBeNull();
+});
+
+it('refuses to mirror an argument the schema does not define', function (): void {
+    $tool = new class extends Tool
+    {
+        protected string $name = 'execute-sql';
+
+        protected string $description = 'Runs SQL';
+
+        protected array $parameterHeaders = ['nope' => 'Nope'];
+
+        public function handle(): Response
+        {
+            return Response::text('ok');
+        }
+    };
+
+    expect(fn (): array => $tool->toArray())
+        ->toThrow(InvalidArgumentException::class, 'mirrors the unknown argument [nope]');
+});
+
+it('refuses to mirror an argument into an invalid header name', function (): void {
+    $tool = new class extends Tool
+    {
+        protected string $name = 'execute-sql';
+
+        protected string $description = 'Runs SQL';
+
+        protected array $parameterHeaders = ['region' => 'Bad Header'];
+
+        public function schema(JsonSchema $schema): array
+        {
+            return ['region' => $schema->string()->required()];
+        }
+
+        public function handle(): Response
+        {
+            return Response::text('ok');
+        }
+    };
+
+    expect(fn (): array => $tool->toArray())
+        ->toThrow(InvalidArgumentException::class, 'not a valid header name token');
+});
+
+it('rejects a header name with a trailing newline', function (): void {
+    expect(ToolHeaders::invalid(schemaWith([
+        'region' => ['type' => 'string', 'x-mcp-header' => "Region\n"],
+    ])))->toContain('is not a valid header name token');
+});
+
+it('allows an argument literally named after the annotation', function (): void {
+    expect(ToolHeaders::invalid(schemaWith([
+        'x-mcp-header' => ['type' => 'string'],
+        'region' => ['type' => 'string', 'x-mcp-header' => 'Region'],
+    ])))->toBeNull();
+});
+
+it('rejects an annotation hiding inside a keyword the client cannot reach', function (): void {
+    expect(ToolHeaders::invalid(schemaWith([
+        'region' => [
+            'type' => 'string',
+            'x-mcp-header' => 'Region',
+            'default' => ['x-mcp-header' => 'Sneaky'],
+        ],
+    ])))->toContain('outside the statically reachable properties');
+});
+
+it('refuses to mirror a value it cannot encode', function (): void {
+    expect(fn (): array => ToolHeaders::extract(schemaWith([
+        'region' => ['type' => 'string', 'x-mcp-header' => 'Region'],
+    ]), ['region' => 1.5]))
+        ->toThrow(ClientException::class, 'cannot be mirrored into a header');
+});


### PR DESCRIPTION
Network intermediaries — load balancers, proxies, WAFs — often need to route on one tool argument, but they cannot afford to parse a JSON-RPC body to find it. `2026-07-28` lets a server nominate arguments to be mirrored into `Mcp-Param-*` request headers so those hops can read them cheaply.

A tool names the arguments it wants mirrored:

```php
class ExecuteSql extends Tool
{
    protected array $parameterHeaders = ['region' => 'Region'];
}
```

The advertised schema then carries the annotation, which is what tells a client to send the header:

```json
"region": { "type": "string", "x-mcp-header": "Region" }
```

and a call with `"region": "us-west1"` is expected to arrive with `Mcp-Param-Region: us-west1`.

### Validating the annotation

`Support\ToolHeaders` enforces the spec's constraints on every advertised schema. A name must be a non-empty RFC 9110 field-name token, must be case-insensitively unique across the schema, must sit on a `string`, `integer`, or `boolean` — never `number` — and must be statically reachable from the schema root, so an annotation buried under `items` or a composition keyword is rejected. Integers outside the IEEE754 safe range cannot be mirrored.

The spec makes rejecting a malformed annotation the *client's* job, and a client that rejects one drops the whole tool from `tools/list`. Validating server-side instead means a bad annotation surfaces as an exception while building the schema, rather than as a tool that silently vanishes for conforming clients.

### Enforcing it on call

Over HTTP, `tools/call` now checks that each annotated argument present in the body arrived with a matching header, failing with `-32020` when one is missing or disagrees with the body. The check is routed from `CallTool` through `ServerContext` because the header middleware cannot reach the tool's schema. Other transports ignore the annotations entirely, which the spec permits.

Sensitive values should not be annotated — header values are visible to every hop in between.

### Spec

- [2026-07-28 changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
- [Tools: `x-mcp-header`](https://modelcontextprotocol.io/specification/2026-07-28/server/tools#x-mcp-header)
- [Custom headers from tool parameters](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http#custom-headers-from-tool-parameters)

Split out of #301, which now covers caching hints only. The client half that mirrors these arguments into request headers is #300, higher in this stack.

Credit to @JordanDalton, whose #275 mapped out the 2026-07-28 work.
