### PR TITLE
fix: reject non-word URI template placeholders

### DIFF
--- a/src/Support/UriTemplate.php
+++ b/src/Support/UriTemplate.php
@@ -82,7 +82,6 @@ class UriTemplate implements Stringable
         );
     }
 
-
     /**
      * Reject placeholders the parser cannot extract.
      *

--- a/src/Support/UriTemplate.php
+++ b/src/Support/UriTemplate.php
@@ -33,6 +33,8 @@ class UriTemplate implements Stringable
             throw new InvalidArgumentException('Invalid URI template: must be a valid URI template with at least one placeholder.');
         }
 
+        $this->assertWordCharacterPlaceholders($template);
+
         $this->variableNames = $this->extractVariableNames($template);
     }
 
@@ -78,6 +80,33 @@ class UriTemplate implements Stringable
             InvalidArgumentException::class,
             sprintf('%s exceeds the maximum length of %d characters (received %d)', $context, $max, Str::length($str))
         );
+    }
+
+
+    /**
+     * Reject placeholders the parser cannot extract.
+     *
+     * Validation previously accepted any `{...}` expression, but
+     * extractVariableNames() / compileRegex() only understand `{word}`
+     * placeholders. Non-word names such as `{customer-id}` or `{+path}`
+     * were therefore advertised and then treated as literal text.
+     */
+    private function assertWordCharacterPlaceholders(string $template): void
+    {
+        if (! preg_match_all('/\{([^{}]+)}/', $template, $matches)) {
+            return;
+        }
+
+        foreach ($matches[1] as $expression) {
+            throw_unless(
+                preg_match('/^\w+$/', $expression) === 1,
+                InvalidArgumentException::class,
+                sprintf(
+                    'Invalid URI template placeholder {%s}: only word-character variable names are supported.',
+                    $expression
+                )
+            );
+        }
     }
 
     /**

--- a/tests/Unit/Support/UriTemplateTest.php
+++ b/tests/Unit/Support/UriTemplateTest.php
@@ -133,3 +133,17 @@ it('casts to string', function (): void {
 
     expect((string) $template)->toBe('file://users/{id}');
 });
+
+it('rejects placeholders that are not word characters', function (): void {
+    expect(fn (): UriTemplate => new UriTemplate('file://projects/{+path}'))
+        ->toThrow(InvalidArgumentException::class, 'only word-character variable names are supported')
+        ->and(fn (): UriTemplate => new UriTemplate('file://customers/{customer-id}'))
+        ->toThrow(InvalidArgumentException::class, 'only word-character variable names are supported')
+        ->and(fn (): UriTemplate => new UriTemplate('file://users/{user.id}'))
+        ->toThrow(InvalidArgumentException::class, 'only word-character variable names are supported');
+});
+
+it('still accepts plain word-character placeholders', function (): void {
+    expect(new UriTemplate('file://projects/{path}'))->toBeInstanceOf(UriTemplate::class)
+        ->and(new UriTemplate('file://customers/{customer_id}'))->toBeInstanceOf(UriTemplate::class);
+});


### PR DESCRIPTION
## Summary

`UriTemplate` previously validated placeholders with `{[^{}]+}` but only extracted `{\w+}` names. Templates such as `file://projects/{+path}` or `file://customers/{customer-id}` were therefore accepted, advertised to clients, and then treated as literal brace text — so `match()` silently never succeeded.

This change rejects unsupported placeholders at construction time with a clear `InvalidArgumentException`, matching the package's existing fail-fast behavior for other malformed templates.

## Test plan

- [x] `./vendor/bin/pest tests/Unit/Support/UriTemplateTest.php` (22 passed)
- [x] New cases cover `{+path}`, `{customer-id}`, `{user.id}` rejection and plain `{path}` / `{customer_id}` acceptance

Fixes #329
