### PR TITLE
Port searchable tool catalogs and inspector route prompts from 0.x

### DIFF
--- a/config/mcp.php
+++ b/config/mcp.php
@@ -51,4 +51,20 @@ return [
 
     'authorization_server' => null,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Tool Search
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the limits enforced during tool search. The maximum
+    | number of tool calls limits how many tools each search request can run
+    | while the maximum output bytes value caps the size of every result.
+    |
+    */
+
+    'tool_search' => [
+        'max_tool_calls' => 10,
+        'max_output_bytes' => 65_536,
+    ],
+
 ];

--- a/src/Console/Commands/InspectorCommand.php
+++ b/src/Console/Commands/InspectorCommand.php
@@ -6,7 +6,9 @@ namespace Laravel\Mcp\Console\Commands;
 
 use Exception;
 use Illuminate\Console\Command;
+use Illuminate\Routing\Exceptions\UrlGenerationException;
 use Illuminate\Routing\Route;
+use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\Arr;
 use Laravel\Mcp\Server\Registrar;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -89,7 +91,14 @@ class InspectorCommand extends Command
                 ]),
             ];
         } else {
-            $serverUrl = url($route->uri());
+            try {
+                $serverUrl = $this->serverUrl($route);
+            } catch (UrlGenerationException) {
+                $this->components->error('Every route parameter needs a value to inspect this server');
+
+                return static::FAILURE;
+            }
+
             if (parse_url($serverUrl, PHP_URL_SCHEME) === 'https') {
                 $env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
             }
@@ -171,6 +180,21 @@ class InspectorCommand extends Command
             ['host', null, InputOption::VALUE_OPTIONAL, 'The host the inspector should bind to'],
             ['port', null, InputOption::VALUE_OPTIONAL, 'The port the inspector should bind to'],
         ];
+    }
+
+    protected function serverUrl(Route $route): string
+    {
+        $parameters = [];
+
+        foreach ($route->parameterNames() as $parameter) {
+            $value = trim((string) $this->components->ask("What is the value for the [{$parameter}] route parameter?"));
+
+            if ($value !== '') {
+                $parameters[$parameter] = $value;
+            }
+        }
+
+        return $this->laravel->make(UrlGenerator::class)->toRoute($route, $parameters, true);
     }
 
     protected function phpBinary(): string

--- a/src/Server.php
+++ b/src/Server.php
@@ -104,7 +104,7 @@ abstract class Server
     ];
 
     /**
-     * @var array<int, Tool|class-string<Tool>>
+     * @var array<int|string, Tool|class-string<Tool>|array<int, Tool|class-string<Tool>>>
      */
     protected array $tools = [];
 

--- a/src/Server/Methods/CallTool.php
+++ b/src/Server/Methods/CallTool.php
@@ -5,22 +5,16 @@ declare(strict_types=1);
 namespace Laravel\Mcp\Server\Methods;
 
 use Generator;
-use Illuminate\Container\Container;
 use Laravel\Mcp\Exceptions\JsonRpcException;
-use Laravel\Mcp\Response;
-use Laravel\Mcp\ResponseFactory;
 use Laravel\Mcp\Server\Contracts\Errable;
 use Laravel\Mcp\Server\Contracts\Method;
-use Laravel\Mcp\Server\Methods\Concerns\InteractsWithResponses;
 use Laravel\Mcp\Server\ServerContext;
-use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\ToolInvoker;
 use Laravel\Mcp\Transport\JsonRpcRequest;
 use Laravel\Mcp\Transport\JsonRpcResponse;
 
 class CallTool implements Errable, Method
 {
-    use InteractsWithResponses;
-
     /**
      * @return JsonRpcResponse|Generator<JsonRpcResponse>
      *
@@ -46,24 +40,6 @@ class CallTool implements Errable, Method
                     $request->id,
                 ));
 
-        // @phpstan-ignore-next-line
-        $response = $this->callHandler(fn (): mixed => Container::getInstance()->call([$tool, 'handle']), $request);
-
-        return is_iterable($response)
-            ? $this->toJsonRpcStreamedResponse($request, $response, $this->serializable($tool))
-            : $this->toJsonRpcResponse($request, $response, $this->serializable($tool));
-    }
-
-    /**
-     * @return callable(ResponseFactory): array<string, mixed>
-     */
-    protected function serializable(Tool $tool): callable
-    {
-        return fn (ResponseFactory $factory): array => $factory->mergeStructuredContent(
-            $factory->mergeMeta([
-                'content' => $factory->responses()->map(fn (Response $response): array => $response->content()->toTool($tool))->all(),
-                'isError' => $factory->responses()->contains(fn (Response $response): bool => $response->isError()),
-            ])
-        );
+        return (new ToolInvoker)->invoke($tool, $request);
     }
 }

