### PR TITLE
Document the migration to MCP 2026-07-28

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,184 @@
+# Upgrade Guide
+
+## Upgrading To 1.x From 0.x
+
+Laravel MCP 1.x implements MCP revision [`2026-07-28`](https://modelcontextprotocol.io/specification/2026-07-28). Existing server registrations, server classes, tools, prompts, resources, authentication middleware, and fluent server tests do not require structural changes.
+
+### MCP Client Compatibility
+
+**Likelihood Of Impact: High**
+
+Laravel MCP servers now support only MCP `2026-07-28`. Before upgrading a server, verify that every client connecting to it supports this protocol revision. Older clients that rely on `initialize`, `notifications/initialized`, `ping`, protocol sessions, or server-initiated requests cannot communicate with a Laravel MCP 1.x server.
+
+The Laravel MCP client remains compatible with `2025-11-25` and `2025-06-18` servers. It opens every connection with `server/discover`, as the specification requires of a client that spans both eras, and falls back to the `initialize` handshake only when the server's answer is not a recognized `2026-07-28` error. Modern servers therefore cost no extra requests. Opening the other way around would pin a server that speaks both eras to the older revision for the life of the connection, because such a server chooses its era from the client's first request. Timeouts, unavailable endpoints, and disconnected transports are surfaced as errors rather than treated as a legacy server.
+
+When the server answers with `UnsupportedProtocolVersionError`, or lists its versions through `server/discover`, the client picks a version both sides support and retries with that instead of guessing.
+
+You may pin the protocol version when the server type is known:
+
+```php
+use Laravel\Mcp\Enums\ProtocolVersion;
+use Laravel\Mcp\Facades\Mcp;
+
+Mcp::client('everything')->withProtocolVersion(ProtocolVersion::LATEST)->tools();
+Mcp::client('everything')->withProtocolVersion(ProtocolVersion::V2025_11_25)->tools();
+```
+
+Pinning a legacy version skips the `server/discover` probe and saves a round trip against a known `2025-11-25` or `2025-06-18` server. Pinning `ProtocolVersion::LATEST` states that the server is modern and skips the legacy fallback entirely. The resolved era is retained when reconnecting and is probed again only if the remembered assumption later fails. The client's `ping()` method remains available for legacy servers; Laravel MCP 1.x servers return a method-not-found error.
+
+For discovery connections, `initializeResult()` returns `null`. Use `discoverResult()` for the server's discovery response and `protocolVersion()` for the resolved protocol version.
+
+The `Laravel\Mcp\Server\Methods\Initialize` and `Laravel\Mcp\Server\Methods\Ping` classes have been removed. Applications that import these classes or register them in a custom `$methods` array should remove those registrations. Use the automatically registered `Laravel\Mcp\Server\Methods\Discover` method for modern server discovery.
+
+### Session APIs Have Been Removed
+
+**Likelihood Of Impact: Medium**
+
+MCP `2026-07-28` removes protocol-level sessions. Laravel MCP no longer issues or reads the `MCP-Session-Id` header. If your application uses the following APIs, update it as indicated:
+
+| Previous API | Upgrade path |
+| ------------ | ------------ |
+| `Request::sessionId()` | Pass an explicit state handle as a tool or prompt argument. |
+| `Request::setSessionId()` | Remove the call. |
+| `Server::generateSessionId()` | Remove the call. |
+| `SessionInitialized` event | Move the work into the tool, prompt, or resource that requires it. |
+| `Laravel\Mcp\Server\Contracts\Transport::sessionId()` | Remove the method and any reliance on session state. |
+| `Laravel\Mcp\Server\Contracts\Transport::send(string $message, ?string $sessionId)` | Use `send(string $message)`. |
+| `JsonRpcRequest::from(array $json, ?string $sessionId)` | Use `JsonRpcRequest::from(array $json)`. |
+| `JsonRpcRequest::__construct(..., ?string $sessionId)` | Remove the session argument. |
+| `Request::__construct(array $arguments, ?string $sessionId)` | The second argument is now `?array $meta`. |
+| `Laravel\Mcp\Server\Transport\HttpTransport::__construct($request, $sessionId)` | Use `HttpTransport::__construct($request)`. |
+| `Laravel\Mcp\Server\Transport\StdioTransport::__construct($sessionId)` | Use `StdioTransport::__construct()`. |
+
+Applications may remain stateful, but state must be represented explicitly rather than inferred from a connection. Treat state handles as identifiers, not authorization credentials, and authorize them against the current user on every request.
+
+Custom server transports should remove their reliance on session state. An implementation that retains an optional `$sessionId` argument on `send()` remains compatible with the contract, but Laravel MCP no longer supplies a session ID.
+
+### Custom Client Transports
+
+**Likelihood Of Impact: Low**
+
+Custom implementations of `Laravel\Mcp\Client\Contracts\Transport` must update their `send` method:
+
+```php
+public function send(string $message, array $headers = []): void;
+```
+
+The additional `$headers` contain generated header names and encoded values, such as `Mcp-Param-*` headers. Forward them unchanged. Custom HTTP transports are also responsible for generating the protocol headers described below from the current protocol version and JSON-RPC message. The first-party HTTP and stdio transports handle these requirements automatically.
+
+### Direct HTTP and JSON-RPC Integrations
+
+**Likelihood Of Impact: Low**
+
+No changes are required when using Laravel MCP's first-party server routes and client transports. Applications that send raw HTTP or JSON-RPC requests must account for the new stateless lifecycle.
+
+Every supported JSON-RPC method call must include the protocol version and client capabilities in `params._meta`. Client identity is optional but recommended:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/list",
+  "params": {
+    "_meta": {
+      "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+      "io.modelcontextprotocol/clientCapabilities": {},
+      "io.modelcontextprotocol/clientInfo": {
+        "name": "Acme Client",
+        "version": "1.0.0"
+      }
+    }
+  }
+}
+```
+
+A missing metadata member returns `-32602`, an unsupported protocol version returns `-32022`, and an operation that requires an undeclared client capability returns `-32021`.
+
+Non-`initialize` HTTP requests carrying an `id` must include `MCP-Protocol-Version` and `Mcp-Method`. Calls to `tools/call`, `prompts/get`, and `resources/read` must also include `Mcp-Name`; use the requested URI for `resources/read`. The mirrored headers must agree with the JSON-RPC body. Unsafe `Mcp-Name` and `Mcp-Param-*` values are encoded using the `=?base64?...?=` format. Requests should accept both `application/json` and `text/event-stream` responses.
+
+Laravel MCP rejects missing or contradictory headers with HTTP `400` and JSON-RPC error `-32020`. Method-not-found errors return HTTP `404`, internal errors return `500`, and other protocol errors return `400`. HTTP `GET` and `DELETE` requests to modern MCP endpoints return `405`.
+
+Interrupted SSE responses are not resumable. Reissue the operation with a new JSON-RPC request ID instead of using `Last-Event-ID`.
+
+### Response Metadata and Caching
+
+**Likelihood Of Impact: Low**
+
+Laravel MCP automatically adds `resultType` and server identity metadata to successful responses. Initial complete results from `server/discover`, `tools/list`, `prompts/list`, `resources/list`, `resources/templates/list`, and `resources/read` also contain `ttlMs` and `cacheScope`:
+
+```json
+{ "resultType": "complete", "ttlMs": 0, "cacheScope": "private", "tools": [] }
+```
+
+The package client accepts these fields automatically. Update strict response schemas, proxies, caches, and raw response assertions to accept them. Legacy results without `resultType` should be treated as complete results.
+
+The default cache settings are `ttlMs: 0` and `cacheScope: private`. They may be configured on the server:
+
+```php
+use Laravel\Mcp\Enums\CacheScope;
+use Laravel\Mcp\Server;
+
+class WeatherServer extends Server
+{
+    protected int $cacheTtlMs = 300000;
+
+    protected CacheScope $cacheScope = CacheScope::PUBLIC;
+}
+```
+
+Only use `CacheScope::PUBLIC` when every cacheable response is independent of the authenticated user, access token, and authorization context. The Laravel MCP client accepts cache hints but does not cache responses based on them.
+
+The error returned when `resources/read` cannot resolve a resource URI has also changed from `-32002` to `-32602`.
+
+### MCP Apps
+
+**Likelihood Of Impact: Low**
+
+Servers that register an `AppResource` continue to advertise MCP Apps support automatically. No changes are required for normal app resources or tools using `#[RendersApp]`.
+
+If your server manually advertises MCP Apps support, replace `Server::CAPABILITY_UI` with `Server::EXTENSION_UI` and register it as an extension:
+
+```php
+protected function boot(): void
+{
+    $this->addExtension(self::EXTENSION_UI);
+}
+```
+
+The advertisement now appears under `capabilities.extensions['io.modelcontextprotocol/ui']` instead of the top-level capabilities object.
+
+MCP Apps are an optional extension. Tools that render an app should continue returning meaningful core MCP content for clients that do not advertise the UI extension.
+
+### Change Notifications
+
+**Likelihood Of Impact: Low**
+
+`resources/subscribe`, `resources/unsubscribe`, and the standalone HTTP `GET` stream are removed. Change notifications are now delivered on a long-lived `subscriptions/listen` request instead.
+
+Laravel MCP never implemented the removed methods or the `GET` stream, and does not implement `subscriptions/listen`. The `resources` capability advertises neither `listChanged` nor `subscribe`, which the specification permits: servers may advertise either feature independently, together, or neither. No changes are required.
+
+### Tool Parameter Headers
+
+**Likelihood Of Impact: Low**
+
+Remote servers may annotate tool arguments with `x-mcp-header` to have their values mirrored into `Mcp-Param-*` request headers, so that intermediaries can route on them without parsing the request body. Supporting this is required of clients, so the Laravel MCP client mirrors annotated arguments automatically when calling such a tool.
+
+Mirrored arguments must resolve to `string`, `integer`, or `boolean` schema properties, and integer values must remain within JavaScript's safe integer range. When receiving remote tools, the Laravel MCP client omits tools with invalid `x-mcp-header` annotations and logs a warning instead of failing the entire tool list.
+
+Annotating arguments is optional for servers, and Laravel MCP servers do not currently do so. No changes are required to your own tools.
+
+### Authentication and Testing
+
+**Likelihood Of Impact: Low**
+
+Passport, Sanctum, route middleware, bearer tokens, authorization logic, and `Request::user()` continue to work without API changes. Because requests are stateless, authentication and authorization are evaluated independently for every request.
+
+The documented fluent helpers for testing tools, prompts, resources, and completions remain unchanged. Raw HTTP and JSON-RPC tests must include the new metadata and headers and should account for the new HTTP statuses and response fields described above.
+
+### Before Deploying
+
+- [ ] Verify every external client supports MCP `2026-07-28`.
+- [ ] Test web and local servers with the official [MCP Inspector](https://github.com/modelcontextprotocol/inspector).
+- [ ] Audit custom transports and raw protocol integrations for per-request metadata and HTTP headers.
+- [ ] Confirm state handles are authorized against the current user on every request.
+- [ ] Confirm public cache hints are not used for user-specific or authorization-specific responses.

--- a/src/Client.php
+++ b/src/Client.php
@@ -40,6 +40,9 @@ class Client
 
     protected ?ProtocolVersion $protocolVersion = null;
 
+    /** @var array<string, array<string, mixed>> */
+    protected array $toolSchemas = [];
+
     public function __construct(
         protected Transport $transport,
         public ?Implementation $clientInfo = null,
@@ -145,7 +148,13 @@ class Client
     public function tools(?int $limit = null, ?iterable $default = null): Collection
     {
         try {
-            return (new ListTools(client: $this, limit: $limit))->handle($this->protocol);
+            $tools = (new ListTools(client: $this, limit: $limit))->handle($this->protocol);
+
+            foreach ($tools as $tool) {
+                $this->toolSchemas[$tool->name] = $tool->inputSchema;
+            }
+
+            return $tools;
         } catch (AuthorizationRequiredException $authorizationRequiredException) {
             if ($default === null) {
                 throw $authorizationRequiredException;
@@ -157,10 +166,15 @@ class Client
 
     /**
      * @param  array<string, mixed>  $arguments
+     * @param  array<string, mixed>|null  $inputSchema
      */
-    public function callTool(string $name, array $arguments = []): ToolResult
+    public function callTool(string $name, array $arguments = [], ?array $inputSchema = null): ToolResult
     {
-        return (new CallTool($name, $arguments))->handle($this->protocol);
+        return (new CallTool(
+            $name,
+            $arguments,
+            $inputSchema ?? $this->toolSchemas[$name] ?? [],
+        ))->handle($this->protocol);
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,6 +20,7 @@ use Laravel\Mcp\Client\Primitives\Prompt;
 use Laravel\Mcp\Client\Primitives\Resource;
 use Laravel\Mcp\Client\Primitives\Tool;
 use Laravel\Mcp\Client\Protocol;
+use Laravel\Mcp\Client\Schema\DiscoverResult;
 use Laravel\Mcp\Client\Schema\InitializeResult;
 use Laravel\Mcp\Client\Schema\PromptResult;
 use Laravel\Mcp\Client\Schema\ResourceReadResult;
@@ -27,6 +28,8 @@ use Laravel\Mcp\Client\Schema\ToolResult;
 use Laravel\Mcp\Client\Transport\HttpTransport;
 use Laravel\Mcp\Client\Transport\StdioTransport;
 use Laravel\Mcp\Client\Transport\TransportFactory;
+use Laravel\Mcp\Enums\ProtocolVersion;
+use Laravel\Mcp\Exceptions\ClientException;
 use Laravel\Mcp\Schema\Implementation;
 
 class Client
@@ -35,13 +38,15 @@ class Client
 
     protected ?string $name = null;
 
+    protected ?ProtocolVersion $protocolVersion = null;
+
     public function __construct(
         protected Transport $transport,
         public ?Implementation $clientInfo = null,
     ) {
         $this->clientInfo = $clientInfo ?? $this->defaultClientInfo();
 
-        $this->protocol = new Protocol($this->transport, $this->clientInfo);
+        $this->protocol = new Protocol($this->transport, $this->clientInfo, $this->protocolVersion);
     }
 
     protected function defaultClientInfo(): Implementation
@@ -99,6 +104,33 @@ class Client
     public function initializeResult(): ?InitializeResult
     {
         return $this->protocol->initializeResult();
+    }
+
+    public function discoverResult(): ?DiscoverResult
+    {
+        return $this->protocol->discoverResult();
+    }
+
+    public function withProtocolVersion(?ProtocolVersion $version): static
+    {
+        if ($version instanceof ProtocolVersion && ! $version->usesDiscovery() && ! in_array($version->value, ProtocolVersion::clientSupported(), true)) {
+            throw new ClientException(sprintf(
+                'This client does not support protocol version [%s]. It supports [%s].',
+                $version->value,
+                implode(', ', [...ProtocolVersion::clientSupported(), ProtocolVersion::LATEST->value]),
+            ));
+        }
+
+        $this->protocolVersion = $version;
+
+        $this->protocol->protocolVersion($version);
+
+        return $this;
+    }
+
+    public function protocolVersion(): ?ProtocolVersion
+    {
+        return $this->protocol->resolvedProtocolVersion();
     }
 
     public function ping(): void
@@ -191,6 +223,7 @@ class Client
             'name' => null,
             'clientInfo' => $this->clientInfo,
             'transport' => $this->transport->recipe(),
+            'protocolVersion' => $this->protocolVersion?->value,
         ];
     }
 
@@ -206,14 +239,16 @@ class Client
 
             $this->transport = $resolved->transport;
             $this->clientInfo = $resolved->clientInfo;
+            $this->protocolVersion = $resolved->protocolVersion;
         } else {
             $this->clientInfo = $data['clientInfo'];
             $this->transport = TransportFactory::fromRecipe($data['transport']);
+            $this->protocolVersion = ProtocolVersion::tryFrom($data['protocolVersion'] ?? '');
         }
 
         $this->clientInfo ??= $this->defaultClientInfo();
 
-        $this->protocol = new Protocol($this->transport, $this->clientInfo);
+        $this->protocol = new Protocol($this->transport, $this->clientInfo, $this->protocolVersion);
     }
 
     public function __destruct()

--- a/src/Client.php
+++ b/src/Client.php
@@ -46,7 +46,7 @@ class Client
     ) {
         $this->clientInfo = $clientInfo ?? $this->defaultClientInfo();
 
-        $this->protocol = new Protocol($this->transport, $this->clientInfo, $this->protocolVersion);
+        $this->protocol = new Protocol($this->transport, $this->clientInfo);
     }
 
     protected function defaultClientInfo(): Implementation
@@ -113,11 +113,11 @@ class Client
 
     public function withProtocolVersion(?ProtocolVersion $version): static
     {
-        if ($version instanceof ProtocolVersion && ! $version->usesDiscovery() && ! in_array($version->value, ProtocolVersion::clientSupported(), true)) {
+        if ($version instanceof ProtocolVersion && ! in_array($version->value, ProtocolVersion::negotiable(), true)) {
             throw new ClientException(sprintf(
                 'This client does not support protocol version [%s]. It supports [%s].',
                 $version->value,
-                implode(', ', [...ProtocolVersion::clientSupported(), ProtocolVersion::LATEST->value]),
+                implode(', ', ProtocolVersion::negotiable()),
             ));
         }
 
@@ -130,7 +130,7 @@ class Client
 
     public function protocolVersion(): ?ProtocolVersion
     {
-        return $this->protocol->resolvedProtocolVersion();
+        return $this->protocol->resolvedProtocolVersion() ?? $this->protocolVersion;
     }
 
     public function ping(): void

--- a/src/Client/Contracts/MirrorsParameters.php
+++ b/src/Client/Contracts/MirrorsParameters.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\Contracts;
+
+interface MirrorsParameters
+{
+    /**
+     * @return array<string, string>
+     */
+    public function requestHeaders(): array;
+}

--- a/src/Client/Contracts/Transport.php
+++ b/src/Client/Contracts/Transport.php
@@ -10,7 +10,10 @@ interface Transport
 
     public function disconnect(): void;
 
-    public function send(string $message): void;
+    /**
+     * @param  array<string, string>  $headers
+     */
+    public function send(string $message, array $headers = []): void;
 
     public function receive(): string;
 

--- a/src/Client/Exceptions/RequestRejectedException.php
+++ b/src/Client/Exceptions/RequestRejectedException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\Exceptions;
+
+use Laravel\Mcp\Exceptions\ClientException;
+
+class RequestRejectedException extends ClientException
+{
+    //
+}

--- a/src/Client/Methods/Discover.php
+++ b/src/Client/Methods/Discover.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\Methods;
+
+use Laravel\Mcp\Client\Contracts\Method;
+use Laravel\Mcp\Client\Protocol;
+use Laravel\Mcp\Client\Schema\DiscoverResult;
+
+/**
+ * @implements Method<DiscoverResult>
+ */
+class Discover implements Method
+{
+    public function method(): string
+    {
+        return 'server/discover';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function params(): array
+    {
+        return [];
+    }
+
+    public function handle(Protocol $protocol): DiscoverResult
+    {
+        return DiscoverResult::from($protocol->dispatch($this));
+    }
+}

--- a/src/Client/Methods/Initialize.php
+++ b/src/Client/Methods/Initialize.php
@@ -15,8 +15,10 @@ use Laravel\Mcp\Schema\Implementation;
  */
 class Initialize implements Method
 {
-    public function __construct(protected Implementation $clientInfo)
-    {
+    public function __construct(
+        protected Implementation $clientInfo,
+        protected ProtocolVersion $protocolVersion = ProtocolVersion::V2025_11_25,
+    ) {
         //
     }
 
@@ -31,7 +33,7 @@ class Initialize implements Method
     public function params(): array
     {
         return [
-            'protocolVersion' => ProtocolVersion::V2025_11_25->value,
+            'protocolVersion' => $this->protocolVersion->value,
             'capabilities' => (object) [],
             'clientInfo' => $this->clientInfo->toArray(),
         ];

--- a/src/Client/Methods/Tools/CallTool.php
+++ b/src/Client/Methods/Tools/CallTool.php
@@ -5,22 +5,38 @@ declare(strict_types=1);
 namespace Laravel\Mcp\Client\Methods\Tools;
 
 use Laravel\Mcp\Client\Contracts\Method;
+use Laravel\Mcp\Client\Contracts\MirrorsParameters;
 use Laravel\Mcp\Client\Protocol;
 use Laravel\Mcp\Client\Schema\ToolResult;
+use Laravel\Mcp\Support\ToolHeaders;
 
 /**
  * @implements Method<ToolResult>
  */
-class CallTool implements Method
+class CallTool implements Method, MirrorsParameters
 {
     /**
      * @param  array<string, mixed>  $arguments
+     * @param  array<string, mixed>  $inputSchema
      */
     public function __construct(
         protected string $name,
         protected array $arguments = [],
+        protected array $inputSchema = [],
     ) {
         //
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function requestHeaders(): array
+    {
+        if ($this->inputSchema === [] || ToolHeaders::invalid($this->inputSchema) !== null) {
+            return [];
+        }
+
+        return ToolHeaders::extract($this->inputSchema, $this->arguments);
     }
 
     public function method(): string

--- a/src/Client/Methods/Tools/ListTools.php
+++ b/src/Client/Methods/Tools/ListTools.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Laravel\Mcp\Client\Methods\Tools;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
 use Laravel\Mcp\Client;
 use Laravel\Mcp\Client\Contracts\Method;
 use Laravel\Mcp\Client\Methods\Concerns\PaginatesList;
 use Laravel\Mcp\Client\Primitives\Tool;
+use Laravel\Mcp\Support\ToolHeaders;
 
 /**
  * @implements Method<Collection<string, Tool>>
@@ -42,10 +44,19 @@ class ListTools implements Method
      */
     protected function hydrate(array $payloads): Collection
     {
-        return collect($payloads)->mapWithKeys(function (array $payload): array {
-            $tool = Tool::from($this->client, $payload);
+        return collect($payloads)
+            ->map(fn (array $payload): Tool => Tool::from($this->client, $payload))
+            ->reject(function (Tool $tool): bool {
+                $reason = ToolHeaders::invalid($tool->inputSchema);
 
-            return [$tool->name => $tool];
-        });
+                if ($reason === null) {
+                    return false;
+                }
+
+                Log::warning("Excluded the MCP tool [{$tool->name}] from the tool list because {$reason}.");
+
+                return true;
+            })
+            ->mapWithKeys(fn (Tool $tool): array => [$tool->name => $tool]);
     }
 }

--- a/src/Client/Primitives/Tool.php
+++ b/src/Client/Primitives/Tool.php
@@ -74,6 +74,6 @@ class Tool
             throw new ClientException("Tool [{$this->name}] is not bound to a client.");
         }
 
-        return $this->client->callTool($this->name, $arguments);
+        return $this->client->callTool($this->name, $arguments, $this->inputSchema);
     }
 }

--- a/src/Client/Protocol.php
+++ b/src/Client/Protocol.php
@@ -7,6 +7,7 @@ namespace Laravel\Mcp\Client;
 use Illuminate\Support\Arr;
 use JsonException;
 use Laravel\Mcp\Client\Contracts\Method;
+use Laravel\Mcp\Client\Contracts\MirrorsParameters;
 use Laravel\Mcp\Client\Contracts\Transport;
 use Laravel\Mcp\Client\Exceptions\RequestRejectedException;
 use Laravel\Mcp\Client\Methods\Discover;
@@ -253,7 +254,10 @@ class Protocol
         );
 
         try {
-            $this->transport->send($request->toJson());
+            $this->transport->send(
+                $request->toJson(),
+                $method instanceof MirrorsParameters ? $method->requestHeaders() : [],
+            );
 
             do {
                 $raw = $this->transport->receive();

--- a/src/Client/Protocol.php
+++ b/src/Client/Protocol.php
@@ -103,35 +103,47 @@ class Protocol
     {
         $version = $this->protocolVersion ?? $this->resolvedProtocolVersion;
 
-        if ($version?->usesDiscovery()) {
-            $this->discover();
-
-            return;
-        }
-
         if ($version instanceof ProtocolVersion) {
-            $this->initialize($version);
+            $version->usesDiscovery()
+                ? $this->discover()
+                : $this->initialize($version);
 
             return;
         }
 
         try {
-            $this->initialize(ProtocolVersion::V2025_11_25);
+            $this->discover();
 
             return;
         } catch (JsonRpcException $jsonRpcException) {
-            if (! $this->suggestsDiscovery($jsonRpcException)) {
-                throw $jsonRpcException;
+            if ($this->identifiesModernServer($jsonRpcException)) {
+                $this->retryWithMutualVersion($jsonRpcException);
+
+                return;
             }
-        } catch (RequestRejectedException) {
-            //
+
+            $rejection = null;
+        } catch (RequestRejectedException $requestRejectedException) {
+            $rejection = $requestRejectedException;
         }
 
-        $this->discover();
+        try {
+            $this->initialize(ProtocolVersion::V2025_11_25);
+        } catch (Throwable $throwable) {
+            throw $rejection instanceof RequestRejectedException
+                ? new ClientException(sprintf(
+                    '%s The legacy handshake also failed: %s',
+                    $rejection->getMessage(),
+                    $throwable->getMessage(),
+                ), 0, $throwable)
+                : $throwable;
+        }
     }
 
     protected function initialize(ProtocolVersion $version): void
     {
+        $this->resolvedProtocolVersion = null;
+
         $this->transport->setProtocolVersion($version->value);
 
         $this->initializeResult = (new Initialize($this->clientInfo, $version))->handle($this);
@@ -149,21 +161,53 @@ class Protocol
 
         $this->transport->setProtocolVersion(ProtocolVersion::LATEST->value);
 
-        $this->discoverResult = (new Discover)->handle($this);
+        try {
+            $this->discoverResult = (new Discover)->handle($this);
 
-        if (! in_array(ProtocolVersion::LATEST->value, $this->discoverResult->supportedVersions, true)) {
-            throw new ClientException(sprintf(
-                'The server does not support protocol version [%s]. It supports [%s].',
-                ProtocolVersion::LATEST->value,
-                implode(', ', $this->discoverResult->supportedVersions),
-            ));
+            $version = ProtocolVersion::mutual($this->discoverResult->supportedVersions);
+
+            if (! $version instanceof ProtocolVersion) {
+                throw new ClientException(sprintf(
+                    'The server supports protocol versions [%s]. This client supports [%s].',
+                    implode(', ', $this->discoverResult->supportedVersions),
+                    implode(', ', ProtocolVersion::negotiable()),
+                ));
+            }
+        } catch (Throwable $throwable) {
+            $this->resolvedProtocolVersion = null;
+
+            throw $throwable;
         }
+
+        if (! $version->usesDiscovery()) {
+            $this->initialize($version);
+
+            return;
+        }
+
+        $this->resolvedProtocolVersion = $version;
+
+        $this->transport->setProtocolVersion($version->value);
     }
 
-    protected function suggestsDiscovery(JsonRpcException $jsonRpcException): bool
+    protected function retryWithMutualVersion(JsonRpcException $jsonRpcException): void
+    {
+        $supported = $jsonRpcException->data()['supported'] ?? null;
+
+        $version = is_array($supported)
+            ? ProtocolVersion::mutual(array_values(array_filter($supported, is_string(...))))
+            : null;
+
+        if (! $version instanceof ProtocolVersion || $version->usesDiscovery()) {
+            throw $jsonRpcException;
+        }
+
+        $this->initialize($version);
+    }
+
+    protected function identifiesModernServer(JsonRpcException $jsonRpcException): bool
     {
         return in_array($jsonRpcException->getCode(), [
-            ErrorCode::METHOD_NOT_FOUND->value,
             ErrorCode::HEADER_MISMATCH->value,
             ErrorCode::MISSING_REQUIRED_CLIENT_CAPABILITY->value,
             ErrorCode::UNSUPPORTED_PROTOCOL_VERSION->value,

--- a/src/Client/Protocol.php
+++ b/src/Client/Protocol.php
@@ -8,8 +8,14 @@ use Illuminate\Support\Arr;
 use JsonException;
 use Laravel\Mcp\Client\Contracts\Method;
 use Laravel\Mcp\Client\Contracts\Transport;
+use Laravel\Mcp\Client\Exceptions\RequestRejectedException;
+use Laravel\Mcp\Client\Methods\Discover;
 use Laravel\Mcp\Client\Methods\Initialize;
+use Laravel\Mcp\Client\Schema\DiscoverResult;
 use Laravel\Mcp\Client\Schema\InitializeResult;
+use Laravel\Mcp\Enums\ErrorCode;
+use Laravel\Mcp\Enums\MetaKey;
+use Laravel\Mcp\Enums\ProtocolVersion;
 use Laravel\Mcp\Exceptions\ClientException;
 use Laravel\Mcp\Exceptions\JsonRpcException;
 use Laravel\Mcp\Exceptions\SessionExpiredException;
@@ -29,9 +35,14 @@ class Protocol
 
     protected ?InitializeResult $initializeResult = null;
 
+    protected ?DiscoverResult $discoverResult = null;
+
+    protected ?ProtocolVersion $resolvedProtocolVersion = null;
+
     public function __construct(
         protected Transport $transport,
         protected Implementation $clientInfo,
+        protected ?ProtocolVersion $protocolVersion = null,
     ) {
         //
     }
@@ -46,6 +57,26 @@ class Protocol
         return $this->initializeResult;
     }
 
+    public function discoverResult(): ?DiscoverResult
+    {
+        return $this->discoverResult;
+    }
+
+    public function protocolVersion(?ProtocolVersion $protocolVersion): void
+    {
+        $this->protocolVersion = $protocolVersion;
+        $this->resolvedProtocolVersion = null;
+
+        if ($this->connected) {
+            $this->disconnect();
+        }
+    }
+
+    public function resolvedProtocolVersion(): ?ProtocolVersion
+    {
+        return $this->resolvedProtocolVersion;
+    }
+
     public function connect(): void
     {
         if ($this->connected) {
@@ -56,11 +87,7 @@ class Protocol
         $this->connecting = true;
 
         try {
-            $this->initializeResult = (new Initialize($this->clientInfo))->handle($this);
-
-            $this->transport->setProtocolVersion($this->initializeResult->protocolVersion);
-
-            $this->notify('notifications/initialized');
+            $this->handshake();
         } catch (Throwable $throwable) {
             $this->disconnect();
 
@@ -70,6 +97,77 @@ class Protocol
         }
 
         $this->connected = true;
+    }
+
+    protected function handshake(): void
+    {
+        $version = $this->protocolVersion ?? $this->resolvedProtocolVersion;
+
+        if ($version?->usesDiscovery()) {
+            $this->discover();
+
+            return;
+        }
+
+        if ($version instanceof ProtocolVersion) {
+            $this->initialize($version);
+
+            return;
+        }
+
+        try {
+            $this->initialize(ProtocolVersion::V2025_11_25);
+
+            return;
+        } catch (JsonRpcException $jsonRpcException) {
+            if (! $this->suggestsDiscovery($jsonRpcException)) {
+                throw $jsonRpcException;
+            }
+        } catch (RequestRejectedException) {
+            //
+        }
+
+        $this->discover();
+    }
+
+    protected function initialize(ProtocolVersion $version): void
+    {
+        $this->transport->setProtocolVersion($version->value);
+
+        $this->initializeResult = (new Initialize($this->clientInfo, $version))->handle($this);
+
+        $this->resolvedProtocolVersion = ProtocolVersion::from($this->initializeResult->protocolVersion);
+
+        $this->transport->setProtocolVersion($this->initializeResult->protocolVersion);
+
+        $this->notify('notifications/initialized');
+    }
+
+    protected function discover(): void
+    {
+        $this->resolvedProtocolVersion = ProtocolVersion::LATEST;
+
+        $this->transport->setProtocolVersion(ProtocolVersion::LATEST->value);
+
+        $this->discoverResult = (new Discover)->handle($this);
+
+        if (! in_array(ProtocolVersion::LATEST->value, $this->discoverResult->supportedVersions, true)) {
+            throw new ClientException(sprintf(
+                'The server does not support protocol version [%s]. It supports [%s].',
+                ProtocolVersion::LATEST->value,
+                implode(', ', $this->discoverResult->supportedVersions),
+            ));
+        }
+    }
+
+    protected function suggestsDiscovery(JsonRpcException $jsonRpcException): bool
+    {
+        return in_array($jsonRpcException->getCode(), [
+            ErrorCode::METHOD_NOT_FOUND->value,
+            ErrorCode::HEADER_MISMATCH->value,
+            ErrorCode::MISSING_REQUIRED_CLIENT_CAPABILITY->value,
+            ErrorCode::UNSUPPORTED_PROTOCOL_VERSION->value,
+        ], true);
     }
 
     public function disconnect(): void
@@ -107,7 +205,7 @@ class Protocol
         $request = new JsonRpcRequest(
             id: $this->nextRequestId++,
             method: $method->method(),
-            params: $method->params(),
+            params: $this->params($method),
         );
 
         try {
@@ -168,6 +266,28 @@ class Protocol
         $result = Arr::get($response, 'result');
 
         return is_array($result) ? $result : [];
+    }
+
+    /**
+     * @param  Method<mixed>  $method
+     * @return array<string, mixed>
+     */
+    protected function params(Method $method): array
+    {
+        $params = $method->params();
+
+        if (! $this->resolvedProtocolVersion?->usesDiscovery()) {
+            return $params;
+        }
+
+        $params['_meta'] = [
+            MetaKey::PROTOCOL_VERSION->value => ProtocolVersion::LATEST->value,
+            MetaKey::CLIENT_CAPABILITIES->value => (object) [],
+            MetaKey::CLIENT_INFO->value => $this->clientInfo->toArray(),
+            ...is_array($params['_meta'] ?? null) ? $params['_meta'] : [],
+        ];
+
+        return $params;
     }
 
     public function notify(string $method): void

--- a/src/Client/Schema/DiscoverResult.php
+++ b/src/Client/Schema/DiscoverResult.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Client\Schema;
+
+use Illuminate\Support\Arr;
+use Laravel\Mcp\Enums\MetaKey;
+use Laravel\Mcp\Exceptions\ClientException;
+use Laravel\Mcp\Schema\Implementation;
+
+class DiscoverResult
+{
+    /**
+     * @param  array<int, string>  $supportedVersions
+     * @param  array<string, mixed>  $capabilities
+     */
+    public function __construct(
+        public array $supportedVersions,
+        public array $capabilities,
+        public ?Implementation $serverInfo = null,
+        public ?string $instructions = null,
+    ) {
+        //
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public static function from(array $payload): self
+    {
+        $supportedVersions = Arr::get($payload, 'supportedVersions');
+        $capabilities = Arr::get($payload, 'capabilities');
+        $instructions = Arr::get($payload, 'instructions');
+        $meta = Arr::get($payload, '_meta');
+
+        if (! is_array($supportedVersions) || ! is_array($capabilities)) {
+            throw new ClientException('Invalid discover response from server.');
+        }
+
+        return new self(
+            supportedVersions: array_values(array_filter($supportedVersions, is_string(...))),
+            capabilities: $capabilities,
+            serverInfo: Implementation::tryFrom(is_array($meta) ? ($meta[MetaKey::SERVER_INFO->value] ?? null) : null),
+            instructions: is_string($instructions) ? $instructions : null,
+        );
+    }
+}

--- a/src/Client/Schema/InitializeResult.php
+++ b/src/Client/Schema/InitializeResult.php
@@ -30,27 +30,25 @@ class InitializeResult
     {
         $protocolVersion = Arr::get($payload, 'protocolVersion');
         $capabilities = Arr::get($payload, 'capabilities');
-        /** @var array{name: string, version: string, title?: string, description?: string, icons?: array<int, array{src: string, mimeType?: string, sizes?: array<string>, theme?: string}>, websiteUrl?: string} $serverInfo */
-        $serverInfo = Arr::get($payload, 'serverInfo');
-        $serverName = Arr::get($serverInfo, 'name');
-        $serverVersion = Arr::get($serverInfo, 'version');
+        $serverInfo = Implementation::tryFrom(Arr::get($payload, 'serverInfo'));
         $instructions = Arr::get($payload, 'instructions');
 
         if (! is_string($protocolVersion) || ! in_array($protocolVersion, ProtocolVersion::clientSupported(), true)) {
-            throw new ClientException('The server negotiated an unsupported protocol version.');
+            throw new ClientException(sprintf(
+                'The server chose protocol version [%s]. This client supports [%s].',
+                is_string($protocolVersion) ? $protocolVersion : 'none',
+                implode(', ', ProtocolVersion::clientSupported()),
+            ));
         }
 
-        if (! is_array($capabilities)
-            || ! is_array($serverInfo)
-            || ! is_string($serverName)
-            || ! is_string($serverVersion)) {
+        if (! is_array($capabilities) || ! $serverInfo instanceof Implementation) {
             throw new ClientException('Invalid initialize response from server.');
         }
 
         return new self(
             protocolVersion: $protocolVersion,
             capabilities: $capabilities,
-            serverInfo: Implementation::from($serverInfo),
+            serverInfo: $serverInfo,
             instructions: is_string($instructions) ? $instructions : null,
         );
     }

--- a/src/Client/Transport/HttpTransport.php
+++ b/src/Client/Transport/HttpTransport.php
@@ -11,16 +11,21 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use Laravel\Mcp\Client\Contracts\Transport;
 use Laravel\Mcp\Client\Exceptions\AuthorizationRequiredException;
+use Laravel\Mcp\Client\Exceptions\RequestRejectedException;
 use Laravel\Mcp\Client\OAuth\WwwAuthenticateChallenge;
 use Laravel\Mcp\Enums\ProtocolVersion;
+use Laravel\Mcp\Enums\RequestHeader;
 use Laravel\Mcp\Exceptions\ClientException;
 use Laravel\Mcp\Exceptions\SessionExpiredException;
+use Laravel\Mcp\Transport\JsonRpcRequest;
 use Psr\Http\Message\StreamInterface;
 use SensitiveParameter;
 use Throwable;
 
 class HttpTransport implements Transport
 {
+    protected const REJECTED_STATUSES = [400, 405, 501];
+
     /** @var string|(Closure(): string)|null */
     protected string|Closure|null $token = null;
 
@@ -97,10 +102,13 @@ class HttpTransport implements Transport
 
     public function send(string $message): void
     {
+        $body = json_decode($message, true);
+        $body = is_array($body) ? $body : [];
+
         $hadSession = $this->sessionId !== null;
 
         try {
-            $response = Http::withHeaders($this->headers())
+            $response = Http::withHeaders($this->headers($body))
                 ->withBody($message, 'application/json')
                 ->timeout($this->timeoutSeconds)
                 ->withOptions(['stream' => true])
@@ -129,6 +137,18 @@ class HttpTransport implements Transport
         }
 
         if (! $response->successful()) {
+            if ($this->hasJsonRpcError($response)) {
+                $this->queue[] = trim($response->body());
+
+                return;
+            }
+
+            if (in_array($response->status(), self::REJECTED_STATUSES, true)) {
+                $this->reset();
+
+                throw new RequestRejectedException("The endpoint [{$this->url}] rejected the request with HTTP status [{$response->status()}].");
+            }
+
             $this->failWith("Unexpected HTTP status [{$response->status()}] from endpoint [{$this->url}].");
         }
 
@@ -140,13 +160,13 @@ class HttpTransport implements Transport
             return;
         }
 
-        $body = trim($response->body());
+        $content = trim($response->body());
 
-        if ($response->accepted() || $body === '') {
+        if ($response->accepted() || $content === '') {
             return;
         }
 
-        $this->queue[] = $body;
+        $this->queue[] = $content;
     }
 
     public function setProtocolVersion(string $version): void
@@ -170,21 +190,38 @@ class HttpTransport implements Transport
         $this->disconnect();
     }
 
+    protected function usesDiscovery(): bool
+    {
+        return ProtocolVersion::tryFrom($this->protocolVersion ?? '')?->usesDiscovery() ?? false;
+    }
+
+    protected function hasJsonRpcError(ClientResponse $response): bool
+    {
+        $body = json_decode($response->body(), true);
+
+        return is_array($body) && is_array($body['error'] ?? null);
+    }
+
     /**
+     * @param  array<string, mixed>  $body
      * @return array<string, string>
      */
-    protected function headers(): array
+    protected function headers(array $body = []): array
     {
         $headers = [
             'Accept' => 'application/json, text/event-stream',
         ];
 
-        if ($this->sessionId !== null) {
+        if ($this->sessionId !== null && ! $this->usesDiscovery()) {
             $headers['MCP-Session-Id'] = $this->sessionId;
         }
 
-        if ($this->initialized) {
-            $headers['MCP-Protocol-Version'] = $this->protocolVersion ?? ProtocolVersion::V2025_11_25->value;
+        if (($this->initialized || $this->usesDiscovery()) && ($body['method'] ?? null) !== 'initialize') {
+            $headers[RequestHeader::PROTOCOL_VERSION->value] = $this->protocolVersion ?? ProtocolVersion::V2025_11_25->value;
+        }
+
+        if ($this->usesDiscovery()) {
+            $headers = array_merge($headers, $this->mirroredHeaders($body));
         }
 
         $token = $this->token instanceof Closure ? (string) ($this->token)() : $this->token;
@@ -206,8 +243,29 @@ class HttpTransport implements Transport
         return $headers;
     }
 
+    /**
+     * @param  array<string, mixed>  $body
+     * @return array<string, string>
+     */
+    protected function mirroredHeaders(array $body): array
+    {
+        if (! isset($body['id']) || ! is_string($body['method'] ?? null)) {
+            return [];
+        }
+
+        return (new JsonRpcRequest(
+            id: is_int($body['id']) || is_string($body['id']) ? $body['id'] : 0,
+            method: $body['method'],
+            params: is_array($body['params'] ?? null) ? $body['params'] : [],
+        ))->mirroredHeaders();
+    }
+
     protected function captureSessionId(ClientResponse $response): void
     {
+        if ($this->usesDiscovery()) {
+            return;
+        }
+
         $sessionId = $response->header('MCP-Session-Id');
 
         if ($sessionId !== '') {

--- a/src/Client/Transport/HttpTransport.php
+++ b/src/Client/Transport/HttpTransport.php
@@ -100,7 +100,10 @@ class HttpTransport implements Transport
         ];
     }
 
-    public function send(string $message): void
+    /**
+     * @param  array<string, string>  $headers
+     */
+    public function send(string $message, array $headers = []): void
     {
         $body = json_decode($message, true);
         $body = is_array($body) ? $body : [];
@@ -108,7 +111,7 @@ class HttpTransport implements Transport
         $hadSession = $this->sessionId !== null;
 
         try {
-            $response = Http::withHeaders($this->headers($body))
+            $response = Http::withHeaders($this->headers($body, $headers))
                 ->withBody($message, 'application/json')
                 ->timeout($this->timeoutSeconds)
                 ->withOptions(['stream' => true])
@@ -204,9 +207,10 @@ class HttpTransport implements Transport
 
     /**
      * @param  array<string, mixed>  $body
+     * @param  array<string, string>  $mirrored
      * @return array<string, string>
      */
-    protected function headers(array $body = []): array
+    protected function headers(array $body = [], array $mirrored = []): array
     {
         $headers = [
             'Accept' => 'application/json, text/event-stream',
@@ -221,7 +225,7 @@ class HttpTransport implements Transport
         }
 
         if ($this->usesDiscovery()) {
-            $headers = array_merge($headers, $this->mirroredHeaders($body));
+            $headers = array_merge($headers, $this->mirroredHeaders($body), $mirrored);
         }
 
         $token = $this->token instanceof Closure ? (string) ($this->token)() : $this->token;

--- a/src/Client/Transport/StdioTransport.php
+++ b/src/Client/Transport/StdioTransport.php
@@ -83,7 +83,10 @@ class StdioTransport implements Transport
         ];
     }
 
-    public function send(string $message): void
+    /**
+     * @param  array<string, string>  $headers
+     */
+    public function send(string $message, array $headers = []): void
     {
         if (! $this->input instanceof InputStream || ! $this->process?->isRunning()) {
             throw new ClientException('Transport is not connected.');

--- a/src/Enums/MetaKey.php
+++ b/src/Enums/MetaKey.php
@@ -8,5 +8,6 @@ enum MetaKey: string
 {
     case PROTOCOL_VERSION = 'io.modelcontextprotocol/protocolVersion';
     case CLIENT_CAPABILITIES = 'io.modelcontextprotocol/clientCapabilities';
+    case CLIENT_INFO = 'io.modelcontextprotocol/clientInfo';
     case SERVER_INFO = 'io.modelcontextprotocol/serverInfo';
 }

--- a/src/Enums/ProtocolVersion.php
+++ b/src/Enums/ProtocolVersion.php
@@ -14,6 +14,11 @@ enum ProtocolVersion: string
 
     public const LATEST = self::V2026_07_28;
 
+    public function usesDiscovery(): bool
+    {
+        return $this->value >= self::V2026_07_28->value;
+    }
+
     /**
      * @return array<int, string>
      */

--- a/src/Enums/ProtocolVersion.php
+++ b/src/Enums/ProtocolVersion.php
@@ -37,4 +37,26 @@ enum ProtocolVersion: string
             self::V2025_06_18->value,
         ];
     }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function negotiable(): array
+    {
+        return [self::LATEST->value, ...self::clientSupported()];
+    }
+
+    /**
+     * @param  array<int, string>  $supported
+     */
+    public static function mutual(array $supported): ?self
+    {
+        foreach (self::negotiable() as $version) {
+            if (in_array($version, $supported, true)) {
+                return self::from($version);
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/Exceptions/JsonRpcException.php
+++ b/src/Exceptions/JsonRpcException.php
@@ -21,6 +21,14 @@ class JsonRpcException extends Exception
         parent::__construct($message, $code);
     }
 
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function data(): ?array
+    {
+        return $this->data;
+    }
+
     public function toJsonRpcResponse(): JsonRpcResponse
     {
         $id = is_string($this->requestId) || is_int($this->requestId)

--- a/src/Schema/Implementation.php
+++ b/src/Schema/Implementation.php
@@ -38,6 +38,16 @@ class Implementation
         ]);
     }
 
+    public static function tryFrom(mixed $data): ?self
+    {
+        if (! is_array($data) || ! is_string($data['name'] ?? null) || ! is_string($data['version'] ?? null)) {
+            return null;
+        }
+
+        /** @var array{name: string, version: string, title?: string, description?: string, icons?: array<int, array{src: string, mimeType?: string, sizes?: array<string>, theme?: string}>, websiteUrl?: string} $data */
+        return self::from($data);
+    }
+
     /**
      * @param  array{
      *     name: string,

--- a/src/Support/ToolHeaders.php
+++ b/src/Support/ToolHeaders.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Support;
+
+use Laravel\Mcp\Exceptions\ClientException;
+use Laravel\Mcp\Transport\HeaderValue;
+
+class ToolHeaders
+{
+    public const ANNOTATION = 'x-mcp-header';
+
+    public const PREFIX = 'Mcp-Param-';
+
+    protected const SAFE_INTEGER = 9007199254740991;
+
+    /**
+     * @param  array<string, mixed>  $inputSchema
+     */
+    public static function invalid(array $inputSchema): ?string
+    {
+        $seen = [];
+
+        foreach (self::annotated($inputSchema) as $path => $name) {
+            if (! is_string($name) || preg_match('/^[!#$%&\'*+\-.^_`|~0-9A-Za-z]+$/D', $name) !== 1) {
+                return 'the ['.self::ANNOTATION."] value on [{$path}] is not a valid header name token";
+            }
+
+            $lowered = strtolower($name);
+
+            if (isset($seen[$lowered])) {
+                return 'the ['.self::ANNOTATION."] value [{$name}] is used more than once";
+            }
+
+            $seen[$lowered] = true;
+        }
+
+        foreach (self::annotatedSchemas($inputSchema) as $path => $schema) {
+            $type = $schema['type'] ?? null;
+
+            if (! in_array($type, ['string', 'integer', 'boolean'], true)) {
+                return 'the ['.self::ANNOTATION."] annotation on [{$path}] must sit on a string, integer, or boolean";
+            }
+        }
+
+        if (self::unreachable($inputSchema)) {
+            return 'an ['.self::ANNOTATION.'] annotation sits outside the statically reachable properties';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $inputSchema
+     * @param  array<string, mixed>  $arguments
+     * @return array<string, string>
+     */
+    public static function extract(array $inputSchema, array $arguments): array
+    {
+        $headers = [];
+
+        foreach (self::annotated($inputSchema) as $path => $name) {
+            $value = self::valueAt($arguments, explode('.', $path));
+            if ($value === null) {
+                continue;
+            }
+
+            if (! self::encodable($value)) {
+                throw new ClientException(
+                    "The [{$path}] argument is annotated with [".self::ANNOTATION.'] but its value cannot be mirrored into a header.',
+                );
+            }
+
+            $headers[self::PREFIX.$name] = (string) new HeaderValue(self::stringify($value));
+        }
+
+        return $headers;
+    }
+
+    /**
+     * @param  array<string, mixed>  $inputSchema
+     * @return array<string, mixed>
+     */
+    protected static function annotated(array $inputSchema, string $prefix = ''): array
+    {
+        $names = [];
+
+        foreach (self::properties($inputSchema) as $key => $schema) {
+            $path = $prefix === '' ? (string) $key : $prefix.'.'.$key;
+
+            if (array_key_exists(self::ANNOTATION, $schema)) {
+                $names[$path] = $schema[self::ANNOTATION];
+            }
+
+            $names = [...$names, ...self::annotated($schema, $path)];
+        }
+
+        return $names;
+    }
+
+    /**
+     * @param  array<string, mixed>  $inputSchema
+     * @return array<string, array<string, mixed>>
+     */
+    protected static function annotatedSchemas(array $inputSchema, string $prefix = ''): array
+    {
+        $schemas = [];
+
+        foreach (self::properties($inputSchema) as $key => $schema) {
+            $path = $prefix === '' ? (string) $key : $prefix.'.'.$key;
+
+            if (array_key_exists(self::ANNOTATION, $schema)) {
+                $schemas[$path] = $schema;
+            }
+
+            $schemas = [...$schemas, ...self::annotatedSchemas($schema, $path)];
+        }
+
+        return $schemas;
+    }
+
+    /**
+     * @param  array<string, mixed>  $schema
+     * @return array<array-key, array<string, mixed>>
+     */
+    protected static function properties(array $schema): array
+    {
+        $properties = $schema['properties'] ?? null;
+
+        if (! is_array($properties)) {
+            return [];
+        }
+
+        return array_filter($properties, is_array(...));
+    }
+
+    /**
+     * @param  array<string, mixed>  $schema
+     */
+    protected static function unreachable(array $schema): bool
+    {
+        foreach ($schema as $key => $value) {
+            if ($key === self::ANNOTATION) {
+                return true;
+            }
+
+            if (! is_array($value)) {
+                continue;
+            }
+
+            if ($key !== 'properties') {
+                if (self::containsAnnotation($value)) {
+                    return true;
+                }
+
+                continue;
+            }
+
+            foreach ($value as $child) {
+                if (! is_array($child)) {
+                    continue;
+                }
+
+                unset($child[self::ANNOTATION]);
+
+                if (self::unreachable($child)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $schema
+     */
+    protected static function containsAnnotation(array $schema): bool
+    {
+        foreach ($schema as $key => $value) {
+            if ($key === self::ANNOTATION) {
+                return true;
+            }
+
+            if (is_array($value) && self::containsAnnotation($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     * @param  array<int, string>  $path
+     */
+    protected static function valueAt(array $arguments, array $path): mixed
+    {
+        $value = $arguments;
+
+        foreach ($path as $segment) {
+            if (! is_array($value) || ! array_key_exists($segment, $value)) {
+                return null;
+            }
+
+            $value = $value[$segment];
+        }
+
+        return $value;
+    }
+
+    protected static function encodable(mixed $value): bool
+    {
+        if (is_bool($value) || is_string($value)) {
+            return true;
+        }
+
+        return is_int($value) && abs($value) <= self::SAFE_INTEGER;
+    }
+
+    protected static function stringify(string|int|bool $value): string
+    {
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        return (string) $value;
+    }
+}

--- a/tests/Feature/Client/HandshakeNegotiationTest.php
+++ b/tests/Feature/Client/HandshakeNegotiationTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Mcp\Client;
+use Laravel\Mcp\Enums\ProtocolVersion;
+use Laravel\Mcp\Enums\RequestHeader;
+use Laravel\Mcp\Exceptions\ClientException;
+use Laravel\Mcp\Exceptions\JsonRpcException;
+use Laravel\Mcp\Transport\HeaderValue;
+
+function headerMismatchResponse(): string
+{
+    return json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'error' => ['code' => -32020, 'message' => 'Header mismatch: The [Mcp-Method] header is required.'],
+    ]);
+}
+
+it('mirrors the method and name into headers on a discovery era call', function (): void {
+    Http::fakeSequence()
+        ->push(headerMismatchResponse(), 400, ['Content-Type' => 'application/json'])
+        ->push(discoverResponse(2), 200, ['Content-Type' => 'application/json'])
+        ->push(json_encode([
+            'jsonrpc' => '2.0',
+            'id' => 3,
+            'result' => ['content' => [['type' => 'text', 'text' => 'hi']], 'isError' => false],
+        ]), 200, ['Content-Type' => 'application/json']);
+
+    Client::web('https://mcp.test/mcp')->callTool('say-hi', ['name' => 'John']);
+
+    Http::assertSentInOrder([
+        function (Request $request): bool {
+            expect($request->header(RequestHeader::METHOD->value))->toBe([]);
+            expect($request->header(RequestHeader::PROTOCOL_VERSION->value))->toBe([]);
+
+            return true;
+        },
+        function (Request $request): bool {
+            expect($request->header(RequestHeader::PROTOCOL_VERSION->value)[0])->toBe('2026-07-28');
+            expect($request->header(RequestHeader::METHOD->value)[0])->toBe('server/discover');
+            expect($request->hasHeader('MCP-Session-Id'))->toBeFalse();
+
+            return true;
+        },
+        function (Request $request): bool {
+            expect($request->header(RequestHeader::METHOD->value)[0])->toBe('tools/call');
+            expect($request->header(RequestHeader::NAME->value)[0])->toBe('say-hi');
+
+            return true;
+        },
+    ]);
+});
+
+it('base64 encodes a name that is not header safe', function (): void {
+    Http::fakeSequence()
+        ->push(headerMismatchResponse(), 400, ['Content-Type' => 'application/json'])
+        ->push(discoverResponse(2), 200, ['Content-Type' => 'application/json'])
+        ->push(json_encode([
+            'jsonrpc' => '2.0',
+            'id' => 3,
+            'result' => ['contents' => [['uri' => 'file://hello 世界', 'text' => 'hi']]],
+        ]), 200, ['Content-Type' => 'application/json']);
+
+    Client::web('https://mcp.test/mcp')->readResource('file://hello 世界');
+
+    Http::assertSent(function (Request $request): bool {
+        if ($request->header(RequestHeader::METHOD->value) === [] || $request->header(RequestHeader::METHOD->value)[0] !== 'resources/read') {
+            return false;
+        }
+
+        return HeaderValue::fromHeader($request->header(RequestHeader::NAME->value)[0])->matches('file://hello 世界');
+    });
+});
+
+it('base64 encodes a name ending in a newline', function (): void {
+    Http::fakeSequence()
+        ->push(headerMismatchResponse(), 400, ['Content-Type' => 'application/json'])
+        ->push(discoverResponse(2), 200, ['Content-Type' => 'application/json'])
+        ->push(json_encode([
+            'jsonrpc' => '2.0',
+            'id' => 3,
+            'result' => ['contents' => [['uri' => "file://hello\n", 'text' => 'hi']]],
+        ]), 200, ['Content-Type' => 'application/json']);
+
+    Client::web('https://mcp.test/mcp')->readResource("file://hello\n");
+
+    Http::assertSent(function (Request $request): bool {
+        if ($request->header(RequestHeader::METHOD->value) === [] || $request->header(RequestHeader::METHOD->value)[0] !== 'resources/read') {
+            return false;
+        }
+
+        $name = $request->header(RequestHeader::NAME->value)[0];
+
+        return str_starts_with($name, '=?base64?')
+            && HeaderValue::fromHeader($name)->matches("file://hello\n");
+    });
+});
+
+it('reads a protocol error out of a 400 response', function (): void {
+    Http::fake([
+        'https://mcp.test/mcp' => Http::response(json_encode([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'error' => [
+                'code' => -32022,
+                'message' => 'Unsupported protocol version',
+                'data' => ['supported' => ['2027-01-01'], 'requested' => '2026-07-28'],
+            ],
+        ]), 400, ['Content-Type' => 'application/json']),
+    ]);
+
+    expect(fn (): array => Client::web('https://mcp.test/mcp')
+        ->withProtocolVersion(ProtocolVersion::LATEST)
+        ->tools()
+        ->all())
+        ->toThrow(JsonRpcException::class, 'Unsupported protocol version');
+
+    Http::assertSentCount(1);
+});
+
+it('falls back to discovery when the endpoint rejects the handshake', function (): void {
+    Http::fakeSequence()
+        ->push('Method Not Allowed', 405)
+        ->push(discoverResponse(2), 200, ['Content-Type' => 'application/json'])
+        ->push(json_encode([
+            'jsonrpc' => '2.0',
+            'id' => 3,
+            'result' => ['tools' => [['name' => 'add', 'description' => 'Adds']]],
+        ]), 200, ['Content-Type' => 'application/json']);
+
+    $client = Client::web('https://mcp.test/mcp');
+
+    expect($client->tools()->keys()->all())->toBe(['add']);
+    expect($client->protocolVersion())->toBe(ProtocolVersion::LATEST);
+});
+
+it('does not downgrade to discovery when the endpoint is unavailable', function (): void {
+    Http::fake([
+        'https://mcp.test/mcp' => Http::response('Bad Gateway', 502),
+    ]);
+
+    expect(fn (): array => Client::web('https://mcp.test/mcp')->tools()->all())
+        ->toThrow(ClientException::class, 'Unexpected HTTP status [502] from endpoint [https://mcp.test/mcp].');
+
+    Http::assertSentCount(1);
+});
+
+it('does not send a protocol version header through the handshake', function (): void {
+    Http::fakeSequence()
+        ->push(initializeResponse(), 200, ['Content-Type' => 'application/json'])
+        ->push('', 202)
+        ->push(json_encode([
+            'jsonrpc' => '2.0',
+            'id' => 2,
+            'result' => ['tools' => []],
+        ]), 200, ['Content-Type' => 'application/json']);
+
+    Client::web('https://mcp.test/mcp')->tools();
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+
+        if (($body['method'] ?? null) !== 'initialize') {
+            return false;
+        }
+
+        return $request->header(RequestHeader::PROTOCOL_VERSION->value) === [];
+    });
+});

--- a/tests/Feature/Client/HandshakeNegotiationTest.php
+++ b/tests/Feature/Client/HandshakeNegotiationTest.php
@@ -11,34 +11,18 @@ use Laravel\Mcp\Exceptions\ClientException;
 use Laravel\Mcp\Exceptions\JsonRpcException;
 use Laravel\Mcp\Transport\HeaderValue;
 
-function headerMismatchResponse(): string
-{
-    return json_encode([
-        'jsonrpc' => '2.0',
-        'id' => 1,
-        'error' => ['code' => -32020, 'message' => 'Header mismatch: The [Mcp-Method] header is required.'],
-    ]);
-}
-
 it('mirrors the method and name into headers on a discovery era call', function (): void {
     Http::fakeSequence()
-        ->push(headerMismatchResponse(), 400, ['Content-Type' => 'application/json'])
-        ->push(discoverResponse(2), 200, ['Content-Type' => 'application/json'])
+        ->push(discoverResponse(), 200, ['Content-Type' => 'application/json'])
         ->push(json_encode([
             'jsonrpc' => '2.0',
-            'id' => 3,
+            'id' => 2,
             'result' => ['content' => [['type' => 'text', 'text' => 'hi']], 'isError' => false],
         ]), 200, ['Content-Type' => 'application/json']);
 
     Client::web('https://mcp.test/mcp')->callTool('say-hi', ['name' => 'John']);
 
     Http::assertSentInOrder([
-        function (Request $request): bool {
-            expect($request->header(RequestHeader::METHOD->value))->toBe([]);
-            expect($request->header(RequestHeader::PROTOCOL_VERSION->value))->toBe([]);
-
-            return true;
-        },
         function (Request $request): bool {
             expect($request->header(RequestHeader::PROTOCOL_VERSION->value)[0])->toBe('2026-07-28');
             expect($request->header(RequestHeader::METHOD->value)[0])->toBe('server/discover');
@@ -57,11 +41,10 @@ it('mirrors the method and name into headers on a discovery era call', function 
 
 it('base64 encodes a name that is not header safe', function (): void {
     Http::fakeSequence()
-        ->push(headerMismatchResponse(), 400, ['Content-Type' => 'application/json'])
-        ->push(discoverResponse(2), 200, ['Content-Type' => 'application/json'])
+        ->push(discoverResponse(), 200, ['Content-Type' => 'application/json'])
         ->push(json_encode([
             'jsonrpc' => '2.0',
-            'id' => 3,
+            'id' => 2,
             'result' => ['contents' => [['uri' => 'file://hello 世界', 'text' => 'hi']]],
         ]), 200, ['Content-Type' => 'application/json']);
 
@@ -78,11 +61,10 @@ it('base64 encodes a name that is not header safe', function (): void {
 
 it('base64 encodes a name ending in a newline', function (): void {
     Http::fakeSequence()
-        ->push(headerMismatchResponse(), 400, ['Content-Type' => 'application/json'])
-        ->push(discoverResponse(2), 200, ['Content-Type' => 'application/json'])
+        ->push(discoverResponse(), 200, ['Content-Type' => 'application/json'])
         ->push(json_encode([
             'jsonrpc' => '2.0',
-            'id' => 3,
+            'id' => 2,
             'result' => ['contents' => [['uri' => "file://hello\n", 'text' => 'hi']]],
         ]), 200, ['Content-Type' => 'application/json']);
 
@@ -122,10 +104,36 @@ it('reads a protocol error out of a 400 response', function (): void {
     Http::assertSentCount(1);
 });
 
-it('falls back to discovery when the endpoint rejects the handshake', function (): void {
+it('retries with a mutual version from a protocol error in a 400 response', function (): void {
+    Http::fakeSequence()
+        ->push(json_encode([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'error' => [
+                'code' => -32022,
+                'message' => 'Unsupported protocol version',
+                'data' => ['supported' => ['2025-11-25'], 'requested' => '2026-07-28'],
+            ],
+        ]), 400, ['Content-Type' => 'application/json'])
+        ->push(initializeResponse(2), 200, ['Content-Type' => 'application/json'])
+        ->push('', 202)
+        ->push(json_encode([
+            'jsonrpc' => '2.0',
+            'id' => 3,
+            'result' => ['tools' => []],
+        ]), 200, ['Content-Type' => 'application/json']);
+
+    $client = Client::web('https://mcp.test/mcp');
+
+    expect($client->tools()->all())->toBe([]);
+    expect($client->protocolVersion())->toBe(ProtocolVersion::V2025_11_25);
+});
+
+it('falls back to the handshake when the endpoint rejects a modern request', function (): void {
     Http::fakeSequence()
         ->push('Method Not Allowed', 405)
-        ->push(discoverResponse(2), 200, ['Content-Type' => 'application/json'])
+        ->push(initializeResponse(2), 200, ['Content-Type' => 'application/json'])
+        ->push('', 202)
         ->push(json_encode([
             'jsonrpc' => '2.0',
             'id' => 3,
@@ -135,10 +143,26 @@ it('falls back to discovery when the endpoint rejects the handshake', function (
     $client = Client::web('https://mcp.test/mcp');
 
     expect($client->tools()->keys()->all())->toBe(['add']);
-    expect($client->protocolVersion())->toBe(ProtocolVersion::LATEST);
+    expect($client->protocolVersion())->toBe(ProtocolVersion::V2025_11_25);
 });
 
-it('does not downgrade to discovery when the endpoint is unavailable', function (): void {
+it('reports the rejected status alongside a failed fallback', function (): void {
+    Http::fakeSequence()
+        ->push('Method Not Allowed', 405)
+        ->push(json_encode([
+            'jsonrpc' => '2.0',
+            'id' => 2,
+            'error' => ['code' => -32603, 'message' => 'Internal error'],
+        ]), 200, ['Content-Type' => 'application/json']);
+
+    expect(fn (): array => Client::web('https://mcp.test/mcp')->tools()->all())
+        ->toThrow(
+            ClientException::class,
+            'The endpoint [https://mcp.test/mcp] rejected the request with HTTP status [405]. The legacy handshake also failed: Internal error',
+        );
+});
+
+it('does not fall back when the endpoint is unavailable', function (): void {
     Http::fake([
         'https://mcp.test/mcp' => Http::response('Bad Gateway', 502),
     ]);
@@ -151,11 +175,12 @@ it('does not downgrade to discovery when the endpoint is unavailable', function 
 
 it('does not send a protocol version header through the handshake', function (): void {
     Http::fakeSequence()
-        ->push(initializeResponse(), 200, ['Content-Type' => 'application/json'])
+        ->push('Bad Request', 400)
+        ->push(initializeResponse(2), 200, ['Content-Type' => 'application/json'])
         ->push('', 202)
         ->push(json_encode([
             'jsonrpc' => '2.0',
-            'id' => 2,
+            'id' => 3,
             'result' => ['tools' => []],
         ]), 200, ['Content-Type' => 'application/json']);
 

--- a/tests/Fixtures/Client/FakeTransport.php
+++ b/tests/Fixtures/Client/FakeTransport.php
@@ -14,6 +14,9 @@ class FakeTransport implements Transport
     /** @var array<int, string> */
     public array $sent = [];
 
+    /** @var array<int, array<string, string>> */
+    public array $sentHeaders = [];
+
     /** @var array<int, string> */
     public array $responses = [];
 
@@ -37,7 +40,7 @@ class FakeTransport implements Transport
         $this->connected = false;
     }
 
-    public function send(string $message): void
+    public function send(string $message, array $headers = []): void
     {
         $frame = json_decode($message, true);
         $frame = is_array($frame) ? $frame : [];
@@ -59,6 +62,7 @@ class FakeTransport implements Transport
         }
 
         $this->sent[] = $message;
+        $this->sentHeaders[] = $headers;
     }
 
     public function setTimeoutSeconds(float $seconds): void

--- a/tests/Fixtures/Client/FakeTransport.php
+++ b/tests/Fixtures/Client/FakeTransport.php
@@ -23,6 +23,10 @@ class FakeTransport implements Transport
 
     public ?string $protocolVersion = null;
 
+    public bool $negotiates = false;
+
+    protected string|int|null $pendingId = null;
+
     public function connect(): void
     {
         $this->connected = true;
@@ -35,6 +39,25 @@ class FakeTransport implements Transport
 
     public function send(string $message): void
     {
+        $frame = json_decode($message, true);
+        $frame = is_array($frame) ? $frame : [];
+
+        $id = $frame['id'] ?? null;
+
+        if (is_string($frame['method'] ?? null) && (is_string($id) || is_int($id))) {
+            $this->pendingId = $id;
+        }
+
+        if (! $this->negotiates && ($frame['method'] ?? null) === 'server/discover') {
+            array_unshift($this->responses, (string) json_encode([
+                'jsonrpc' => '2.0',
+                'id' => $this->pendingId,
+                'error' => ['code' => -32601, 'message' => 'Method not found.'],
+            ]));
+
+            return;
+        }
+
         $this->sent[] = $message;
     }
 
@@ -60,12 +83,27 @@ class FakeTransport implements Transport
     {
         if ($this->responses === []) {
             if ($this->repeatResponse !== null) {
-                return $this->repeatResponse;
+                return $this->answering($this->repeatResponse);
             }
 
             throw new RuntimeException('No queued responses in FakeTransport.');
         }
 
-        return array_shift($this->responses);
+        return $this->answering(array_shift($this->responses));
+    }
+
+    protected function answering(string $raw): string
+    {
+        $frame = json_decode($raw, true);
+
+        if (! is_array($frame) || ! array_key_exists('id', $frame)) {
+            return $raw;
+        }
+
+        if (! array_key_exists('result', $frame) && ! array_key_exists('error', $frame)) {
+            return $raw;
+        }
+
+        return (string) json_encode([...$frame, 'id' => $this->pendingId]);
     }
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -118,16 +118,42 @@ function expectedDiscoverResponse(): array
     ];
 }
 
-function initializeResponse(): string
+function initializeResponse(int $id = 1): string
 {
     return json_encode([
         'jsonrpc' => '2.0',
-        'id' => 1,
+        'id' => $id,
         'result' => [
             'protocolVersion' => '2025-11-25',
             'capabilities' => new stdClass,
             'serverInfo' => ['name' => 'Test Server', 'version' => '1.0.0'],
         ],
+    ]);
+}
+
+function discoverResponse(int $id = 1): string
+{
+    return json_encode([
+        'jsonrpc' => '2.0',
+        'id' => $id,
+        'result' => [
+            'resultType' => 'complete',
+            'supportedVersions' => ['2026-07-28'],
+            'capabilities' => ['tools' => ['listChanged' => false]],
+            'instructions' => 'Be nice.',
+            '_meta' => [
+                'io.modelcontextprotocol/serverInfo' => ['name' => 'Test Server', 'version' => '1.0.0'],
+            ],
+        ],
+    ]);
+}
+
+function methodNotFoundResponse(int $id = 1): string
+{
+    return json_encode([
+        'jsonrpc' => '2.0',
+        'id' => $id,
+        'error' => ['code' => -32601, 'message' => 'Method not found.'],
     ]);
 }
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Http\Client\ResponseSequence;
+use Illuminate\Support\Facades\Http;
 use Tests\Fixtures\ArrayTransport;
 use Tests\Fixtures\ExampleServer;
 use Tests\TestCase;
@@ -118,27 +120,30 @@ function expectedDiscoverResponse(): array
     ];
 }
 
-function initializeResponse(int $id = 1): string
+function initializeResponse(int $id = 1, string $version = '2025-11-25'): string
 {
     return json_encode([
         'jsonrpc' => '2.0',
         'id' => $id,
         'result' => [
-            'protocolVersion' => '2025-11-25',
+            'protocolVersion' => $version,
             'capabilities' => new stdClass,
             'serverInfo' => ['name' => 'Test Server', 'version' => '1.0.0'],
         ],
     ]);
 }
 
-function discoverResponse(int $id = 1): string
+/**
+ * @param  array<int, string>  $supportedVersions
+ */
+function discoverResponse(int $id = 1, array $supportedVersions = ['2026-07-28']): string
 {
     return json_encode([
         'jsonrpc' => '2.0',
         'id' => $id,
         'result' => [
             'resultType' => 'complete',
-            'supportedVersions' => ['2026-07-28'],
+            'supportedVersions' => $supportedVersions,
             'capabilities' => ['tools' => ['listChanged' => false]],
             'instructions' => 'Be nice.',
             '_meta' => [
@@ -146,6 +151,11 @@ function discoverResponse(int $id = 1): string
             ],
         ],
     ]);
+}
+
+function legacyEndpoint(): ResponseSequence
+{
+    return Http::fakeSequence()->push('Bad Request', 400);
 }
 
 function methodNotFoundResponse(int $id = 1): string

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -167,6 +167,19 @@ function methodNotFoundResponse(int $id = 1): string
     ]);
 }
 
+function toolCallResponse(int $id, string $text): string
+{
+    return (string) json_encode([
+        'jsonrpc' => '2.0',
+        'id' => $id,
+        'result' => [
+            'resultType' => 'complete',
+            'content' => [['type' => 'text', 'text' => $text]],
+            'isError' => false,
+        ],
+    ]);
+}
+
 function pingResponse(int $id): string
 {
     return json_encode([

--- a/tests/Unit/Client/ClientTest.php
+++ b/tests/Unit/Client/ClientTest.php
@@ -53,7 +53,7 @@ it('disconnects when the server negotiates a version the client does not support
 
     expect(function () use ($client): void {
         $client->connect();
-    })->toThrow(ClientException::class, 'The server negotiated an unsupported protocol version.');
+    })->toThrow(ClientException::class, 'The server chose protocol version [2024-11-05]. This client supports [2025-11-25, 2025-06-18].');
 
     expect($transport->connected)->toBeFalse();
 });

--- a/tests/Unit/Client/ClientTest.php
+++ b/tests/Unit/Client/ClientTest.php
@@ -68,7 +68,7 @@ it('pings the server', function (): void {
 
     $ping = json_decode($transport->sent[2], true);
     expect($ping['method'])->toBe('ping');
-    expect($ping['id'])->toBe(2);
+    expect($ping['id'])->toBe(3);
 });
 
 it('lazily connects when ping is called first', function (): void {
@@ -219,6 +219,7 @@ it('throws when the response carries both result and error', function (): void {
 
 it('throws when the response carries neither result nor error', function (): void {
     $transport = new FakeTransport;
+    $transport->negotiates = true;
     $transport->responses[] = json_encode([
         'jsonrpc' => '2.0',
         'id' => 1,

--- a/tests/Unit/Client/HandshakeTest.php
+++ b/tests/Unit/Client/HandshakeTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Mcp\Client;
+use Laravel\Mcp\Enums\ProtocolVersion;
+use Laravel\Mcp\Exceptions\ClientException;
+use Laravel\Mcp\Exceptions\JsonRpcException;
+use Tests\Fixtures\Client\FakeTransport;
+
+it('opens with the handshake and does not probe a legacy server', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+
+    $client = new Client($transport);
+    $client->connect();
+
+    expect($client->protocolVersion())->toBe(ProtocolVersion::V2025_11_25);
+    expect($client->discoverResult())->toBeNull();
+    expect($client->initializeResult()?->serverInfo->name)->toBe('Test Server');
+
+    expect($transport->sent)->toHaveCount(2);
+    expect(json_decode($transport->sent[0], true)['method'])->toBe('initialize');
+    expect(json_decode($transport->sent[1], true)['method'])->toBe('notifications/initialized');
+});
+
+it('never sends a discovery era version through the handshake', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+
+    (new Client($transport))->connect();
+
+    $initialize = json_decode($transport->sent[0], true);
+
+    expect($initialize['params']['protocolVersion'])->toBe(ProtocolVersion::V2025_11_25->value);
+    expect($initialize['params'])->not->toHaveKey('_meta');
+});
+
+it('falls back to discovery when the handshake is not implemented', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = methodNotFoundResponse();
+    $transport->responses[] = discoverResponse(2);
+
+    $client = new Client($transport);
+    $client->connect();
+
+    expect($client->protocolVersion())->toBe(ProtocolVersion::LATEST);
+    expect($client->initializeResult())->toBeNull();
+    expect($client->discoverResult()?->supportedVersions)->toBe([ProtocolVersion::LATEST->value]);
+    expect($client->discoverResult()?->serverInfo?->name)->toBe('Test Server');
+    expect($client->discoverResult()?->instructions)->toBe('Be nice.');
+
+    expect($transport->sent)->toHaveCount(2);
+    expect(json_decode($transport->sent[0], true)['method'])->toBe('initialize');
+    expect(json_decode($transport->sent[1], true)['method'])->toBe('server/discover');
+    expect($transport->protocolVersion)->toBe(ProtocolVersion::LATEST->value);
+});
+
+it('falls back to discovery when the server demands the mirrored headers', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'error' => ['code' => -32020, 'message' => 'Header mismatch: The [Mcp-Method] header is required.'],
+    ]);
+    $transport->responses[] = discoverResponse(2);
+
+    $client = new Client($transport);
+    $client->connect();
+
+    expect($client->protocolVersion())->toBe(ProtocolVersion::LATEST);
+    expect(json_decode($transport->sent[1], true)['method'])->toBe('server/discover');
+});
+
+it('propagates a handshake error that does not point at discovery', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'error' => ['code' => -32602, 'message' => 'Invalid params'],
+    ]);
+
+    expect(fn (): Client => (new Client($transport))->connect())
+        ->toThrow(JsonRpcException::class, 'Invalid params');
+
+    expect($transport->sent)->toHaveCount(1);
+});
+
+it('sends the required protocol metadata on every discovery era request', function (): void {
+    config(['app.name' => 'Acme MCP App']);
+
+    $transport = new FakeTransport;
+    $transport->responses[] = methodNotFoundResponse();
+    $transport->responses[] = discoverResponse(2);
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 3,
+        'result' => ['tools' => [['name' => 'add', 'description' => 'Adds two numbers']]],
+    ]);
+
+    (new Client($transport))->tools();
+
+    expect(json_decode($transport->sent[0], true)['params'])->not->toHaveKey('_meta');
+
+    foreach (array_slice($transport->sent, 1) as $raw) {
+        $meta = json_decode($raw, true)['params']['_meta'];
+
+        expect($meta['io.modelcontextprotocol/protocolVersion'])->toBe(ProtocolVersion::LATEST->value);
+        expect($meta)->toHaveKey('io.modelcontextprotocol/clientCapabilities');
+        expect($meta['io.modelcontextprotocol/clientInfo']['name'])->toBe('Acme MCP App');
+    }
+});
+
+it('skips the handshake when a discovery version is pinned', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = discoverResponse();
+
+    $client = (new Client($transport))->withProtocolVersion(ProtocolVersion::LATEST);
+    $client->connect();
+
+    expect($client->protocolVersion())->toBe(ProtocolVersion::LATEST);
+    expect($transport->sent)->toHaveCount(1);
+    expect(json_decode($transport->sent[0], true)['method'])->toBe('server/discover');
+});
+
+it('offers the pinned version and does not fall back to discovery', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = methodNotFoundResponse();
+
+    $client = (new Client($transport))->withProtocolVersion(ProtocolVersion::V2025_06_18);
+
+    expect(fn (): Client => $client->connect())->toThrow(JsonRpcException::class);
+
+    expect($transport->sent)->toHaveCount(1);
+    expect(json_decode($transport->sent[0], true)['params']['protocolVersion'])
+        ->toBe(ProtocolVersion::V2025_06_18->value);
+});
+
+it('rejects a protocol version this client does not support', function (): void {
+    $client = new Client(new FakeTransport);
+
+    expect(fn (): Client => $client->withProtocolVersion(ProtocolVersion::V2024_11_05))
+        ->toThrow(ClientException::class, 'This client does not support protocol version [2024-11-05].');
+});
+
+it('remembers a discovery era server across reconnects', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = methodNotFoundResponse();
+    $transport->responses[] = discoverResponse(2);
+
+    $client = new Client($transport);
+    $client->connect();
+    $client->disconnect();
+
+    $transport->sent = [];
+    $transport->responses[] = discoverResponse(3);
+
+    $client->connect();
+
+    expect($client->protocolVersion())->toBe(ProtocolVersion::LATEST);
+    expect($transport->sent)->toHaveCount(1);
+    expect(json_decode($transport->sent[0], true)['method'])->toBe('server/discover');
+});
+
+it('reconnects when the protocol version is pinned after connecting', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = initializeResponse();
+    $transport->responses[] = discoverResponse(2);
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 3,
+        'result' => ['tools' => []],
+    ]);
+
+    $client = new Client($transport);
+    $client->connect();
+
+    expect($client->protocolVersion())->toBe(ProtocolVersion::V2025_11_25);
+
+    $client->withProtocolVersion(ProtocolVersion::LATEST);
+    $client->tools();
+
+    expect($client->protocolVersion())->toBe(ProtocolVersion::LATEST);
+    expect(json_decode($transport->sent[2], true)['method'])->toBe('server/discover');
+    expect(json_decode($transport->sent[3], true)['params'])->toHaveKey('_meta');
+});
+
+it('rejects a malformed discover response', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = methodNotFoundResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => ['capabilities' => []],
+    ]);
+
+    expect(function () use ($transport): void {
+        (new Client($transport))->connect();
+    })->toThrow(ClientException::class, 'Invalid discover response from server.');
+});
+
+it('rejects a discovery era server that does not support the latest version', function (): void {
+    $transport = new FakeTransport;
+    $transport->responses[] = methodNotFoundResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'result' => [
+            'supportedVersions' => ['2027-01-01'],
+            'capabilities' => [],
+            'instructions' => null,
+        ],
+    ]);
+
+    expect(function () use ($transport): void {
+        (new Client($transport))->connect();
+    })
+        ->toThrow(ClientException::class, 'The server does not support protocol version [2026-07-28]. It supports [2027-01-01].');
+});

--- a/tests/Unit/Client/HandshakeTest.php
+++ b/tests/Unit/Client/HandshakeTest.php
@@ -8,38 +8,17 @@ use Laravel\Mcp\Exceptions\ClientException;
 use Laravel\Mcp\Exceptions\JsonRpcException;
 use Tests\Fixtures\Client\FakeTransport;
 
-it('opens with the handshake and does not probe a legacy server', function (): void {
+function negotiatingTransport(): FakeTransport
+{
     $transport = new FakeTransport;
-    $transport->responses[] = initializeResponse();
+    $transport->negotiates = true;
 
-    $client = new Client($transport);
-    $client->connect();
+    return $transport;
+}
 
-    expect($client->protocolVersion())->toBe(ProtocolVersion::V2025_11_25);
-    expect($client->discoverResult())->toBeNull();
-    expect($client->initializeResult()?->serverInfo->name)->toBe('Test Server');
-
-    expect($transport->sent)->toHaveCount(2);
-    expect(json_decode($transport->sent[0], true)['method'])->toBe('initialize');
-    expect(json_decode($transport->sent[1], true)['method'])->toBe('notifications/initialized');
-});
-
-it('never sends a discovery era version through the handshake', function (): void {
-    $transport = new FakeTransport;
-    $transport->responses[] = initializeResponse();
-
-    (new Client($transport))->connect();
-
-    $initialize = json_decode($transport->sent[0], true);
-
-    expect($initialize['params']['protocolVersion'])->toBe(ProtocolVersion::V2025_11_25->value);
-    expect($initialize['params'])->not->toHaveKey('_meta');
-});
-
-it('falls back to discovery when the handshake is not implemented', function (): void {
-    $transport = new FakeTransport;
-    $transport->responses[] = methodNotFoundResponse();
-    $transport->responses[] = discoverResponse(2);
+it('probes discovery first and stays modern against a modern server', function (): void {
+    $transport = negotiatingTransport();
+    $transport->responses[] = discoverResponse();
 
     $client = new Client($transport);
     $client->connect();
@@ -50,59 +29,136 @@ it('falls back to discovery when the handshake is not implemented', function ():
     expect($client->discoverResult()?->serverInfo?->name)->toBe('Test Server');
     expect($client->discoverResult()?->instructions)->toBe('Be nice.');
 
-    expect($transport->sent)->toHaveCount(2);
-    expect(json_decode($transport->sent[0], true)['method'])->toBe('initialize');
-    expect(json_decode($transport->sent[1], true)['method'])->toBe('server/discover');
+    expect($transport->sent)->toHaveCount(1);
+    expect(json_decode($transport->sent[0], true)['method'])->toBe('server/discover');
     expect($transport->protocolVersion)->toBe(ProtocolVersion::LATEST->value);
 });
 
-it('falls back to discovery when the server demands the mirrored headers', function (): void {
-    $transport = new FakeTransport;
+it('falls back to the handshake when discovery is not implemented', function (): void {
+    $transport = negotiatingTransport();
+    $transport->responses[] = methodNotFoundResponse();
+    $transport->responses[] = initializeResponse(2);
+
+    $client = new Client($transport);
+    $client->connect();
+
+    expect($client->protocolVersion())->toBe(ProtocolVersion::V2025_11_25);
+    expect($client->discoverResult())->toBeNull();
+    expect($client->initializeResult()?->serverInfo->name)->toBe('Test Server');
+
+    expect($transport->sent)->toHaveCount(3);
+    expect(json_decode($transport->sent[0], true)['method'])->toBe('server/discover');
+    expect(json_decode($transport->sent[1], true)['method'])->toBe('initialize');
+    expect(json_decode($transport->sent[2], true)['method'])->toBe('notifications/initialized');
+    expect($transport->protocolVersion)->toBe(ProtocolVersion::V2025_11_25->value);
+});
+
+it('never sends a discovery era version or metadata through the handshake', function (): void {
+    $transport = negotiatingTransport();
+    $transport->responses[] = methodNotFoundResponse();
+    $transport->responses[] = initializeResponse(2);
+
+    (new Client($transport))->connect();
+
+    $initialize = json_decode($transport->sent[1], true);
+
+    expect($initialize['params']['protocolVersion'])->toBe(ProtocolVersion::V2025_11_25->value);
+    expect($initialize['params'])->not->toHaveKey('_meta');
+});
+
+it('does not fall back when the error identifies a modern server', function (): void {
+    $transport = negotiatingTransport();
     $transport->responses[] = json_encode([
         'jsonrpc' => '2.0',
         'id' => 1,
         'error' => ['code' => -32020, 'message' => 'Header mismatch: The [Mcp-Method] header is required.'],
     ]);
-    $transport->responses[] = discoverResponse(2);
+
+    expect(fn (): Client => (new Client($transport))->connect())
+        ->toThrow(JsonRpcException::class, 'Header mismatch');
+
+    expect($transport->sent)->toHaveCount(1);
+});
+
+it('retries with a mutually supported version from an unsupported version error', function (): void {
+    $transport = negotiatingTransport();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'error' => [
+            'code' => -32022,
+            'message' => 'Unsupported protocol version',
+            'data' => ['supported' => ['2025-11-25', '2025-06-18'], 'requested' => '2026-07-28'],
+        ],
+    ]);
+    $transport->responses[] = initializeResponse(2);
 
     $client = new Client($transport);
     $client->connect();
 
-    expect($client->protocolVersion())->toBe(ProtocolVersion::LATEST);
-    expect(json_decode($transport->sent[1], true)['method'])->toBe('server/discover');
+    expect($client->protocolVersion())->toBe(ProtocolVersion::V2025_11_25);
+    expect(json_decode($transport->sent[1], true)['params']['protocolVersion'])
+        ->toBe(ProtocolVersion::V2025_11_25->value);
 });
 
-it('propagates a handshake error that does not point at discovery', function (): void {
-    $transport = new FakeTransport;
+it('propagates an unsupported version error with no mutually supported version', function (): void {
+    $transport = negotiatingTransport();
     $transport->responses[] = json_encode([
         'jsonrpc' => '2.0',
         'id' => 1,
-        'error' => ['code' => -32602, 'message' => 'Invalid params'],
+        'error' => [
+            'code' => -32022,
+            'message' => 'Unsupported protocol version',
+            'data' => ['supported' => ['2027-01-01'], 'requested' => '2026-07-28'],
+        ],
     ]);
 
     expect(fn (): Client => (new Client($transport))->connect())
-        ->toThrow(JsonRpcException::class, 'Invalid params');
+        ->toThrow(JsonRpcException::class, 'Unsupported protocol version');
 
     expect($transport->sent)->toHaveCount(1);
+});
+
+it('falls back to the handshake when discovery lists only a legacy version', function (): void {
+    $transport = negotiatingTransport();
+    $transport->responses[] = discoverResponse(1, ['2025-11-25']);
+    $transport->responses[] = initializeResponse(2);
+
+    $client = new Client($transport);
+    $client->connect();
+
+    expect($client->protocolVersion())->toBe(ProtocolVersion::V2025_11_25);
+    expect(json_decode($transport->sent[1], true)['method'])->toBe('initialize');
+    expect(json_decode($transport->sent[1], true)['params'])->not->toHaveKey('_meta');
+});
+
+it('surfaces the handshake failure and not the probe when the fallback fails', function (): void {
+    $transport = negotiatingTransport();
+    $transport->responses[] = methodNotFoundResponse();
+    $transport->responses[] = json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 2,
+        'error' => ['code' => -32603, 'message' => 'Internal error'],
+    ]);
+
+    expect(fn (): Client => (new Client($transport))->connect())
+        ->toThrow(JsonRpcException::class, 'Internal error');
 });
 
 it('sends the required protocol metadata on every discovery era request', function (): void {
     config(['app.name' => 'Acme MCP App']);
 
-    $transport = new FakeTransport;
-    $transport->responses[] = methodNotFoundResponse();
-    $transport->responses[] = discoverResponse(2);
+    $transport = negotiatingTransport();
+    $transport->responses[] = discoverResponse();
     $transport->responses[] = json_encode([
         'jsonrpc' => '2.0',
-        'id' => 3,
+        'id' => 2,
         'result' => ['tools' => [['name' => 'add', 'description' => 'Adds two numbers']]],
     ]);
 
     (new Client($transport))->tools();
 
-    expect(json_decode($transport->sent[0], true)['params'])->not->toHaveKey('_meta');
-
-    foreach (array_slice($transport->sent, 1) as $raw) {
+    foreach ($transport->sent as $raw) {
         $meta = json_decode($raw, true)['params']['_meta'];
 
         expect($meta['io.modelcontextprotocol/protocolVersion'])->toBe(ProtocolVersion::LATEST->value);
@@ -111,8 +167,8 @@ it('sends the required protocol metadata on every discovery era request', functi
     }
 });
 
-it('skips the handshake when a discovery version is pinned', function (): void {
-    $transport = new FakeTransport;
+it('skips the probe when a discovery version is pinned', function (): void {
+    $transport = negotiatingTransport();
     $transport->responses[] = discoverResponse();
 
     $client = (new Client($transport))->withProtocolVersion(ProtocolVersion::LATEST);
@@ -123,17 +179,24 @@ it('skips the handshake when a discovery version is pinned', function (): void {
     expect(json_decode($transport->sent[0], true)['method'])->toBe('server/discover');
 });
 
-it('offers the pinned version and does not fall back to discovery', function (): void {
-    $transport = new FakeTransport;
-    $transport->responses[] = methodNotFoundResponse();
+it('offers the pinned legacy version and does not probe discovery', function (): void {
+    $transport = negotiatingTransport();
+    $transport->responses[] = initializeResponse(1, ProtocolVersion::V2025_06_18->value);
 
     $client = (new Client($transport))->withProtocolVersion(ProtocolVersion::V2025_06_18);
+    $client->connect();
 
-    expect(fn (): Client => $client->connect())->toThrow(JsonRpcException::class);
-
-    expect($transport->sent)->toHaveCount(1);
+    expect($client->protocolVersion())->toBe(ProtocolVersion::V2025_06_18);
+    expect(json_decode($transport->sent[0], true)['method'])->toBe('initialize');
     expect(json_decode($transport->sent[0], true)['params']['protocolVersion'])
         ->toBe(ProtocolVersion::V2025_06_18->value);
+});
+
+it('reports the pinned version before connecting', function (): void {
+    $client = (new Client(negotiatingTransport()))->withProtocolVersion(ProtocolVersion::LATEST);
+
+    expect($client->protocolVersion())->toBe(ProtocolVersion::LATEST);
+    expect($client->connected())->toBeFalse();
 });
 
 it('rejects a protocol version this client does not support', function (): void {
@@ -144,16 +207,15 @@ it('rejects a protocol version this client does not support', function (): void 
 });
 
 it('remembers a discovery era server across reconnects', function (): void {
-    $transport = new FakeTransport;
-    $transport->responses[] = methodNotFoundResponse();
-    $transport->responses[] = discoverResponse(2);
+    $transport = negotiatingTransport();
+    $transport->responses[] = discoverResponse();
 
     $client = new Client($transport);
     $client->connect();
     $client->disconnect();
 
     $transport->sent = [];
-    $transport->responses[] = discoverResponse(3);
+    $transport->responses[] = discoverResponse(2);
 
     $client->connect();
 
@@ -162,13 +224,56 @@ it('remembers a discovery era server across reconnects', function (): void {
     expect(json_decode($transport->sent[0], true)['method'])->toBe('server/discover');
 });
 
+it('remembers a legacy server across reconnects', function (): void {
+    $transport = negotiatingTransport();
+    $transport->responses[] = methodNotFoundResponse();
+    $transport->responses[] = initializeResponse(2);
+
+    $client = new Client($transport);
+    $client->connect();
+    $client->disconnect();
+
+    $transport->sent = [];
+    $transport->responses[] = initializeResponse(3);
+
+    $client->connect();
+
+    expect($client->protocolVersion())->toBe(ProtocolVersion::V2025_11_25);
+    expect($transport->sent)->toHaveCount(2);
+    expect(json_decode($transport->sent[0], true)['method'])->toBe('initialize');
+});
+
+it('re-probes after a remembered discovery era assumption fails', function (): void {
+    $transport = negotiatingTransport();
+    $transport->responses[] = discoverResponse();
+
+    $client = new Client($transport);
+    $client->connect();
+    $client->disconnect();
+
+    $transport->responses[] = methodNotFoundResponse(2);
+
+    expect(fn (): Client => $client->connect())->toThrow(JsonRpcException::class);
+
+    $transport->sent = [];
+    $transport->responses[] = methodNotFoundResponse(3);
+    $transport->responses[] = initializeResponse(4);
+
+    $client->connect();
+
+    expect($client->protocolVersion())->toBe(ProtocolVersion::V2025_11_25);
+    expect(json_decode($transport->sent[0], true)['method'])->toBe('server/discover');
+    expect(json_decode($transport->sent[1], true)['method'])->toBe('initialize');
+});
+
 it('reconnects when the protocol version is pinned after connecting', function (): void {
-    $transport = new FakeTransport;
-    $transport->responses[] = initializeResponse();
-    $transport->responses[] = discoverResponse(2);
+    $transport = negotiatingTransport();
+    $transport->responses[] = methodNotFoundResponse();
+    $transport->responses[] = initializeResponse(2);
+    $transport->responses[] = discoverResponse(3);
     $transport->responses[] = json_encode([
         'jsonrpc' => '2.0',
-        'id' => 3,
+        'id' => 4,
         'result' => ['tools' => []],
     ]);
 
@@ -181,16 +286,15 @@ it('reconnects when the protocol version is pinned after connecting', function (
     $client->tools();
 
     expect($client->protocolVersion())->toBe(ProtocolVersion::LATEST);
-    expect(json_decode($transport->sent[2], true)['method'])->toBe('server/discover');
-    expect(json_decode($transport->sent[3], true)['params'])->toHaveKey('_meta');
+    expect(json_decode($transport->sent[3], true)['method'])->toBe('server/discover');
+    expect(json_decode($transport->sent[4], true)['params'])->toHaveKey('_meta');
 });
 
 it('rejects a malformed discover response', function (): void {
-    $transport = new FakeTransport;
-    $transport->responses[] = methodNotFoundResponse();
+    $transport = negotiatingTransport();
     $transport->responses[] = json_encode([
         'jsonrpc' => '2.0',
-        'id' => 2,
+        'id' => 1,
         'result' => ['capabilities' => []],
     ]);
 
@@ -199,21 +303,12 @@ it('rejects a malformed discover response', function (): void {
     })->toThrow(ClientException::class, 'Invalid discover response from server.');
 });
 
-it('rejects a discovery era server that does not support the latest version', function (): void {
-    $transport = new FakeTransport;
-    $transport->responses[] = methodNotFoundResponse();
-    $transport->responses[] = json_encode([
-        'jsonrpc' => '2.0',
-        'id' => 2,
-        'result' => [
-            'supportedVersions' => ['2027-01-01'],
-            'capabilities' => [],
-            'instructions' => null,
-        ],
-    ]);
+it('rejects a server with no protocol version this client can speak', function (): void {
+    $transport = negotiatingTransport();
+    $transport->responses[] = discoverResponse(1, ['2027-01-01']);
 
     expect(function () use ($transport): void {
         (new Client($transport))->connect();
     })
-        ->toThrow(ClientException::class, 'The server does not support protocol version [2026-07-28]. It supports [2027-01-01].');
+        ->toThrow(ClientException::class, 'The server supports protocol versions [2027-01-01]. This client supports [2026-07-28, 2025-11-25, 2025-06-18].');
 });

--- a/tests/Unit/Client/ToolHeaderTest.php
+++ b/tests/Unit/Client/ToolHeaderTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Log;
+use Laravel\Mcp\Client;
+use Laravel\Mcp\Enums\ProtocolVersion;
+use Tests\Fixtures\Client\FakeTransport;
+
+function toolsListResponse(int $id, array $tools): string
+{
+    return (string) json_encode([
+        'jsonrpc' => '2.0',
+        'id' => $id,
+        'result' => ['resultType' => 'complete', 'tools' => $tools],
+    ]);
+}
+
+function annotatedTool(string $header = 'Region'): array
+{
+    return [
+        'name' => 'execute_sql',
+        'description' => 'Runs SQL',
+        'inputSchema' => [
+            'type' => 'object',
+            'properties' => [
+                'region' => ['type' => 'string', 'x-mcp-header' => $header],
+                'query' => ['type' => 'string'],
+            ],
+        ],
+    ];
+}
+
+it('mirrors annotated parameters into headers on a tool call', function (): void {
+    $transport = new FakeTransport;
+    $transport->negotiates = true;
+    $transport->responses[] = discoverResponse();
+    $transport->responses[] = toolsListResponse(2, [annotatedTool()]);
+    $transport->responses[] = toolCallResponse(3, 'done');
+
+    $client = (new Client($transport))->withProtocolVersion(ProtocolVersion::LATEST);
+    $client->tools();
+    $client->callTool('execute_sql', ['region' => 'us-west1', 'query' => 'select 1']);
+
+    expect($transport->sentHeaders[2])->toBe(['Mcp-Param-Region' => 'us-west1']);
+});
+
+it('sends no parameter headers for a tool it has not listed', function (): void {
+    $transport = new FakeTransport;
+    $transport->negotiates = true;
+    $transport->responses[] = discoverResponse();
+    $transport->responses[] = toolCallResponse(2, 'done');
+
+    (new Client($transport))->withProtocolVersion(ProtocolVersion::LATEST)->callTool('execute_sql', ['region' => 'us-west1']);
+
+    expect($transport->sentHeaders[1])->toBe([]);
+});
+
+it('excludes a tool whose annotation is invalid from the tool list', function (): void {
+    Log::spy();
+
+    $transport = new FakeTransport;
+    $transport->negotiates = true;
+    $transport->responses[] = discoverResponse();
+    $transport->responses[] = toolsListResponse(2, [
+        annotatedTool('Bad Header'),
+        ['name' => 'plain', 'description' => 'Fine', 'inputSchema' => ['type' => 'object']],
+    ]);
+
+    $tools = (new Client($transport))->withProtocolVersion(ProtocolVersion::LATEST)->tools();
+
+    expect($tools->keys()->all())->toBe(['plain']);
+
+    Log::shouldHaveReceived('warning')->once()->withArgs(
+        fn (string $message): bool => str_contains($message, 'execute_sql') && str_contains($message, 'not a valid header name token'),
+    );
+});
+
+it('mirrors parameters from the tool primitive without a listing round trip', function (): void {
+    $transport = new FakeTransport;
+    $transport->negotiates = true;
+    $transport->responses[] = discoverResponse();
+    $transport->responses[] = toolsListResponse(2, [annotatedTool()]);
+    $transport->responses[] = toolCallResponse(3, 'done');
+
+    $client = (new Client($transport))->withProtocolVersion(ProtocolVersion::LATEST);
+    $tool = $client->tools()->get('execute_sql');
+
+    (fn (): array => $this->toolSchemas = [])->call($client);
+
+    $tool->call(['region' => 'us-west1', 'query' => 'select 1']);
+
+    expect($transport->sentHeaders[2])->toBe(['Mcp-Param-Region' => 'us-west1']);
+});

--- a/tests/Unit/Client/Transport/HttpTransportTest.php
+++ b/tests/Unit/Client/Transport/HttpTransportTest.php
@@ -384,7 +384,7 @@ it('throws when the server negotiates a protocol version the client does not sup
 
     expect(function (): void {
         Client::web('https://mcp.test/mcp')->tools();
-    })->toThrow(ClientException::class, 'The server negotiated an unsupported protocol version.');
+    })->toThrow(ClientException::class, 'The server chose protocol version [2025-03-26]. This client supports [2025-11-25, 2025-06-18].');
 });
 
 it('interoperates with a server negotiated down to 2025-06-18', function (): void {

--- a/tests/Unit/Client/Transport/HttpTransportTest.php
+++ b/tests/Unit/Client/Transport/HttpTransportTest.php
@@ -196,10 +196,10 @@ it('merges custom headers across multiple withHeaders calls', function (): void 
 });
 
 it('sends custom headers when built via Client::web', function (): void {
-    Http::fakeSequence()
+    legacyEndpoint()
         ->push(json_encode([
             'jsonrpc' => '2.0',
-            'id' => 1,
+            'id' => 2,
             'result' => [
                 'protocolVersion' => ProtocolVersion::V2025_11_25->value,
                 'capabilities' => new stdClass,
@@ -209,7 +209,7 @@ it('sends custom headers when built via Client::web', function (): void {
         ->push('', 202)
         ->push(json_encode([
             'jsonrpc' => '2.0',
-            'id' => 2,
+            'id' => 3,
             'result' => ['tools' => [['name' => 'add', 'description' => 'Adds two numbers']]],
         ]), 200, ['Content-Type' => 'application/json'])
         ->whenEmpty(Http::response('', 202));
@@ -339,10 +339,10 @@ it('throws when receiving with no queued message', function (): void {
 });
 
 it('drives a full handshake and tools list over HTTP via Client::web', function (): void {
-    Http::fakeSequence()
+    legacyEndpoint()
         ->push(json_encode([
             'jsonrpc' => '2.0',
-            'id' => 1,
+            'id' => 2,
             'result' => [
                 'protocolVersion' => ProtocolVersion::V2025_11_25->value,
                 'capabilities' => new stdClass,
@@ -352,7 +352,7 @@ it('drives a full handshake and tools list over HTTP via Client::web', function 
         ->push('', 202)
         ->push(json_encode([
             'jsonrpc' => '2.0',
-            'id' => 2,
+            'id' => 3,
             'result' => ['tools' => [['name' => 'add', 'description' => 'Adds two numbers']]],
         ]), 200, ['Content-Type' => 'application/json'])
         ->whenEmpty(Http::response('', 202));
@@ -370,10 +370,10 @@ it('drives a full handshake and tools list over HTTP via Client::web', function 
 });
 
 it('throws when the server negotiates a protocol version the client does not support', function (): void {
-    Http::fakeSequence()
+    legacyEndpoint()
         ->push(json_encode([
             'jsonrpc' => '2.0',
-            'id' => 1,
+            'id' => 2,
             'result' => [
                 'protocolVersion' => ProtocolVersion::V2025_03_26->value,
                 'capabilities' => new stdClass,
@@ -388,10 +388,10 @@ it('throws when the server negotiates a protocol version the client does not sup
 });
 
 it('interoperates with a server negotiated down to 2025-06-18', function (): void {
-    Http::fakeSequence()
+    legacyEndpoint()
         ->push(json_encode([
             'jsonrpc' => '2.0',
-            'id' => 1,
+            'id' => 2,
             'result' => [
                 'protocolVersion' => ProtocolVersion::V2025_06_18->value,
                 'capabilities' => new stdClass,
@@ -401,7 +401,7 @@ it('interoperates with a server negotiated down to 2025-06-18', function (): voi
         ->push('', 202)
         ->push(json_encode([
             'jsonrpc' => '2.0',
-            'id' => 2,
+            'id' => 3,
             'result' => [
                 'tools' => [[
                     'name' => 'add',
@@ -421,7 +421,7 @@ it('interoperates with a server negotiated down to 2025-06-18', function (): voi
         ]), 200, ['Content-Type' => 'application/json'])
         ->push(json_encode([
             'jsonrpc' => '2.0',
-            'id' => 3,
+            'id' => 4,
             'result' => [
                 'content' => [['type' => 'text', 'text' => '3']],
                 'structuredContent' => ['sum' => 3],
@@ -455,21 +455,21 @@ it('builds a WebClient from Client::web', function (): void {
 });
 
 it('re-initializes and retries once after a 404 session expiry', function (): void {
-    Http::fakeSequence()
-        ->push(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => [
+    legacyEndpoint()
+        ->push(json_encode(['jsonrpc' => '2.0', 'id' => 2, 'result' => [
             'protocolVersion' => ProtocolVersion::V2025_11_25->value,
             'capabilities' => new stdClass,
             'serverInfo' => ['name' => 'Test Server', 'version' => '1.0.0'],
         ]]), 200, ['Content-Type' => 'application/json', 'MCP-Session-Id' => 'session-1'])
         ->push('', 202)
         ->push('', 404)
-        ->push(json_encode(['jsonrpc' => '2.0', 'id' => 3, 'result' => [
+        ->push(json_encode(['jsonrpc' => '2.0', 'id' => 4, 'result' => [
             'protocolVersion' => ProtocolVersion::V2025_11_25->value,
             'capabilities' => new stdClass,
             'serverInfo' => ['name' => 'Test Server', 'version' => '1.0.0'],
         ]]), 200, ['Content-Type' => 'application/json', 'MCP-Session-Id' => 'session-2'])
         ->push('', 202)
-        ->push(json_encode(['jsonrpc' => '2.0', 'id' => 4, 'result' => [
+        ->push(json_encode(['jsonrpc' => '2.0', 'id' => 5, 'result' => [
             'tools' => [['name' => 'add', 'description' => 'Adds two numbers']],
         ]]), 200, ['Content-Type' => 'application/json'])
         ->whenEmpty(Http::response('', 202));

--- a/tests/Unit/Support/ToolHeadersTest.php
+++ b/tests/Unit/Support/ToolHeadersTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Mcp\Exceptions\ClientException;
+use Laravel\Mcp\Support\ToolHeaders;
+
+function schemaWith(array $properties): array
+{
+    return ['type' => 'object', 'properties' => $properties];
+}
+
+it('accepts a valid annotation', function (): void {
+    expect(ToolHeaders::invalid(schemaWith([
+        'region' => ['type' => 'string', 'x-mcp-header' => 'Region'],
+        'query' => ['type' => 'string'],
+    ])))->toBeNull();
+});
+
+it('accepts an annotation on a nested property', function (): void {
+    expect(ToolHeaders::invalid(schemaWith([
+        'target' => ['type' => 'object', 'properties' => [
+            'region' => ['type' => 'string', 'x-mcp-header' => 'Region'],
+        ]],
+    ])))->toBeNull();
+});
+
+it('rejects an invalid annotation', function (array $properties, string $reason): void {
+    expect(ToolHeaders::invalid(schemaWith($properties)))->toContain($reason);
+})->with([
+    'empty' => [['a' => ['type' => 'string', 'x-mcp-header' => '']], 'not a valid header name token'],
+    'space' => [['a' => ['type' => 'string', 'x-mcp-header' => 'My Header']], 'not a valid header name token'],
+    'newline' => [['a' => ['type' => 'string', 'x-mcp-header' => "Bad\nName"]], 'not a valid header name token'],
+    'not a string' => [['a' => ['type' => 'string', 'x-mcp-header' => 12]], 'not a valid header name token'],
+    'number type' => [['a' => ['type' => 'number', 'x-mcp-header' => 'A']], 'must sit on a string, integer, or boolean'],
+    'array type' => [['a' => ['type' => 'array', 'x-mcp-header' => 'A']], 'must sit on a string, integer, or boolean'],
+    'duplicate' => [[
+        'a' => ['type' => 'string', 'x-mcp-header' => 'Region'],
+        'b' => ['type' => 'string', 'x-mcp-header' => 'region'],
+    ], 'is used more than once'],
+]);
+
+it('rejects an annotation that is not statically reachable', function (): void {
+    expect(ToolHeaders::invalid([
+        'type' => 'object',
+        'properties' => [
+            'rows' => ['type' => 'array', 'items' => [
+                'type' => 'object',
+                'properties' => ['region' => ['type' => 'string', 'x-mcp-header' => 'Region']],
+            ]],
+        ],
+    ]))->toContain('outside the statically reachable properties');
+});
+
+it('extracts and encodes the annotated values', function (): void {
+    $schema = schemaWith([
+        'region' => ['type' => 'string', 'x-mcp-header' => 'Region'],
+        'limit' => ['type' => 'integer', 'x-mcp-header' => 'Limit'],
+        'dry' => ['type' => 'boolean', 'x-mcp-header' => 'Dry'],
+        'label' => ['type' => 'string', 'x-mcp-header' => 'Label'],
+        'query' => ['type' => 'string'],
+    ]);
+
+    expect(ToolHeaders::extract($schema, [
+        'region' => 'us-west1',
+        'limit' => 42,
+        'dry' => false,
+        'label' => 'Hello, 世界',
+        'query' => 'select 1',
+    ]))->toBe([
+        'Mcp-Param-Region' => 'us-west1',
+        'Mcp-Param-Limit' => '42',
+        'Mcp-Param-Dry' => 'false',
+        'Mcp-Param-Label' => '=?base64?'.base64_encode('Hello, 世界').'?=',
+    ]);
+});
+
+it('omits a header when the argument is absent or null', function (): void {
+    $schema = schemaWith([
+        'region' => ['type' => 'string', 'x-mcp-header' => 'Region'],
+        'zone' => ['type' => 'string', 'x-mcp-header' => 'Zone'],
+    ]);
+
+    expect(ToolHeaders::extract($schema, ['zone' => null]))->toBe([]);
+});
+
+it('extracts a nested value at its exact path', function (): void {
+    $schema = schemaWith([
+        'target' => ['type' => 'object', 'properties' => [
+            'region' => ['type' => 'string', 'x-mcp-header' => 'Region'],
+        ]],
+    ]);
+
+    expect(ToolHeaders::extract($schema, ['target' => ['region' => 'eu-west1']]))
+        ->toBe(['Mcp-Param-Region' => 'eu-west1']);
+});
+
+it('rejects a header name with a trailing newline', function (): void {
+    expect(ToolHeaders::invalid(schemaWith([
+        'region' => ['type' => 'string', 'x-mcp-header' => "Region\n"],
+    ])))->toContain('is not a valid header name token');
+});
+
+it('allows an argument literally named after the annotation', function (): void {
+    expect(ToolHeaders::invalid(schemaWith([
+        'x-mcp-header' => ['type' => 'string'],
+        'region' => ['type' => 'string', 'x-mcp-header' => 'Region'],
+    ])))->toBeNull();
+});
+
+it('rejects an annotation hiding inside a keyword the client cannot reach', function (): void {
+    expect(ToolHeaders::invalid(schemaWith([
+        'region' => [
+            'type' => 'string',
+            'x-mcp-header' => 'Region',
+            'default' => ['x-mcp-header' => 'Sneaky'],
+        ],
+    ])))->toContain('outside the statically reachable properties');
+});
+
+it('refuses to mirror a value it cannot encode', function (): void {
+    expect(fn (): array => ToolHeaders::extract(schemaWith([
+        'region' => ['type' => 'string', 'x-mcp-header' => 'Region'],
+    ]), ['region' => 1.5]))
+        ->toThrow(ClientException::class, 'cannot be mirrored into a header');
+});


### PR DESCRIPTION
Nine protocol changes land together with no single place that tells an upgrader what to do. This PR adds `UPGRADE.md`, with one section per breaking change and its replacement.

```php
// before
public function handle(Request $request): Response
{
    return Response::text($request->sessionId());
}

// after: no sessions, pass state as a tool argument
public function handle(Request $request): Response
{
    return Response::text($request->get('basket_id'));
}
```

It covers the removed handshake and `SessionInitialized`, required request `_meta`, `server/discover`, removed session APIs, mirrored HTTP headers and status codes, result types and caching hints, `InputRequired`, subscriptions, the Apps extension, mirrored tool parameters, client protocol version pinning, client input handlers, and custom client transport changes.

The guide leaves two release checks unchecked: official Inspector coverage and Tier 1 client interoperability. Both require real external clients.

No code changes: this PR documents the breaking protocol migration.

### Spec

- [2026-07-28 changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
- [2026-07-28 specification](https://modelcontextprotocol.io/specification/2026-07-28)

Credit to @JordanDalton, whose #275 mapped out the 2026-07-28 work.

