### PR TITLE
Add rate limiting to the OAuth client registration endpoint

### DIFF
--- a/config/mcp.php
+++ b/config/mcp.php
@@ -53,6 +53,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Rate Limiting
+    |--------------------------------------------------------------------------
+    |
+    | By default, the OAuth dynamic client registration endpoint is rate limited
+    | to prevent unbounded client creation. You may name your own limiter to
+    | replace it, or set the value to null to remove the limit entirely.
+    |
+    */
+
+    'limiters' => [
+        'register' => 'mcp-register',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Tool Search
     |--------------------------------------------------------------------------
     |

--- a/src/Server/Http/Controllers/OAuthRegisterController.php
+++ b/src/Server/Http/Controllers/OAuthRegisterController.php
@@ -26,8 +26,8 @@ class OAuthRegisterController
         $validator = Validator::make($request->all(), [
             'client_name' => ['nullable', 'string', 'min:1', 'max:255'],
             'name' => ['nullable', 'string', 'min:1', 'max:255'],
-            'redirect_uris' => ['required', 'array', 'min:1'],
-            'redirect_uris.*' => ['required', 'string', function (string $attribute, $value, $fail): void {
+            'redirect_uris' => ['required', 'array', 'min:1', 'max:5'],
+            'redirect_uris.*' => ['required', 'string', 'max:2048', function (string $attribute, $value, $fail): void {
                 if (! $this->isValidRedirectUri($value)) {
                     $fail($attribute.' is not a valid URL.');
 

--- a/src/Server/McpServiceProvider.php
+++ b/src/Server/McpServiceProvider.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp\Server;
 
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request as HttpRequest;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Mcp\Client\ClientManager;
@@ -32,6 +35,7 @@ class McpServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->registerMcpScope();
+        $this->registerRateLimiter();
         $this->registerRoutes();
         $this->registerContainerCallbacks();
         $this->registerClientDisconnect();
@@ -66,6 +70,17 @@ class McpServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../../config/mcp.php' => config_path('mcp.php'),
         ], 'mcp-config');
+    }
+
+    protected function registerRateLimiter(): void
+    {
+        $this->app->booted(function (): void {
+            if (RateLimiter::limiter('mcp-register') !== null) {
+                return;
+            }
+
+            RateLimiter::for('mcp-register', fn (HttpRequest $request): Limit => Limit::perMinute(10)->by((string) $request->ip()));
+        });
     }
 
     protected function registerRoutes(): void

--- a/src/Server/Registrar.php
+++ b/src/Server/Registrar.php
@@ -151,7 +151,11 @@ class Registrar
             ->where('path', '.*')
             ->name('mcp.oauth.authorization-server.nested');
 
-        Router::post($oauthPrefix.'/register', OAuthRegisterController::class);
+        $route = Router::post($oauthPrefix.'/register', OAuthRegisterController::class);
+
+        if (is_string($limiter = config('mcp.limiters.register'))) {
+            $route->middleware("throttle:{$limiter}");
+        }
     }
 
     /**

--- a/tests/Unit/Server/RegistrarTest.php
+++ b/tests/Unit/Server/RegistrarTest.php
@@ -938,3 +938,74 @@ it('returns json validation errors even without Accept application/json header',
     $response->assertHeader('Content-Type', 'application/json');
     $response->assertJsonStructure(['error', 'error_description']);
 });
+
+it('rejects more than five redirect URIs', function (): void {
+    ensureMockClientRepository();
+
+    $registrar = new Registrar;
+    $registrar->oauthRoutes();
+
+    $this->app->instance(ClientRepository::class, new ClientRepository);
+
+    $response = $this->postJson('/oauth/register', [
+        'client_name' => 'Test Client',
+        'redirect_uris' => array_map(
+            fn (int $port): string => "http://localhost:{$port}/callback",
+            range(3000, 3005),
+        ),
+    ]);
+
+    $response->assertStatus(400);
+    $response->assertJson(['error' => 'invalid_redirect_uri']);
+});
+
+it('rejects a redirect URI longer than 2048 characters', function (): void {
+    ensureMockClientRepository();
+
+    $registrar = new Registrar;
+    $registrar->oauthRoutes();
+
+    $this->app->instance(ClientRepository::class, new ClientRepository);
+
+    $response = $this->postJson('/oauth/register', [
+        'client_name' => 'Test Client',
+        'redirect_uris' => ['http://localhost:3000/'.str_repeat('a', 2048)],
+    ]);
+
+    $response->assertStatus(400);
+    $response->assertJson(['error' => 'invalid_redirect_uri']);
+});
+
+it('throttles the registration endpoint', function (): void {
+    ensureMockClientRepository();
+
+    $registrar = new Registrar;
+    $registrar->oauthRoutes();
+
+    $this->app->instance(ClientRepository::class, new ClientRepository);
+
+    foreach (range(1, 10) as $ignored) {
+        $this->postJson('/oauth/register', [
+            'client_name' => 'Test Client',
+            'redirect_uris' => ['http://localhost:3000/callback'],
+        ])->assertStatus(201);
+    }
+
+    $this->postJson('/oauth/register', [
+        'client_name' => 'Test Client',
+        'redirect_uris' => ['http://localhost:3000/callback'],
+    ])->assertStatus(429);
+});
+
+it('does not throttle the registration endpoint when the throttle is disabled', function (): void {
+    config()->set('mcp.limiters.register');
+
+    $registrar = new Registrar;
+    $registrar->oauthRoutes();
+
+    $route = collect(Route::getRoutes())->first(
+        fn ($route): bool => $route->uri() === 'oauth/register'
+    );
+
+    expect($route->gatherMiddleware())->not->toContain('throttle:mcp-register');
+});


### PR DESCRIPTION
This PR adds rate limiting to the OAuth dynamic client registration endpoint, following the same shape Fortify uses:

```php
// config/mcp.php
'limiters' => [
    'register' => 'mcp-register',
],
```

The default is 10 per minute per IP and gets registered in the service provider, so it applies without anyone needing to publish the config first. There are three ways to change it: define your own `mcp-register` limiter, point the config at a different limiter name, or set it to `null` to turn it off.

```php
RateLimiter::for('mcp-register', fn ($request) => Limit::perMinute(60)->by($request->ip()));
```

Registration payloads also now cap `redirect_uris` at 5 entries of 2048 characters each, which every real client fits inside comfortably.