### PR TITLE
Restore Laravel 11 compatibility in implementation parsing

### DIFF
--- a/src/Schema/Implementation.php
+++ b/src/Schema/Implementation.php
@@ -47,24 +47,54 @@ class Implementation
 
         try {
             return new self(
-                name: Arr::string($data, 'name'),
-                version: Arr::string($data, 'version'),
-                title: Arr::string($data, 'title', '') ?: null,
-                description: Arr::string($data, 'description', '') ?: null,
-                icons: Arr::map(Arr::array($data, 'icons', []), function (mixed $icon): Icon {
+                name: self::stringAt($data, 'name'),
+                version: self::stringAt($data, 'version'),
+                title: self::stringAt($data, 'title', '') ?: null,
+                description: self::stringAt($data, 'description', '') ?: null,
+                icons: Arr::map(self::arrayAt($data, 'icons', []), function (mixed $icon): Icon {
                     $icon = Arr::wrap($icon);
 
                     return Icon::from(
-                        src: Arr::string($icon, 'src'),
-                        mimeType: Arr::string($icon, 'mimeType', '') ?: null,
-                        sizes: array_values(array_filter(Arr::array($icon, 'sizes', []), is_string(...))),
-                        theme: IconTheme::tryFrom(Arr::string($icon, 'theme', '')),
+                        src: self::stringAt($icon, 'src'),
+                        mimeType: self::stringAt($icon, 'mimeType', '') ?: null,
+                        sizes: array_values(array_filter(self::arrayAt($icon, 'sizes', []), is_string(...))),
+                        theme: IconTheme::tryFrom(self::stringAt($icon, 'theme', '')),
                     );
                 }),
-                websiteUrl: Arr::string($data, 'websiteUrl', '') ?: null,
+                websiteUrl: self::stringAt($data, 'websiteUrl', '') ?: null,
             );
         } catch (InvalidArgumentException) {
             return null;
         }
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $array
+     */
+    protected static function stringAt(array $array, string $key, ?string $default = null): string
+    {
+        $value = Arr::get($array, $key, $default);
+
+        if (! is_string($value)) {
+            throw new InvalidArgumentException("The [{$key}] value must be a string.");
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $array
+     * @param  array<array-key, mixed>|null  $default
+     * @return array<array-key, mixed>
+     */
+    protected static function arrayAt(array $array, string $key, ?array $default = null): array
+    {
+        $value = Arr::get($array, $key, $default);
+
+        if (! is_array($value)) {
+            throw new InvalidArgumentException("The [{$key}] value must be an array.");
+        }
+
+        return $value;
     }
 }


### PR DESCRIPTION
`Implementation::from()` uses `Arr::string()` and `Arr::array()`, which only exist in Laravel 12. The package still supports `illuminate/support: ^11.45.3`, so on Laravel 11 every call to it dies with `BadMethodCallException: Method Illuminate\Support\Arr::string does not exist`. That is 145 failing tests on the `PHP 8.2 - Laravel 11` job on `main` right now.

Before:

```php
name: Arr::string($data, 'name'),
icons: Arr::map(Arr::array($data, 'icons', []), ...),
```

After:

```php
name: self::stringAt($data, 'name'),
icons: Arr::map(self::arrayAt($data, 'icons', []), ...),
```

`stringAt()` and `arrayAt()` throw `InvalidArgumentException` on a type mismatch just like the framework helpers do, so the `catch` already in `from()` keeps returning `null` for malformed payloads. Nothing changes on Laravel 12 or 13, and the existing `ImplementationTest` dataset already covers every malformed case.

Happy to drop these for the framework helpers again once the package floor moves to Laravel 12.