### PR TITLE
Validate params shape on JSON-RPC notifications

### DIFF
--- a/src/Transport/JsonRpcNotification.php
+++ b/src/Transport/JsonRpcNotification.php
@@ -33,19 +33,16 @@ class JsonRpcNotification
             throw new JsonRpcException('Invalid Request: Invalid or missing "method". Must be a string.', -32600);
         }
 
-        if (array_key_exists('params', $jsonRequest) && ! self::isObject($jsonRequest['params'])) {
+        $params = array_key_exists('params', $jsonRequest) ? $jsonRequest['params'] : [];
+
+        if (! is_array($params) || ($params !== [] && array_is_list($params))) {
             throw new JsonRpcException('Invalid params: The [params] member must be an object.', -32602);
         }
 
         return new static(
             method: $jsonRequest['method'],
-            params: $jsonRequest['params'] ?? []
+            params: $params
         );
-    }
-
-    private static function isObject(mixed $value): bool
-    {
-        return is_array($value) && ($value === [] || ! array_is_list($value));
     }
 
     /**

--- a/src/Transport/JsonRpcNotification.php
+++ b/src/Transport/JsonRpcNotification.php
@@ -19,7 +19,7 @@ class JsonRpcNotification
     }
 
     /**
-     * @param  array{jsonrpc?: mixed, method?: mixed, params?: array<string, mixed>}  $jsonRequest
+     * @param  array{jsonrpc?: mixed, method?: mixed, params?: mixed}  $jsonRequest
      *
      * @throws JsonRpcException
      */
@@ -33,10 +33,19 @@ class JsonRpcNotification
             throw new JsonRpcException('Invalid Request: Invalid or missing "method". Must be a string.', -32600);
         }
 
+        if (array_key_exists('params', $jsonRequest) && ! self::isObject($jsonRequest['params'])) {
+            throw new JsonRpcException('Invalid params: The [params] member must be an object.', -32602);
+        }
+
         return new static(
             method: $jsonRequest['method'],
             params: $jsonRequest['params'] ?? []
         );
+    }
+
+    private static function isObject(mixed $value): bool
+    {
+        return is_array($value) && ($value === [] || ! array_is_list($value));
     }
 
     /**

--- a/tests/Unit/Transport/JsonRpcNotificationTest.php
+++ b/tests/Unit/Transport/JsonRpcNotificationTest.php
@@ -58,6 +58,24 @@ it('throws exception for non string method in notification', function (): void {
     ]);
 });
 
+it('throws exception for invalid params type in notification', function (mixed $params): void {
+    $this->expectException(JsonRpcException::class);
+    $this->expectExceptionMessage('Invalid params: The [params] member must be an object.');
+    $this->expectExceptionCode(-32602);
+
+    JsonRpcNotification::from([
+        'jsonrpc' => '2.0',
+        'method' => 'notifications/progress',
+        'params' => $params,
+    ]);
+})->with([
+    'string' => ['invalid'],
+    'integer' => [1],
+    'boolean' => [true],
+    'null' => [null],
+    'list' => [[1, 2, 3]],
+]);
+
 it('serializes to an array with params when present', function (): void {
     $notification = new JsonRpcNotification('notifications/progress', ['progress' => 50]);
 


### PR DESCRIPTION
A notification whose `params` member isn't an object throws a TypeError out of the constructor, so the server answers with an internal error instead of a protocol one.

`JsonRpcRequest::from()` has guarded this since #273. Notifications now get the same check and come back as a -32602 invalid params error.

Tests cover the scalar, null, and list cases.
