### PR TITLE
Asserting registered tools and prompts and resources

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -37,6 +37,7 @@ use Laravel\Mcp\Server\Prompt;
 use Laravel\Mcp\Server\Resource;
 use Laravel\Mcp\Server\ServerContext;
 use Laravel\Mcp\Server\Testing\PendingTestResponse;
+use Laravel\Mcp\Server\Testing\TestListResponse;
 use Laravel\Mcp\Server\Testing\TestResponse;
 use Laravel\Mcp\Server\Tool;
 use Laravel\Mcp\Transport\JsonRpcNotification;
@@ -450,7 +451,7 @@ abstract class Server
     /**
      * @param  array<array-key, mixed>  $arguments
      */
-    public static function __callStatic(string $name, array $arguments): PendingTestResponse|TestResponse
+    public static function __callStatic(string $name, array $arguments): PendingTestResponse|TestResponse|TestListResponse
     {
         $pendingTestResponse = new PendingTestResponse(
             Container::getInstance(),

--- a/src/Server/Testing/PendingTestResponse.php
+++ b/src/Server/Testing/PendingTestResponse.php
@@ -64,6 +64,38 @@ class PendingTestResponse
         return new TestListResponse($tools);
     }
 
+    public function resources(): TestListResponse
+    {
+        $server = $this->initializeServer();
+        $resources = [];
+        $cursor = null;
+
+        do {
+            $request = new JsonRpcRequest(
+                uniqid(),
+                'resources/list',
+                $cursor !== null ? ['cursor' => $cursor] : [],
+            );
+
+            $response = $this->executeRequest($server, $request);
+
+            if (! $response instanceof JsonRpcResponse) {
+                throw new InvalidArgumentException('Expected a JsonRpcResponse for [resources/list].');
+            }
+
+            $result = $response->toArray()['result'] ?? null;
+
+            if (! is_array($result) || ! is_array($result['resources'] ?? null)) {
+                throw new InvalidArgumentException('Invalid resources/list response from server.');
+            }
+
+            $resources = [...$resources, ...$result['resources']];
+            $cursor = is_string($result['nextCursor'] ?? null) ? $result['nextCursor'] : null;
+        } while ($cursor !== null);
+
+        return new TestListResponse($resources);
+    }
+
     /**
      * @param  class-string<Tool>|Tool  $tool
      * @param  array<string, mixed>  $arguments

--- a/src/Server/Testing/PendingTestResponse.php
+++ b/src/Server/Testing/PendingTestResponse.php
@@ -32,6 +32,38 @@ class PendingTestResponse
         //
     }
 
+    public function tools(): TestListResponse
+    {
+        $server = $this->initializeServer();
+        $tools = [];
+        $cursor = null;
+
+        do {
+            $request = new JsonRpcRequest(
+                uniqid(),
+                'tools/list',
+                $cursor !== null ? ['cursor' => $cursor] : [],
+            );
+
+            $response = $this->executeRequest($server, $request);
+
+            if (! $response instanceof JsonRpcResponse) {
+                throw new InvalidArgumentException('Expected a JsonRpcResponse for [tools/list].');
+            }
+
+            $result = $response->toArray()['result'] ?? null;
+
+            if (! is_array($result) || ! is_array($result['tools'] ?? null)) {
+                throw new InvalidArgumentException('Invalid tools/list response from server.');
+            }
+
+            $tools = [...$tools, ...$result['tools']];
+            $cursor = is_string($result['nextCursor'] ?? null) ? $result['nextCursor'] : null;
+        } while ($cursor !== null);
+
+        return new TestListResponse($tools);
+    }
+
     /**
      * @param  class-string<Tool>|Tool  $tool
      * @param  array<string, mixed>  $arguments

--- a/src/Server/Testing/PendingTestResponse.php
+++ b/src/Server/Testing/PendingTestResponse.php
@@ -96,6 +96,38 @@ class PendingTestResponse
         return new TestListResponse($resources);
     }
 
+    public function prompts(): TestListResponse
+    {
+        $server = $this->initializeServer();
+        $prompts = [];
+        $cursor = null;
+
+        do {
+            $request = new JsonRpcRequest(
+                uniqid(),
+                'prompts/list',
+                $cursor !== null ? ['cursor' => $cursor] : [],
+            );
+
+            $response = $this->executeRequest($server, $request);
+
+            if (! $response instanceof JsonRpcResponse) {
+                throw new InvalidArgumentException('Expected a JsonRpcResponse for [prompts/list].');
+            }
+
+            $result = $response->toArray()['result'] ?? null;
+
+            if (! is_array($result) || ! is_array($result['prompts'] ?? null)) {
+                throw new InvalidArgumentException('Invalid prompts/list response from server.');
+            }
+
+            $prompts = [...$prompts, ...$result['prompts']];
+            $cursor = is_string($result['nextCursor'] ?? null) ? $result['nextCursor'] : null;
+        } while ($cursor !== null);
+
+        return new TestListResponse($prompts);
+    }
+
     /**
      * @param  class-string<Tool>|Tool  $tool
      * @param  array<string, mixed>  $arguments

--- a/src/Server/Testing/TestListResponse.php
+++ b/src/Server/Testing/TestListResponse.php
@@ -28,8 +28,9 @@ class TestListResponse
     public function assertRegistered(array|string $classes): static
     {
         $itemNames = Arr::pluck($this->items, 'name');
+        $classes = is_array($classes) ? $classes : [$classes];
 
-        foreach (Arr::wrap($classes) as $class) {
+        foreach ($classes as $class) {
             $name = (new $class)->name();
 
             Assert::assertContains($name, $itemNames, "The expected class [{$class}] was not found in the response content.");
@@ -47,8 +48,9 @@ class TestListResponse
     public function assertNotRegistered(array|string $classes): static
     {
         $itemNames = Arr::pluck($this->items, 'name');
+        $classes = is_array($classes) ? $classes : [$classes];
 
-        foreach (Arr::wrap($classes) as $class) {
+        foreach ($classes as $class) {
             $name = (new $class)->name();
 
             Assert::assertNotContains($name, $itemNames, "The expected class [{$class}] was found in the response content.");

--- a/src/Server/Testing/TestListResponse.php
+++ b/src/Server/Testing/TestListResponse.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Server\Testing;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Support\Traits\Macroable;
+use PHPUnit\Framework\Assert;
+
+class TestListResponse
+{
+    use Conditionable;
+    use Macroable;
+
+    public function __construct(
+        protected array $items,
+    ) {}
+
+    /**
+     * @param  array<class-string>|class-string  $classes
+     */
+    public function assertRegistered(array|string $classes): static
+    {
+        $itemNames = Arr::pluck($this->items, 'name');
+
+        foreach (Arr::wrap($classes) as $class) {
+            $name = (new $class)->name();
+
+            Assert::assertContains($name, $itemNames, "The expected class [{$class}] was not found in the response content.");
+        }
+
+        // @phpstan-ignore-next-line
+        Assert::assertTrue(true);
+
+        return $this;
+    }
+
+    /**
+     * @param  array<class-string>|class-string  $classes
+     */
+    public function assertNotRegistered(array|string $classes): static
+    {
+        $itemNames = Arr::pluck($this->items, 'name');
+
+        foreach (Arr::wrap($classes) as $class) {
+            $name = (new $class)->name();
+
+            Assert::assertNotContains($name, $itemNames, "The expected class [{$class}] was found in the response content.");
+        }
+
+        // @phpstan-ignore-next-line
+        Assert::assertTrue(true);
+
+        return $this;
+    }
+
+    public function dd(): void
+    {
+        dd($this->items);
+    }
+
+    public function dump(): static
+    {
+        dump($this->items);
+
+        return $this;
+    }
+}

