### PR TITLE
Acknowledge and gracefully close subscriptions/listen requests

### DIFF
--- a/src/Enums/MetaKey.php
+++ b/src/Enums/MetaKey.php
@@ -10,4 +10,5 @@ enum MetaKey: string
     case CLIENT_CAPABILITIES = 'io.modelcontextprotocol/clientCapabilities';
     case CLIENT_INFO = 'io.modelcontextprotocol/clientInfo';
     case SERVER_INFO = 'io.modelcontextprotocol/serverInfo';
+    case SUBSCRIPTION_ID = 'io.modelcontextprotocol/subscriptionId';
 }

--- a/src/Server.php
+++ b/src/Server.php
@@ -27,6 +27,7 @@ use Laravel\Mcp\Server\Methods\CompletionComplete;
 use Laravel\Mcp\Server\Methods\Concerns\ResolvesResources;
 use Laravel\Mcp\Server\Methods\Discover;
 use Laravel\Mcp\Server\Methods\GetPrompt;
+use Laravel\Mcp\Server\Methods\Listen;
 use Laravel\Mcp\Server\Methods\ListPrompts;
 use Laravel\Mcp\Server\Methods\ListResources;
 use Laravel\Mcp\Server\Methods\ListResourceTemplates;
@@ -134,6 +135,7 @@ abstract class Server
         'prompts/get' => GetPrompt::class,
         'completion/complete' => CompletionComplete::class,
         'server/discover' => Discover::class,
+        'subscriptions/listen' => Listen::class,
     ];
 
     public function __construct(

--- a/src/Server/Methods/Listen.php
+++ b/src/Server/Methods/Listen.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Server\Methods;
+
+use Generator;
+use Laravel\Mcp\Enums\MetaKey;
+use Laravel\Mcp\Server\Contracts\Method;
+use Laravel\Mcp\Server\ServerContext;
+use Laravel\Mcp\Transport\JsonRpcRequest;
+use Laravel\Mcp\Transport\JsonRpcResponse;
+
+class Listen implements Method
+{
+    /**
+     * @return Generator<int, JsonRpcResponse>
+     */
+    public function handle(JsonRpcRequest $request, ServerContext $context): Generator
+    {
+        yield JsonRpcResponse::notification('notifications/subscriptions/acknowledged', [
+            '_meta' => [MetaKey::SUBSCRIPTION_ID->value => $request->id],
+            'notifications' => (object) [],
+        ]);
+
+        yield JsonRpcResponse::result($request->id, [
+            '_meta' => [MetaKey::SUBSCRIPTION_ID->value => $request->id],
+        ]);
+    }
+}

--- a/tests/Feature/Server/SubscriptionsTest.php
+++ b/tests/Feature/Server/SubscriptionsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Tests\Fixtures\ArrayTransport;
+use Tests\Fixtures\ExampleServer;
+
+function listenMessages(array $notifications): array
+{
+    $transport = new ArrayTransport;
+    $server = new ExampleServer($transport);
+
+    $server->start();
+
+    ($transport->handler)((string) json_encode([
+        'jsonrpc' => '2.0',
+        'id' => 7,
+        'method' => 'subscriptions/listen',
+        'params' => [
+            '_meta' => protocolMeta(),
+            'notifications' => $notifications,
+        ],
+    ]));
+
+    return array_map(fn (string $sent): array => json_decode($sent, true), $transport->sent);
+}
+
+it('acknowledges an empty filter first and carries the subscription id', function (): void {
+    $messages = listenMessages(['toolsListChanged' => true]);
+
+    expect($messages[0]['method'])->toBe('notifications/subscriptions/acknowledged');
+    expect($messages[0]['params']['_meta']['io.modelcontextprotocol/subscriptionId'])->toBe(7);
+    expect($messages[0]['params']['notifications'])->toBe([]);
+});
+
+it('closes the subscription immediately with an empty result', function (): void {
+    $messages = listenMessages(['toolsListChanged' => true, 'resourceSubscriptions' => ['file://a']]);
+
+    expect($messages)->toHaveCount(2);
+
+    $last = end($messages);
+
+    expect($last['id'])->toBe(7);
+    expect($last['result']['_meta']['io.modelcontextprotocol/subscriptionId'])->toBe(7);
+});


### PR DESCRIPTION
The 2026-07-28 revision replaced the HTTP GET endpoint and `resources/subscribe` with `subscriptions/listen`, and clients now call it unconditionally on connect, the filter negotiation happens inside the exchange itself instead of through advertised capabilities. Under the earlier protocol this method did not exist, so the server never registered it, and every modern era client now gets this in its logs:

```json
{"jsonrpc":"2.0","id":"listen:2","error":{"code":-32601,"message":"The method [subscriptions/listen] was not found."}}
```

This PR solves that by adding the method. The handler acknowledges the subscription with an empty honored filter and then immediately closes with the graceful closure result the spec defines, because we do not want to hold a long lived connection open inside a PHP or Laravel request:

```json
{"jsonrpc":"2.0","method":"notifications/subscriptions/acknowledged","params":{"_meta":{"io.modelcontextprotocol/subscriptionId":7},"notifications":{}}}
{"jsonrpc":"2.0","id":7,"result":{"resultType":"complete","_meta":{"io.modelcontextprotocol/subscriptionId":7}}}
```

The client learns it is subscribed to nothing and moves on, and the whole exchange fits in a single request lifecycle. Actually delivering change notifications is out of scope until a `listChanged` capability becomes true. Tests included.

