### PR TITLE
Update SKILL.blade.php

### DIFF
--- a/resources/boost/skills/mcp-development/SKILL.blade.php
+++ b/resources/boost/skills/mcp-development/SKILL.blade.php
@@ -23,7 +23,7 @@ Register MCP servers in `routes/ai.php`:
 @boostsnippet("Register MCP Server", "php")
 use Laravel\Mcp\Facades\Mcp;
 
-Mcp::web();
+Mcp::web('/mcp/demo', \App\Mcp\Servers\AppServer::class);
 @endboostsnippet
 
 ### Creating MCP Primitives


### PR DESCRIPTION
Laravel MCP v0.9.4 declares `web(string $route, string $serverClass)`. Without both arguments, this example raises an argument-count error.