--- a/src/Server/Testing/TestListResponse.php
+++ b/src/Server/Testing/TestListResponse.php
@@ -7,6 +7,7 @@ namespace Laravel\Mcp\Server\Testing;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
+use Laravel\Mcp\Server\Primitive;
 use PHPUnit\Framework\Assert;
 
 class TestListResponse
@@ -14,12 +15,15 @@ class TestListResponse
     use Conditionable;
     use Macroable;
 
+    /**
+     * @param  array<int, array<string, mixed>>  $items
+     */
     public function __construct(
         protected array $items,
     ) {}
 
     /**
-     * @param  array<class-string>|class-string  $classes
+     * @param  array<class-string<Primitive>>|class-string<Primitive>  $classes
      */
     public function assertRegistered(array|string $classes): static
     {
@@ -38,7 +42,7 @@ class TestListResponse
     }
 
     /**
-     * @param  array<class-string>|class-string  $classes
+     * @param  array<class-string<Primitive>>|class-string<Primitive>  $classes
      */
     public function assertNotRegistered(array|string $classes): static
     {

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Console\Command;
 use Laravel\Mcp\Server\Contracts\Annotation;
 use Laravel\Mcp\Server\Contracts\Method;
+use Laravel\Mcp\Server\Testing\TestListResponse;
 use Laravel\Mcp\Server\Testing\TestResponse;
 use Symfony\Component\Console\Attribute\AsCommand;
 
@@ -10,7 +11,7 @@ arch('strict and safe')
     ->expect('Laravel\Mcp')
     ->toUseStrictTypes()
     ->not->toUse(['die', 'dd', 'dump', 'var_dump'])
-    ->ignoring(TestResponse::class);
+    ->ignoring([TestResponse::class, TestListResponse::class]);
 
 arch('mcp methods extend base class')
     ->expect('Laravel\Mcp\Server\Methods')

--- a/tests/Feature/Testing/Prompts/AssertRegisteredTest.php
+++ b/tests/Feature/Testing/Prompts/AssertRegisteredTest.php
@@ -43,24 +43,25 @@ class TireRotationPrompt extends Prompt
     }
 }
 