--- a/src/Server/ServerContext.php
+++ b/src/Server/ServerContext.php
@@ -6,15 +6,17 @@ namespace Laravel\Mcp\Server;
 
 use Illuminate\Container\Container;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 use Laravel\Mcp\Schema\Implementation;
 use Laravel\Mcp\Server\Contracts\HasUriTemplate;
+use Laravel\Mcp\Server\Tools\ToolSearch;
 
 class ServerContext
 {
     /**
      * @param  array<int, string>  $supportedProtocolVersions
      * @param  array<string, mixed>  $serverCapabilities
-     * @param  array<int, Tool|string>  $tools
+     * @param  array<int|string, Tool|string|array<int, Tool|string>>  $tools
      * @param  array<int, Resource|string>  $resources
      * @param  array<int, Prompt|string>  $prompts
      */
@@ -37,10 +39,40 @@ class ServerContext
      */
     public function tools(): Collection
     {
-        /** @var Collection<int,Tool> $tools */
-        $tools = collect($this->tools);
+        $configuredTools = collect($this->tools)->map(function (Tool|string|array $tool, int|string $key): Tool|ToolSearch|string {
+            if ($key !== ToolSearch::class) {
+                if (is_array($tool)) {
+                    throw new InvalidArgumentException('Tool groups must use ToolSearch::class as their key.');
+                }
 
-        return $this->resolvePrimitives($tools);
+                return $tool;
+            }
+
+            if (! is_array($tool)) {
+                throw new InvalidArgumentException('The ToolSearch::class entry must contain an array of tools.');
+            }
+
+            return new ToolSearch($tool);
+        });
+
+        $hasToolSearch = $configuredTools->contains(fn (Tool|ToolSearch|string $tool): bool => $tool instanceof ToolSearch);
+
+        /** @var Collection<int, Tool|string> $tools */
+        $tools = $configuredTools->flatMap(fn (Tool|ToolSearch|string $tool): array => $tool instanceof ToolSearch
+            ? $tool->tools()
+            : [$tool]);
+
+        $tools = $this->resolvePrimitives($tools);
+
+        if ($hasToolSearch) {
+            $duplicate = $tools->map(fn (Tool $tool): string => $tool->name())->duplicates()->first();
+
+            if (is_string($duplicate)) {
+                throw new InvalidArgumentException("Duplicate server tool name [{$duplicate}].");
+            }
+        }
+
+        return $tools;
     }
 
     /**

--- a/src/Server/ToolInvoker.php
+++ b/src/Server/ToolInvoker.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Server;
+
+use Generator;
+use Illuminate\Container\Container;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Contracts\Errable;
+use Laravel\Mcp\Server\Methods\Concerns\InteractsWithResponses;
+use Laravel\Mcp\Transport\JsonRpcRequest;
+use Laravel\Mcp\Transport\JsonRpcResponse;
+
+class ToolInvoker implements Errable
+{
+    use InteractsWithResponses;
+
+    public function invoke(Tool $tool, JsonRpcRequest $request): Generator|JsonRpcResponse
+    {
+        // @phpstan-ignore-next-line
+        $response = $this->callHandler(fn (): mixed => Container::getInstance()->call([$tool, 'handle']), $request);
+
+        return is_iterable($response)
+            ? $this->toJsonRpcStreamedResponse($request, $response, $this->serializable($tool))
+            : $this->toJsonRpcResponse($request, $response, $this->serializable($tool));
+    }
+
+    protected function serializable(Tool $tool): callable
+    {
+        return fn (ResponseFactory $factory): array => $factory->mergeStructuredContent(
+            $factory->mergeMeta([
+                'content' => $factory->responses()->map(fn (Response $response): array => $response->content()->toTool($tool))->all(),
+                'isError' => $factory->responses()->contains(fn (Response $response): bool => $response->isError()),
+            ])
+        );
+    }
+}

--- a/src/Server/Tools/ExecuteTools.php
+++ b/src/Server/Tools/ExecuteTools.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Server\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Validation\ValidationException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
+
+#[IsOpenWorld]
+class ExecuteTools extends Tool
+{
+    protected string $name = 'execute_tools';
+
+    protected string $title = 'Execute Tools';
+
+    public function __construct(protected ToolSearch $catalog, protected int $maxToolCalls) {}
+
+    public function description(): string
+    {
+        return 'Execute one or more independent catalog tools synchronously in order. Pass {"calls":[{"name":"tool_name","arguments":{"key":"value"}}]} using exact names and arguments returned by search_tools. Execution stops on the first error. If a call depends on a previous result, invoke execute_tools again with a new calls array.';
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'calls' => $schema->array()
+                ->items($schema->object([
+                    'name' => $schema->string()->max(255)->description('The exact tool name returned by search_tools.')->required(),
+                    'arguments' => $schema->object()->description('Arguments matching the tool input schema.'),
+                ])->withoutAdditionalProperties())
+                ->min(1)
+                ->max($this->maxToolCalls)
+                ->description('Independent tool calls to execute synchronously in order.')
+                ->required(),
+        ];
+    }
+
+    /**
+     * @return array<int, Response>
+     */
+    public function handle(Request $request): array
+    {
+        $request->validate([
+            'calls' => ['required', 'array', 'min:1', 'max:'.$this->maxToolCalls],
+            'calls.*' => ['array:name,arguments'],
+            'calls.*.name' => ['required', 'string', 'max:255'],
+            'calls.*.arguments' => ['array'],
+        ]);
+
+        $calls = $request->get('calls');
+
+        if (! is_array($calls) || ! array_is_list($calls)) {
+            throw ValidationException::withMessages(['calls' => 'The calls field must be a list.']);
+        }
+
+        foreach ($calls as $index => $call) {
+            $arguments = $call['arguments'] ?? [];
+
+            if ($arguments !== [] && array_is_list($arguments)) {
+                throw ValidationException::withMessages(["calls.{$index}.arguments" => 'The arguments field must be an object.']);
+            }
+        }
+
+        return $this->catalog->execute($calls, $request);
+    }
+}

