### PR TITLE
Assert tools/list returns tools in declaration order

### DIFF
--- a/tests/Unit/Methods/ListToolsTest.php
+++ b/tests/Unit/Methods/ListToolsTest.php
@@ -523,3 +523,56 @@ it('excludes outputSchema for default object type only', function (): void {
         ->and($payload['result']['tools'])->toHaveCount(1)
         ->and($payload['result']['tools'][0])->not->toHaveKey('outputSchema');
 });
+
+it('lists tools in a deterministic order matching declaration order', function (): void {
+    $context = new ServerContext(
+        supportedProtocolVersions: ['2025-03-26'],
+        serverCapabilities: [],
+        implementation: new Implementation('Test Server', '1.0.0'),
+        instructions: 'Test instructions',
+        maxPaginationLength: 50,
+        defaultPaginationLength: 2,
+        tools: [
+            ToolWithOutputSchema::class,
+            SayHiTool::class,
+            ToolWithoutOutputSchema::class,
+            SayHiWithMetaTool::class,
+        ],
+        resources: [],
+        prompts: [],
+    );
+
+    $declarationOrder = [
+        'tool-with-output-schema',
+        'say-hi-tool',
+        'tool-without-output-schema',
+        'say-hi-with-meta-tool',
+    ];
+
+    $listTools = new ListTools;
+
+    $names = function (array $params) use ($listTools, $context): array {
+        $payload = $listTools->handle(JsonRpcRequest::from([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'list-tools',
+            'params' => $params,
+        ]), $context)->toArray();
+
+        return [
+            array_column($payload['result']['tools'], 'name'),
+            $payload['result']['nextCursor'] ?? null,
+        ];
+    };
+
+    [$first] = $names(['per_page' => 50]);
+    [$second] = $names(['per_page' => 50]);
+
+    expect($first)->toEqual($declarationOrder)
+        ->and($second)->toEqual($first);
+
+    [$pageOne, $cursor] = $names([]);
+    [$pageTwo] = $names(['cursor' => $cursor]);
+
+    expect([...$pageOne, ...$pageTwo])->toEqual($declarationOrder);
+});


### PR DESCRIPTION
The spec says servers SHOULD return tools from `tools/list` in a deterministic order, since clients cache the list and feed it into the model's system prompt. A shuffle between calls busts every prompt-cache entry.

We already satisfy this: `ServerContext::tools()` maps and filters in declaration order, and the paginator calls `->values()` before slicing, so nothing reorders. No autodiscovery either, which is where other SDKs get bitten by filesystem ordering.

So this is just a regression guard, no production change. It lists a non-alphabetical set of tools twice, asserts both calls match declaration order, and checks that two paginated pages concatenate to the same sequence. Stops anyone from later "improving" `resolvePrimitives()` with a `sortBy` or a name-keyed lookup.