-it('asserts registered prompts of a server', function (): void {
+it('may assert that prompts are registered on a server', function (): void {
+    OilChangePrompt::$shouldRegister = true;
+
     GarageListPromptsServer::prompts()->assertRegistered([
         OilChangePrompt::class,
         TireRotationPrompt::class,
     ]);
+});
 
-    try {
-        GarageListPromptsServer::prompts()->assertRegistered([
-            TireRotationPrompt::class,
-        ])->assertNotRegistered([
-            OilChangePrompt::class,
-        ]);
+it('may fail to assert that prompts are registered on a server', function (): void {
+    OilChangePrompt::$shouldRegister = false;
 
-        $this->fail('Expected an AssertionFailedError to be thrown, but it was not.');
-    } catch (AssertionFailedError $error) {
-        expect($error->getMessage())->toContain('The expected class ['.OilChangePrompt::class.'] was found in the response content.');
-    }
+    GarageListPromptsServer::prompts()->assertRegistered([
+        TireRotationPrompt::class,
+        OilChangePrompt::class,
+    ]);
+})->throws(AssertionFailedError::class, 'The expected class ['.OilChangePrompt::class.'] was not found in the response content.');
 
+it('may assert that prompts are not registered on a server', function (): void {
     OilChangePrompt::$shouldRegister = false;
 
     GarageListPromptsServer::prompts()->assertRegistered([
@@ -68,15 +69,14 @@ it('asserts registered prompts of a server', function (): void {
     ])->assertNotRegistered([
         OilChangePrompt::class,
     ]);
-
-    try {
-        GarageListPromptsServer::prompts()->assertRegistered([
-            TireRotationPrompt::class,
-            OilChangePrompt::class,
-        ]);
-
-        $this->fail('Expected an AssertionFailedError to be thrown, but it was not.');
-    } catch (AssertionFailedError $error) {
-        expect($error->getMessage())->toContain('The expected class ['.OilChangePrompt::class.'] was not found in the response content.');
-    }
 });
+
+it('may fail to assert that prompts are not registered on a server', function (): void {
+    OilChangePrompt::$shouldRegister = true;
+
+    GarageListPromptsServer::prompts()->assertRegistered([
+        TireRotationPrompt::class,
+    ])->assertNotRegistered([
+        OilChangePrompt::class,
+    ]);
+})->throws(AssertionFailedError::class, 'The expected class ['.OilChangePrompt::class.'] was found in the response content.');

--- a/tests/Feature/Testing/Prompts/AssertRegisteredTest.php
+++ b/tests/Feature/Testing/Prompts/AssertRegisteredTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Prompt;
+use PHPUnit\Framework\AssertionFailedError;
+
+class GarageListPromptsServer extends Server
+{
+    public int $defaultPaginationLength = 1;
+
+    protected array $prompts = [
+        OilChangePrompt::class,
+        TireRotationPrompt::class,
+    ];
+}
+
+class OilChangePrompt extends Prompt
+{
+    public static $shouldRegister = true;
+
+    protected string $name = 'garage/oil-change';
+
+    public function shouldRegister(): bool
+    {
+        return static::$shouldRegister;
+    }
+
+    public function handle(): string
+    {
+        return 'Oil changed.';
+    }
+}
+
+class TireRotationPrompt extends Prompt
+{
+    protected string $name = 'garage/tire-rotation';
+
+    public function handle(): string
+    {
+        return 'Tires rotated.';
+    }
+}
+
+it('asserts registered prompts of a server', function (): void {
+    GarageListPromptsServer::prompts()->assertRegistered([
+        OilChangePrompt::class,
+        TireRotationPrompt::class,
+    ]);
+
+    try {
+        GarageListPromptsServer::prompts()->assertRegistered([
+            TireRotationPrompt::class,
+        ])->assertNotRegistered([
+            OilChangePrompt::class,
+        ]);
+
+        $this->fail('Expected an AssertionFailedError to be thrown, but it was not.');
+    } catch (AssertionFailedError $error) {
+        expect($error->getMessage())->toContain('The expected class ['.OilChangePrompt::class.'] was found in the response content.');
+    }
+
+    OilChangePrompt::$shouldRegister = false;
+
+    GarageListPromptsServer::prompts()->assertRegistered([
+        TireRotationPrompt::class,
+    ])->assertNotRegistered([
+        OilChangePrompt::class,
+    ]);
+
+    try {
+        GarageListPromptsServer::prompts()->assertRegistered([
+            TireRotationPrompt::class,
+            OilChangePrompt::class,
+        ]);
+
+        $this->fail('Expected an AssertionFailedError to be thrown, but it was not.');
+    } catch (AssertionFailedError $error) {
+        expect($error->getMessage())->toContain('The expected class ['.OilChangePrompt::class.'] was not found in the response content.');
+    }
+});

--- a/tests/Feature/Testing/Resources/AssertRegisteredTest.php
+++ b/tests/Feature/Testing/Resources/AssertRegisteredTest.php
@@ -43,24 +43,25 @@ class TireRotationResource extends Resource
     }
 }
 
-it('asserts registered resources of a server', function (): void {
+it('may assert that resources are registered on a server', function (): void {
+    OilChangeResource::$shouldRegister = true;
+
     GarageListResourcesServer::resources()->assertRegistered([
         OilChangeResource::class,
         TireRotationResource::class,
     ]);
+});
 
-    try {
-        GarageListResourcesServer::resources()->assertRegistered([
-            TireRotationResource::class,
-        ])->assertNotRegistered([
-            OilChangeResource::class,
-        ]);
+it('may fail to assert that resources are registered on a server', function (): void {
+    OilChangeResource::$shouldRegister = false;
 
-        $this->fail('Expected an AssertionFailedError to be thrown, but it was not.');
-    } catch (AssertionFailedError $error) {
-        expect($error->getMessage())->toContain('The expected class ['.OilChangeResource::class.'] was found in the response content.');
-    }
+    GarageListResourcesServer::resources()->assertRegistered([
+        TireRotationResource::class,
+        OilChangeResource::class,
+    ]);
+})->throws(AssertionFailedError::class, 'The expected class ['.OilChangeResource::class.'] was not found in the response content.');
 
+it('may assert that resources are not registered on a server', function (): void {
     OilChangeResource::$shouldRegister = false;
 
     GarageListResourcesServer::resources()->assertRegistered([
@@ -68,15 +69,16 @@ it('asserts registered resources of a server', function (): void {
     ])->assertNotRegistered([
         OilChangeResource::class,
     ]);
-
-    try {
-        GarageListResourcesServer::resources()->assertRegistered([
-            TireRotationResource::class,
-            OilChangeResource::class,
-        ]);
-
-        $this->fail('Expected an AssertionFailedError to be thrown, but it was not.');
-    } catch (AssertionFailedError $error) {
-        expect($error->getMessage())->toContain('The expected class ['.OilChangeResource::class.'] was not found in the response content.');
-    }
 });
+
+it('may fail to assert that resources are not registered on a server', function (): void {
+    OilChangeResource::$shouldRegister = true;
+
+    GarageListResourcesServer::resources()->assertRegistered([
+        TireRotationResource::class,
+    ])->assertNotRegistered([
+        OilChangeResource::class,
+    ]);
+
+    $this->fail('Expected an AssertionFailedError to be thrown, but it was not.');
+})->throws(AssertionFailedError::class, 'The expected class ['.OilChangeResource::class.'] was found in the response content.');

--- a/tests/Feature/Testing/Resources/AssertRegisteredTest.php
+++ b/tests/Feature/Testing/Resources/AssertRegisteredTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Resource;
+use PHPUnit\Framework\AssertionFailedError;
+
+class GarageListResourcesServer extends Server
+{
+    public int $defaultPaginationLength = 1;
+
+    protected array $resources = [
+        OilChangeResource::class,
+        TireRotationResource::class,
+    ];
+}
+
+class OilChangeResource extends Resource
+{
+    public static $shouldRegister = true;
+
+    protected string $name = 'garage/oil-change';
+
+    public function shouldRegister(): bool
+    {
+        return static::$shouldRegister;
+    }
+
+    public function handle(): string
+    {
+        return 'Oil changed.';
+    }
+}
+
+class TireRotationResource extends Resource
+{
+    protected string $name = 'garage/tire-rotation';
+
+    public function handle(): string
+    {
+        return 'Tires rotated.';
+    }
+}
+
+it('asserts registered resources of a server', function (): void {
+    GarageListResourcesServer::resources()->assertRegistered([
+        OilChangeResource::class,
+        TireRotationResource::class,
+    ]);
+
+    try {
+        GarageListResourcesServer::resources()->assertRegistered([
+            TireRotationResource::class,
+        ])->assertNotRegistered([
+            OilChangeResource::class,
+        ]);
+
+        $this->fail('Expected an AssertionFailedError to be thrown, but it was not.');
+    } catch (AssertionFailedError $error) {
+        expect($error->getMessage())->toContain('The expected class ['.OilChangeResource::class.'] was found in the response content.');
+    }
+
+    OilChangeResource::$shouldRegister = false;
+
+    GarageListResourcesServer::resources()->assertRegistered([
+        TireRotationResource::class,
+    ])->assertNotRegistered([
+        OilChangeResource::class,
+    ]);
+
+    try {
+        GarageListResourcesServer::resources()->assertRegistered([
+            TireRotationResource::class,
+            OilChangeResource::class,
+        ]);
+
+        $this->fail('Expected an AssertionFailedError to be thrown, but it was not.');
+    } catch (AssertionFailedError $error) {
+        expect($error->getMessage())->toContain('The expected class ['.OilChangeResource::class.'] was not found in the response content.');
+    }
+});

--- a/tests/Feature/Testing/Tools/AssertRegisteredTest.php
+++ b/tests/Feature/Testing/Tools/AssertRegisteredTest.php
@@ -43,24 +43,25 @@ class TireRotationTool extends Tool
     }
 }
 
-it('asserts registered tools of a server', function (): void {
+it('may assert that tools are registered on a server', function (): void {
+    OilChangeTool::$shouldRegister = true;
+
     GarageListToolsServer::tools()->assertRegistered([
         OilChangeTool::class,
         TireRotationTool::class,
     ]);
+});
 
-    try {
-        GarageListToolsServer::tools()->assertRegistered([
-            TireRotationTool::class,
-        ])->assertNotRegistered([
-            OilChangeTool::class,
-        ]);
+it('may fail to assert that tools are registered on a server', function (): void {
+    OilChangeTool::$shouldRegister = false;
 
-        $this->fail('Expected an AssertionFailedError to be thrown, but it was not.');
-    } catch (AssertionFailedError $error) {
-        expect($error->getMessage())->toContain('The expected class ['.OilChangeTool::class.'] was found in the response content.');
-    }
+    GarageListToolsServer::tools()->assertRegistered([
+        TireRotationTool::class,
+        OilChangeTool::class,
+    ]);
+})->throws(AssertionFailedError::class, 'The expected class ['.OilChangeTool::class.'] was not found in the response content.');
 
+it('may assert that tools are not registered on a server', function (): void {
     OilChangeTool::$shouldRegister = false;
 
     GarageListToolsServer::tools()->assertRegistered([
@@ -68,15 +69,14 @@ it('asserts registered tools of a server', function (): void {
     ])->assertNotRegistered([
         OilChangeTool::class,
     ]);
-
-    try {
-        GarageListToolsServer::tools()->assertRegistered([
-            TireRotationTool::class,
-            OilChangeTool::class,
-        ]);
-
-        $this->fail('Expected an AssertionFailedError to be thrown, but it was not.');
-    } catch (AssertionFailedError $error) {
-        expect($error->getMessage())->toContain('The expected class ['.OilChangeTool::class.'] was not found in the response content.');
-    }
 });
+
+it('may fail to assert that tools are not registered on a server', function (): void {
+    OilChangeTool::$shouldRegister = true;
+
+    GarageListToolsServer::tools()->assertRegistered([
+        TireRotationTool::class,
+    ])->assertNotRegistered([
+        OilChangeTool::class,
+    ]);
+})->throws(AssertionFailedError::class, 'The expected class ['.OilChangeTool::class.'] was found in the response content.');

--- a/tests/Feature/Testing/Tools/AssertRegisteredTest.php
+++ b/tests/Feature/Testing/Tools/AssertRegisteredTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Tool;
+use PHPUnit\Framework\AssertionFailedError;
+
+class GarageListToolsServer extends Server
+{
+    public int $defaultPaginationLength = 1;
+
+    protected array $tools = [
+        OilChangeTool::class,
+        TireRotationTool::class,
+    ];
+}
+
+class OilChangeTool extends Tool
+{
+    public static $shouldRegister = true;
+
+    protected string $name = 'garage/oil-change';
+
+    public function shouldRegister(): bool
+    {
+        return static::$shouldRegister;
+    }
+
+    public function handle(): string
+    {
+        return 'Oil changed.';
+    }
+}
+
+class TireRotationTool extends Tool
+{
+    protected string $name = 'garage/tire-rotation';
+
+    public function handle(): string
+    {
+        return 'Tires rotated.';
+    }
+}
+
+it('asserts registered tools of a server', function (): void {
+    GarageListToolsServer::tools()->assertRegistered([
+        OilChangeTool::class,
+        TireRotationTool::class,
+    ]);
+
+    try {
+        GarageListToolsServer::tools()->assertRegistered([
+            TireRotationTool::class,
+        ])->assertNotRegistered([
+            OilChangeTool::class,
+        ]);
+
+        $this->fail('Expected an AssertionFailedError to be thrown, but it was not.');
+    } catch (AssertionFailedError $error) {
+        expect($error->getMessage())->toContain('The expected class ['.OilChangeTool::class.'] was found in the response content.');
+    }
+
+    OilChangeTool::$shouldRegister = false;
+
+    GarageListToolsServer::tools()->assertRegistered([
+        TireRotationTool::class,
+    ])->assertNotRegistered([
+        OilChangeTool::class,
+    ]);
+
+    try {
+        GarageListToolsServer::tools()->assertRegistered([
+            TireRotationTool::class,
+            OilChangeTool::class,
+        ]);
+
+        $this->fail('Expected an AssertionFailedError to be thrown, but it was not.');
+    } catch (AssertionFailedError $error) {
+        expect($error->getMessage())->toContain('The expected class ['.OilChangeTool::class.'] was not found in the response content.');
+    }
+});


### PR DESCRIPTION
Currently, there is no easy way to test the `shouldRegister` method in a tool/prompt/resource. This PR fixes that by introducing a method that gets all the registered tools/prompts/resources on a server (which triggers the `shouldRegister` methods). The returned object has some assertion methods:

```php
YourMcpServer::prompts()
	->assertRegistered([FooPrompt::class])
	->assertNotRegistered([BarPrompt::class]);

YourMcpServer::resources()
	->assertRegistered([FooResource::class])
	->assertNotRegistered([BarResource::class]);

YourMcpServer::tools()
	->assertRegistered([FooTool::class])
	->assertNotRegistered([BarTool::class]);
```