--- a/src/Server/Tools/SearchTools.php
+++ b/src/Server/Tools/SearchTools.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Server\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+class SearchTools extends Tool
+{
+    protected string $name = 'search_tools';
+
+    protected string $title = 'Search Tools';
+
+    public function __construct(protected ToolSearch $catalog) {}
+
+    public function description(): string
+    {
+        return 'Search the tools available through execute_tools. Returns exact tool names, descriptions, and complete input schemas. An empty query browses the catalog.';
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'query' => $schema->string()->max(4096)->description('Search terms. An empty query browses the catalog.'),
+            'limit' => $schema->integer()->min(1)->max(50)->description('Maximum results to return. Defaults to 10.'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $request->validate([
+            'query' => ['nullable', 'string', 'max:4096'],
+            'limit' => ['nullable', 'integer', 'between:1,50'],
+        ]);
+
+        $result = $this->catalog->search(
+            (string) $request->get('query', ''),
+            (int) $request->get('limit', 10),
+        );
+
+        return $this->catalog->response($result, ! $result['ok']);
+    }
+}

--- a/src/Server/Tools/ToolSearch.php
+++ b/src/Server/Tools/ToolSearch.php
@@ -1,0 +1,292 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Server\Tools;
+
+use Illuminate\Container\Container;
+use Illuminate\Support\Collection;
+use InvalidArgumentException;
+use JsonException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\ToolInvoker;
+use Laravel\Mcp\Transport\JsonRpcRequest;
+use Laravel\Mcp\Transport\JsonRpcResponse;
+
+class ToolSearch
+{
+    protected int $maxToolCalls;
+
+    protected int $maxOutputBytes;
+
+    /**
+     * @var array<int, Tool|string>
+     */
+    protected array $tools = [];
+
+    /**
+     * @param  iterable<Tool|string>  $tools
+     */
+    public function __construct(iterable $tools)
+    {
+        $config = Container::getInstance()->make('config');
+
+        $this->maxToolCalls = max(1, (int) $config->get('mcp.tool_search.max_tool_calls', 25));
+        $this->maxOutputBytes = max(256, (int) $config->get('mcp.tool_search.max_output_bytes', 65_536));
+
+        foreach ($tools as $tool) {
+            if (! $tool instanceof Tool && (! is_string($tool) || ! is_subclass_of($tool, Tool::class))) {
+                throw new InvalidArgumentException('ToolSearch entries must be tool instances or tool class names.');
+            }
+
+            $this->tools[] = $tool;
+        }
+    }
+
+    /**
+     * @return array{SearchTools, ExecuteTools}
+     */
+    public function tools(): array
+    {
+        return [new SearchTools($this), new ExecuteTools($this, $this->maxToolCalls)];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function search(string $query, int $limit): array
+    {
+        $terms = $this->terms($query);
+
+        $candidates = $this->resolvedTools()
+            ->filter(fn (Tool $tool): bool => $tool->eligibleForRegistration())
+            ->values()
+            ->map(function (Tool $tool, int $index) use ($terms): array {
+                $definition = $tool->toArray();
+                $schema = $definition['inputSchema'] ?? ['type' => 'object', 'properties' => (object) []];
+                $name = mb_strtolower($tool->name());
+                $description = mb_strtolower($tool->description());
+                $schemaText = mb_strtolower(json_encode($schema, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE | JSON_UNESCAPED_UNICODE));
+                $score = $terms !== [] && $terms === $this->terms($name) ? 8 : 0;
+
+                foreach ($terms as $term) {
+                    $score += str_contains($name, $term) ? 4 : 0;
+                    $score += str_contains($description, $term) ? 2 : 0;
+                    $score += str_contains($schemaText, $term) ? 1 : 0;
+                }
+
+                $annotations = $definition['annotations'] ?? [];
+
+                return [
+                    'index' => $index,
+                    'score' => $score,
+                    'tool' => [
+                        'name' => $tool->name(),
+                        'description' => $tool->description(),
+                        'inputSchema' => $schema,
+                        ...is_array($annotations) && $annotations !== [] ? ['annotations' => $annotations] : [],
+                    ],
+                ];
+            })
+            ->filter(fn (array $candidate): bool => $terms === [] || $candidate['score'] > 0)
+            ->sort(fn (array $left, array $right): int => $right['score'] <=> $left['score'] ?: $left['index'] <=> $right['index'])
+            ->values();
+
+        $tools = [];
+        $hasMore = $candidates->count() > $limit;
+        $size = $this->outputSize(['ok' => true, 'tools' => [], 'hasMore' => false]);
+
+        foreach ($candidates->take($limit) as $candidate) {
+            $size += $this->outputSize($candidate['tool']) + 1;
+
+            if ($size > $this->maxOutputBytes) {
+                if ($tools === []) {
+                    return $this->outputLimitExceeded();
+                }
+
+                $hasMore = true;
+
+                break;
+            }
+
+            $tools[] = $candidate['tool'];
+        }
+
+        return ['ok' => true, 'tools' => $tools, 'hasMore' => $hasMore];
+    }
+
+    /**
+     * @param  array<int, array{name: string, arguments?: array<string, mixed>}>  $calls
+     * @return array<int, Response>
+     */
+    public function execute(array $calls, Request $parentRequest): array
+    {
+        $results = [];
+        $responses = [];
+        $tools = $this->resolvedTools();
+        $size = $this->outputSize(['ok' => true, 'results' => []]);
+
+        foreach ($calls as $index => $call) {
+            $invocation = $this->invokeTool($tools, $call['name'], $call['arguments'] ?? [], $parentRequest, $index);
+            $result = $invocation['result'];
+            array_push($responses, ...$invocation['notifications']);
+            $results[] = $entry = ['name' => $call['name'], ...$result];
+            $size += $this->outputSize($entry) + 1;
+
+            if ($size > $this->maxOutputBytes) {
+                return [...$responses, $this->response($this->outputLimitExceeded(count($results), $index + 1), true)];
+            }
+
+            if ($result['isError']) {
+                return [...$responses, $this->response(['ok' => false, 'results' => $results], true)];
+            }
+        }
+
+        return [...$responses, $this->response(['ok' => true, 'results' => $results])];
+    }
+
+    /**
+     * @param  array<string, mixed>  $content
+     */
+    public function response(array $content, bool $isError = false): Response
+    {
+        $json = json_encode($content, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        return $isError ? Response::error($json) : Response::text($json);
+    }
+
+    /**
+     * @param  Collection<int, Tool>  $tools
+     * @param  array<string, mixed>  $arguments
+     * @return array{notifications: array<int, Response>, result: array<string, mixed>}
+     */
+    protected function invokeTool(Collection $tools, string $name, array $arguments, Request $parentRequest, int $index): array
+    {
+        $params = ['name' => $name, 'arguments' => $arguments];
+
+        if ($parentRequest->meta() !== null) {
+            $params['_meta'] = $parentRequest->meta();
+        }
+
+        $request = new JsonRpcRequest(
+            id: "execute-tools:{$index}",
+            method: 'tools/call',
+            params: $params,
+        );
+
+        $container = Container::getInstance();
+        $hadParentRequest = $container->bound('mcp.request');
+        $boundParentRequest = $hadParentRequest ? $container->make('mcp.request') : null;
+        $container->instance('mcp.request', $request->toRequest());
+
+        try {
+            $tool = $tools->first(fn (Tool $tool): bool => $tool->name() === $name);
+
+            if (! $tool instanceof Tool) {
+                return ['notifications' => [], 'result' => $this->failedResult("Tool [{$name}] was not found in the catalog.")];
+            }
+
+            if (! $tool->eligibleForRegistration()) {
+                return ['notifications' => [], 'result' => $this->failedResult("Tool [{$name}] is not available.")];
+            }
+
+            $toolResponses = (new ToolInvoker)->invoke($tool, $request);
+            $toolResponses = $toolResponses instanceof JsonRpcResponse ? [$toolResponses] : $toolResponses;
+            $notifications = [];
+            $result = null;
+
+            foreach ($toolResponses as $toolResponse) {
+                $payload = $toolResponse->toArray();
+
+                if (isset($payload['method'])) {
+                    $notifications[] = Response::notification($payload['method'], is_array($payload['params']) ? $payload['params'] : []);
+
+                    continue;
+                }
+
+                $result = $payload['result'];
+            }
+
+            return [
+                'notifications' => $notifications,
+                'result' => $result ?? $this->failedResult("Tool [{$name}] returned no result."),
+            ];
+        } finally {
+            if ($hadParentRequest) {
+                $container->instance('mcp.request', $boundParentRequest);
+            } else {
+                $container->forgetInstance('mcp.request');
+            }
+        }
+    }
+
+    /**
+     * @return Collection<int, Tool>
+     */
+    protected function resolvedTools(): Collection
+    {
+        $tools = collect($this->tools)->map(fn (Tool|string $tool): Tool => is_string($tool)
+            ? Container::getInstance()->make($tool)
+            : $tool);
+
+        $duplicate = $tools->map(fn (Tool $tool): string => $tool->name())->duplicates()->first();
+
+        if (is_string($duplicate)) {
+            throw new InvalidArgumentException("Duplicate tool name [{$duplicate}] in ToolSearch catalog.");
+        }
+
+        return $tools->values();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function terms(string $text): array
+    {
+        return array_values(array_filter(
+            preg_split('/[^\pL\pN]+/u', mb_strtolower($text)) ?: [],
+            fn (string $term): bool => $term !== '',
+        ));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function failedResult(string $message): array
+    {
+        return [
+            'content' => [['type' => 'text', 'text' => $message]],
+            'isError' => true,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function outputLimitExceeded(int $completedToolCalls = 0, int $attemptedToolCalls = 0): array
+    {
+        return [
+            'ok' => false,
+            'error' => [
+                'kind' => 'OutputLimitExceeded',
+                'message' => "The tool output exceeded {$this->maxOutputBytes} bytes.",
+            ],
+            'completedToolCalls' => $completedToolCalls,
+            'attemptedToolCalls' => $attemptedToolCalls,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $output
+     */
+    protected function outputSize(array $output): int
+    {
+        try {
+            return strlen(json_encode($output, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } catch (JsonException $jsonException) {
+            throw new InvalidArgumentException("Unable to encode the tool output: {$jsonException->getMessage()}", 0, $jsonException);
+        }
+    }
+}

--- a/tests/Unit/Console/Commands/McpInspectorCommandTest.php
+++ b/tests/Unit/Console/Commands/McpInspectorCommandTest.php
@@ -2,10 +2,12 @@
 
 declare(strict_types=1);
 
+use Illuminate\Console\View\Components\Factory;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\UrlGenerator;
 use Laravel\Mcp\Console\Commands\InspectorCommand;
 use Laravel\Mcp\Server\Registrar;
+use Tests\Fixtures\ExampleServer;
 
 beforeEach(function (): void {
     $this->registrar = Mockery::mock(Registrar::class);
@@ -241,4 +243,65 @@ it('retrieves php binary path correctly', function (): void {
     // Should return either a path to php or 'php'
     expect($phpBinary)->toBeString();
     expect(strlen((string) $phpBinary))->toBeGreaterThan(0);
+});
+
+it('asks for route parameter values when building the server url', function (): void {
+    $route = (new Registrar)->web('mcp/{organisation:uuid}', ExampleServer::class);
+
+    $components = Mockery::mock(Factory::class);
+    $components->shouldReceive('ask')
+        ->once()
+        ->with('What is the value for the [organisation] route parameter?')
+        ->andReturn('4f8a1c2e');
+
+    $command = new InspectorCommand;
+    $command->setLaravel($this->app);
+
+    (new ReflectionProperty($command, 'components'))->setValue($command, $components);
+
+    $serverUrl = (new ReflectionMethod($command, 'serverUrl'))->invoke($command, $route);
+
+    expect($serverUrl)->toBe('http://localhost/mcp/4f8a1c2e');
+});
+
+it('fails when a route parameter is left blank', function (): void {
+    $route = (new Registrar)->web('mcp/{organisation:uuid}', ExampleServer::class);
+
+    $this->registrar
+        ->shouldReceive('getLocalServer')
+        ->with('demo')
+        ->andReturn(null);
+
+    $this->registrar
+        ->shouldReceive('getWebServer')
+        ->with('demo')
+        ->andReturn($route);
+
+    $this->registrar->shouldReceive('servers')->andReturn(['demo' => $route]);
+
+    $this->artisan('mcp:inspector', ['handle' => 'demo'])
+        ->expectsQuestion('What is the value for the [organisation] route parameter?', null)
+        ->expectsOutputToContain('Every route parameter needs a value to inspect this server')
+        ->assertExitCode(1);
+});
+
+it('fails when a route parameter only contains whitespace', function (): void {
+    $route = (new Registrar)->web('mcp/{organisation:uuid}', ExampleServer::class);
+
+    $this->registrar
+        ->shouldReceive('getLocalServer')
+        ->with('demo')
+        ->andReturn(null);
+
+    $this->registrar
+        ->shouldReceive('getWebServer')
+        ->with('demo')
+        ->andReturn($route);
+
+    $this->registrar->shouldReceive('servers')->andReturn(['demo' => $route]);
+
+    $this->artisan('mcp:inspector', ['handle' => 'demo'])
+        ->expectsQuestion('What is the value for the [organisation] route parameter?', '   ')
+        ->expectsOutputToContain('Every route parameter needs a value to inspect this server')
+        ->assertExitCode(1);
 });

--- a/tests/Unit/Tools/ToolSearchTest.php
+++ b/tests/Unit/Tools/ToolSearchTest.php
@@ -1,0 +1,339 @@
+<?php
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Collection;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Schema\Implementation;
+use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Methods\CallTool;
+use Laravel\Mcp\Server\ServerContext;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+use Laravel\Mcp\Server\Tools\ExecuteTools;
+use Laravel\Mcp\Server\Tools\SearchTools;
+use Laravel\Mcp\Server\Tools\ToolSearch;
+use Laravel\Mcp\Server\Transport\FakeTransporter;
+use Laravel\Mcp\Transport\JsonRpcRequest;
+use Laravel\Mcp\Transport\JsonRpcResponse;
+use Tests\Fixtures\SayHiTool;
+use Tests\Fixtures\StreamingTool;
+use Tests\Fixtures\StructuredContentTool;
+
+it('supports declaring a searchable tool group on the server', function (): void {
+    $server = new class(new FakeTransporter) extends Server
+    {
+        protected array $tools = [
+            StructuredContentTool::class,
+            ToolSearch::class => [
+                SayHiTool::class,
+            ],
+        ];
+    };
+
+    $context = $server->createContext();
+    $tools = $context->tools();
+    $searchTools = $tools->first(fn (Tool $tool): bool => $tool->name() === 'search_tools');
+
+    expect($tools->map(fn (Tool $tool): string => $tool->name())->all())->toBe([
+        'structured-content-tool',
+        'search_tools',
+        'execute_tools',
+    ])->and($searchTools)->toBeInstanceOf(SearchTools::class);
+
+    if (! $searchTools instanceof Tool) {
+        throw new LogicException('The search tool was not registered.');
+    }
+
+    $result = callContextTool($context, $searchTools, ['query' => 'person name']);
+
+    expect($result['payload']['tools'][0]['name'])->toBe('say-hi-tool');
+});
+
+it('searches hidden tools and returns their complete schemas', function (): void {
+    $context = toolSearchContext([
+        SayHiTool::class,
+        StructuredContentTool::class,
+    ]);
+    $searchTools = toolFromContext($context, 'search_tools');
+
+    $result = callContextTool($context, $searchTools, [
+        'query' => 'person name',
+    ]);
+
+    expect($searchTools)->toBeInstanceOf(SearchTools::class)
+        ->and($searchTools->name())->toBe('search_tools')
+        ->and($result['isError'])->toBeFalse()
+        ->and($result['payload'])->toEqual([
+            'ok' => true,
+            'tools' => [[
+                'name' => 'say-hi-tool',
+                'description' => 'This tool says hello to a person',
+                'inputSchema' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                            'description' => 'The name of the person to greet',
+                        ],
+                    ],
+                    'required' => ['name'],
+                ],
+            ]],
+            'hasMore' => false,
+        ]);
+});
+
+it('includes tool annotations in search results', function (): void {
+    $annotatedTool = new #[IsDestructive] class extends Tool
+    {
+        protected string $name = 'delete-thing-tool';
+
+        protected string $description = 'Deletes a thing';
+
+        public function handle(): Response
+        {
+            return Response::text('deleted');
+        }
+    };
+
+    $context = toolSearchContext([$annotatedTool]);
+    $searchTools = toolFromContext($context, 'search_tools');
+
+    $result = callContextTool($context, $searchTools, ['query' => 'delete']);
+
+    expect($result['payload']['tools'][0]['annotations'])->toBe(['destructiveHint' => true]);
+});
+
+it('executes multiple independent tools synchronously', function (): void {
+    $context = toolSearchContext([
+        SayHiTool::class,
+        StructuredContentTool::class,
+    ]);
+    $executeTools = toolFromContext($context, 'execute_tools');
+
+    $result = callContextTool($context, $executeTools, [
+        'calls' => [
+            ['name' => 'say-hi-tool', 'arguments' => ['name' => 'Taylor']],
+            ['name' => 'structured-content-tool', 'arguments' => []],
+        ],
+    ]);
+
+    expect($executeTools)->toBeInstanceOf(ExecuteTools::class)
+        ->and($executeTools->name())->toBe('execute_tools')
+        ->and($result['isError'])->toBeFalse()
+        ->and($result['payload'])->toBe([
+            'ok' => true,
+            'results' => [
+                [
+                    'name' => 'say-hi-tool',
+                    'content' => [['type' => 'text', 'text' => 'Hello, Taylor!']],
+                    'isError' => false,
+                ],
+                [
+                    'name' => 'structured-content-tool',
+                    'content' => [['type' => 'text', 'text' => '{"temperature":22.5,"conditions":"Partly cloudy","humidity":65}']],
+                    'isError' => false,
+                    'structuredContent' => [
+                        'temperature' => 22.5,
+                        'conditions' => 'Partly cloudy',
+                        'humidity' => 65,
+                    ],
+                ],
+            ],
+        ]);
+});
+
+it('stops executing after the first tool error', function (): void {
+    $calls = [];
+
+    $recordingTool = new class($calls) extends Tool
+    {
+        public function __construct(private array &$calls) {}
+
+        public function handle(Request $request): Response
+        {
+            $this->calls[] = $request->get('value');
+
+            return Response::text((string) $request->get('value'));
+        }
+
+        public function schema(JsonSchema $schema): array
+        {
+            return ['value' => $schema->string()->required()];
+        }
+    };
+
+    $context = toolSearchContext([
+        SayHiTool::class,
+        $recordingTool,
+    ]);
+    $executeTools = toolFromContext($context, 'execute_tools');
+
+    $result = callContextTool($context, $executeTools, [
+        'calls' => [
+            ['name' => 'say-hi-tool', 'arguments' => []],
+            ['name' => $recordingTool->name(), 'arguments' => ['value' => 'not-run']],
+        ],
+    ]);
+
+    expect($result['isError'])->toBeTrue()
+        ->and($result['payload']['ok'])->toBeFalse()
+        ->and($result['payload']['results'])->toHaveCount(1)
+        ->and($result['payload']['results'][0]['isError'])->toBeTrue()
+        ->and($calls)->toBe([]);
+});
+
+it('forwards nested tool notifications', function (): void {
+    $context = toolSearchContext([StreamingTool::class]);
+    $executeTools = toolFromContext($context, 'execute_tools');
+    $responses = callContextToolResponses($context, $executeTools, [
+        'calls' => [[
+            'name' => 'streaming-tool',
+            'arguments' => ['count' => 2],
+        ]],
+    ]);
+
+    expect($responses)->toHaveCount(3)
+        ->and($responses[0]['method'])->toBe('stream/progress')
+        ->and($responses[1]['method'])->toBe('stream/progress')
+        ->and(json_decode($responses[2]['result']['content'][0]['text'], true)['ok'])->toBeTrue();
+});
+
+it('enforces the configured call and output limits', function (): void {
+    config()->set('mcp.tool_search.max_tool_calls', 1);
+    config()->set('mcp.tool_search.max_output_bytes', 256);
+
+    $context = toolSearchContext([SayHiTool::class]);
+    $executeTools = toolFromContext($context, 'execute_tools');
+
+    $callLimit = callContextTool($context, $executeTools, [
+        'calls' => [
+            ['name' => 'say-hi-tool', 'arguments' => ['name' => 'One']],
+            ['name' => 'say-hi-tool', 'arguments' => ['name' => 'Two']],
+        ],
+    ]);
+
+    $outputLimit = callContextTool($context, $executeTools, [
+        'calls' => [[
+            'name' => 'say-hi-tool',
+            'arguments' => ['name' => str_repeat('x', 256)],
+        ]],
+    ]);
+
+    expect($callLimit['isError'])->toBeTrue()
+        ->and($callLimit['content'][0]['text'])->toContain('The calls field must not have more than 1 items.')
+        ->and($outputLimit['payload'])->toBe([
+            'ok' => false,
+            'error' => [
+                'kind' => 'OutputLimitExceeded',
+                'message' => 'The tool output exceeded 256 bytes.',
+            ],
+            'completedToolCalls' => 1,
+            'attemptedToolCalls' => 1,
+        ]);
+});
+
+it('expands into two tools and rejects duplicate catalog names', function (): void {
+    $context = toolSearchContext([
+        SayHiTool::class,
+        new SayHiTool,
+    ]);
+    $searchTools = toolFromContext($context, 'search_tools');
+    $executeTools = toolFromContext($context, 'execute_tools');
+
+    $result = callContextTool($context, $searchTools);
+
+    expect([$searchTools->name(), $executeTools->name()])->toBe(['search_tools', 'execute_tools'])
+        ->and($result['isError'])->toBeTrue()
+        ->and($result['content'][0]['text'])->toBe('Duplicate tool name [say-hi-tool] in ToolSearch catalog.');
+});
+
+it('rejects generated tool name collisions', function (): void {
+    $context = new ServerContext(
+        supportedProtocolVersions: ['2025-03-26'],
+        serverCapabilities: [],
+        implementation: new Implementation('Test Server', '1.0.0'),
+        instructions: 'Test instructions',
+        maxPaginationLength: 50,
+        defaultPaginationLength: 10,
+        tools: [
+            ToolSearch::class => [SayHiTool::class],
+            new class extends Tool
+            {
+                protected string $name = 'search_tools';
+
+                public function handle(): Response
+                {
+                    return Response::text('collision');
+                }
+            },
+        ],
+        resources: [],
+        prompts: [],
+    );
+
+    expect(fn (): Collection => $context->tools())
+        ->toThrow(InvalidArgumentException::class, 'Duplicate server tool name [search_tools].');
+});
+
+function toolSearchContext(array $tools): ServerContext
+{
+    return new ServerContext(
+        supportedProtocolVersions: ['2025-03-26'],
+        serverCapabilities: [],
+        implementation: new Implementation('Test Server', '1.0.0'),
+        instructions: 'Test instructions',
+        maxPaginationLength: 50,
+        defaultPaginationLength: 10,
+        tools: [ToolSearch::class => $tools],
+        resources: [],
+        prompts: [],
+    );
+}
+
+function toolFromContext(ServerContext $context, string $name): Tool
+{
+    $tool = $context->tools()->first(fn (Tool $tool): bool => $tool->name() === $name);
+
+    if (! $tool instanceof Tool) {
+        throw new LogicException("Tool [{$name}] was not registered.");
+    }
+
+    return $tool;
+}
+
+function callContextTool(ServerContext $context, Tool $tool, array $arguments = []): array
+{
+    $responses = callContextToolResponses($context, $tool, $arguments);
+    $result = $responses[array_key_last($responses)]['result'];
+
+    if (isset($result['content'][0]['text'])) {
+        $payload = json_decode($result['content'][0]['text'], true);
+
+        if (is_array($payload)) {
+            $result['payload'] = $payload;
+        }
+    }
+
+    return $result;
+}
+
+function callContextToolResponses(ServerContext $context, Tool $tool, array $arguments = []): array
+{
+    $request = JsonRpcRequest::from([
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => $tool->name(),
+            'arguments' => $arguments,
+        ],
+    ]);
+
+    app()->instance('mcp.request', $request->toRequest());
+    $response = (new CallTool)->handle($request, $context);
+    $responses = $response instanceof JsonRpcResponse ? [$response] : iterator_to_array($response);
+
+    return array_map(fn (JsonRpcResponse $response): array => $response->toArray(), $responses);
+}


### PR DESCRIPTION
Main is missing two features that landed on 0.x: searchable tool catalogs (#317) and route parameter prompting in `mcp:inspector` (#294). This PR brings both forward as cherry-picks on top of main.

Tool catalogs let a server hide a large tool list behind `search_tools` / `execute_tools` meta-tools:

```php
protected array $tools = [
    AlwaysVisibleTool::class,
    ToolSearch::class => [
        RarelyUsedTool::class,
        AnotherTool::class,
    ],
];
```

The only adaptation needed was dropping the `sessionId` argument from the nested `JsonRpcRequest` in `ToolSearch`, since main removed transport session state in #285. The inspector commit merged cleanly into the modern era config launch from #316.


🤖 Generated with [Claude Code](https://claude.com/claude-code)