### PR TITLE
`assertNotRegistered` method on `TestResponse`

### DIFF
--- a/src/Server/Testing/TestResponse.php
+++ b/src/Server/Testing/TestResponse.php
@@ -197,6 +197,22 @@ class TestResponse
         return $this->assertHasNoErrors();
     }
 
+    public function assertNotRegistered(): static
+    {
+        [$primitiveType, $primitiveIdentifier] = match (true) {
+            $this->primitive instanceof Tool => ['tool', $this->primitive->name()],
+            $this->primitive instanceof Prompt => ['prompt', $this->primitive->name()],
+            $this->primitive instanceof Resource => ['resource', $this->primitive->uri()],
+        };
+
+        Assert::assertTrue(
+            count(array_filter($this->errors(), fn ($error) => str_contains($error, ucfirst($primitiveType).' ['.$primitiveIdentifier.'] not found.'))) > 0,
+            'The '.$primitiveType.' ['. get_class($this->primitive) .'] is registered.',
+        );
+
+        return $this;
+    }
+
     public function assertHasNoErrors(): static
     {
         Assert::assertSame([], $this->errors(), 'The response has errors.');

--- a/src/Server/Testing/TestResponse.php
+++ b/src/Server/Testing/TestResponse.php
@@ -203,6 +203,7 @@ class TestResponse
             $this->primitive instanceof Tool => ['tool', $this->primitive->name()],
             $this->primitive instanceof Prompt => ['prompt', $this->primitive->name()],
             $this->primitive instanceof Resource => ['resource', $this->primitive->uri()],
+            default => throw new RuntimeException('This primitive type is not supported.'),
         };
 
         Assert::assertTrue(

--- a/src/Server/Testing/TestResponse.php
+++ b/src/Server/Testing/TestResponse.php
@@ -206,8 +206,8 @@ class TestResponse
         };
 
         Assert::assertTrue(
-            count(array_filter($this->errors(), fn ($error) => str_contains($error, ucfirst($primitiveType).' ['.$primitiveIdentifier.'] not found.'))) > 0,
-            'The '.$primitiveType.' ['. get_class($this->primitive) .'] is registered.',
+            count(array_filter($this->errors(), fn (string $error): bool => str_contains($error, ucfirst($primitiveType).' ['.$primitiveIdentifier.'] not found.'))) > 0,
+            'The '.$primitiveType.' ['.$this->primitive::class.'] is registered.',
         );
 
         return $this;

--- a/tests/Feature/Testing/Prompts/AssertNotRegisteredTest.php
+++ b/tests/Feature/Testing/Prompts/AssertNotRegisteredTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Prompt;
+use PHPUnit\Framework\AssertionFailedError;
+
+class ShopNotRegisteredTestPromptServer extends Server
+{
+    protected array $prompts = [
+        BuyNotRegisteredTestPrompt::class,
+    ];
+}
+
+class BuyNotRegisteredTestPrompt extends Prompt
+{
+    public static $shouldRegister = true;
+
+    public function shouldRegister(Request $request): bool
+    {
+        return static::$shouldRegister;
+    }
+
+    public function handle(Request $request): string
+    {
+        return 'Purchase successful!';
+    }
+}
+
+it('may assert that prompt is not registered', function (): void {
+    BuyNotRegisteredTestPrompt::$shouldRegister = false;
+
+    $response = ShopNotRegisteredTestPromptServer::prompt(BuyNotRegisteredTestPrompt::class);
+
+    $response->assertNotRegistered();
+});
+
+it('may fail to assert that prompt is not registered', function (): void {
+    BuyNotRegisteredTestPrompt::$shouldRegister = true;
+
+    $response = ShopNotRegisteredTestPromptServer::prompt(BuyNotRegisteredTestPrompt::class);
+
+    $response->assertNotRegistered();
+})->throws(AssertionFailedError::class, 'The prompt ['.BuyNotRegisteredTestPrompt::class.'] is registered.');

--- a/tests/Feature/Testing/Resources/AssertNotRegisteredTest.php
+++ b/tests/Feature/Testing/Resources/AssertNotRegisteredTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Resource;
+use PHPUnit\Framework\AssertionFailedError;
+
+class ShopNotRegisteredTestResourceServer extends Server
+{
+    protected array $resources = [
+        BuyNotRegisteredTestResource::class,
+    ];
+}
+
+class BuyNotRegisteredTestResource extends Resource
+{
+    public static $shouldRegister = true;
+
+    public function shouldRegister(Request $request): bool
+    {
+        return static::$shouldRegister;
+    }
+
+    public function handle(Request $request): string
+    {
+        return 'Purchase successful!';
+    }
+}
+
+it('may assert that resource is not registered', function (): void {
+    BuyNotRegisteredTestResource::$shouldRegister = false;
+
+    $response = ShopNotRegisteredTestResourceServer::resource(BuyNotRegisteredTestResource::class);
+
+    $response->assertNotRegistered();
+});
+
+it('may fail to assert that resource is not registered', function (): void {
+    BuyNotRegisteredTestResource::$shouldRegister = true;
+
+    $response = ShopNotRegisteredTestResourceServer::resource(BuyNotRegisteredTestResource::class);
+
+    $response->assertNotRegistered();
+})->throws(AssertionFailedError::class, 'The resource ['.BuyNotRegisteredTestResource::class.'] is registered.');

--- a/tests/Feature/Testing/Tools/AssertNotRegisteredTest.php
+++ b/tests/Feature/Testing/Tools/AssertNotRegisteredTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Tool;
+use PHPUnit\Framework\AssertionFailedError;
+
+class ShopNotRegisteredTestServer extends Server
+{
+    protected array $tools = [
+        BuyNotRegisteredTestTool::class,
+    ];
+}
+
+class BuyNotRegisteredTestTool extends Tool
+{
+    public static $shouldRegister = true;
+
+    public function shouldRegister(Request $request): bool
+    {
+        return static::$shouldRegister;
+    }
+
+    public function handle(Request $request): string
+    {
+        return 'Purchase successful!';
+    }
+}
+
+it('may assert that tool is not registered', function (): void {
+    BuyNotRegisteredTestTool::$shouldRegister = false;
+
+    $response = ShopNotRegisteredTestServer::tool(BuyNotRegisteredTestTool::class);
+
+    $response->assertNotRegistered();
+});
+
+it('may fail to assert that tool is not registered', function (): void {
+    BuyNotRegisteredTestTool::$shouldRegister = true;
+
+    $response = ShopNotRegisteredTestServer::tool(BuyNotRegisteredTestTool::class);
+
+    $response->assertNotRegistered();
+})->throws(AssertionFailedError::class, 'The tool ['.BuyNotRegisteredTestTool::class.'] is registered.');


### PR DESCRIPTION
In the `shouldRegister` method of tool/prompt/resource, you can determine whether a tool should be available based on application state, configuration, or request parameters.

```php
class SomeTool extends Prompt
{
    public function shouldRegister(Request $request): bool
    {
        return $request->get('foo') !== 'bar';
    }
}
```

If you call a tool/prompt/resource with certain request parameters, then the `shouldRegister` method may return `false`. Currently, to assert that, you have to manually construct the returned error:

```php
YourMcpServer::tool(SomeTool::class, ['foo' => 'bar'])->assertHasErrors('The tool [some-tool] not found');
```

This PR simplifies that by introducing a `assertNotRegistered` method:

```php
YourMcpServer::tool(SomeTool::class, ['foo' => 'bar'])->assertNotRegistered();
```