### PR TITLE
Argument attribute

### DIFF
--- a/src/Attributes/Argument.php
+++ b/src/Attributes/Argument.php
@@ -13,14 +13,21 @@ use Illuminate\Validation\ValidationException;
 use Laravel\Mcp\Request;
 use ReflectionNamedType;
 use ReflectionParameter;
+use RuntimeException;
 
 #[Attribute(Attribute::TARGET_PARAMETER)]
 class Argument implements ContextualAttribute
 {
     public function __construct(public ?string $name = null) {}
 
-    public static function resolve(self $attribute, Container $container, ReflectionParameter $parameter): mixed
+    public static function resolve(self $attribute, Container $container, ?ReflectionParameter $parameter = null): mixed
     {
+        $parameter ??= self::resolveReflectionParameter();
+
+        if (! $parameter instanceof ReflectionParameter) {
+            throw new RuntimeException('Unable to resolve the reflected parameter for the [Argument] attribute.');
+        }
+
         /** @var Request $request */
         $request = $container->make(Request::class);
         $type = $parameter->getType();
@@ -74,5 +81,26 @@ class Argument implements ContextualAttribute
         }
 
         return $resolved;
+    }
+
+    private static function resolveReflectionParameter(): ?ReflectionParameter
+    {
+        foreach (debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT) as $frame) {
+            if (($frame['class'] ?? null) !== 'Illuminate\\Container\\BoundMethod') {
+                continue;
+            }
+
+            if (($frame['function'] ?? null) !== 'addDependencyForCallParameter') {
+                continue;
+            }
+
+            $parameter = $frame['args'][1] ?? null;
+
+            if ($parameter instanceof ReflectionParameter) {
+                return $parameter;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Attributes/Argument.php
+++ b/src/Attributes/Argument.php
@@ -86,7 +86,7 @@ class Argument implements ContextualAttribute
     private static function resolveReflectionParameter(): ?ReflectionParameter
     {
         foreach (debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT) as $frame) {
-            if (($frame['class'] ?? null) !== 'Illuminate\\Container\\BoundMethod') {
+            if (($frame['class'] ?? null) !== \Illuminate\Container\BoundMethod::class) {
                 continue;
             }
 

--- a/src/Attributes/Argument.php
+++ b/src/Attributes/Argument.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Attributes;
+
+use Attribute;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Container\ContextualAttribute;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Validation\ValidationException;
+use Laravel\Mcp\Request;
+use ReflectionNamedType;
+use ReflectionParameter;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class Argument implements ContextualAttribute
+{
+    public function __construct(public ?string $name = null) {}
+
+    public static function resolve(self $attribute, Container $container, ReflectionParameter $parameter): mixed
+    {
+        /** @var Request $request */
+        $request = $container->make(Request::class);
+        $type = $parameter->getType();
+
+        $key = $attribute->name ?? $parameter->getName();
+        $arguments = $request->all();
+
+        if (! array_key_exists($key, $arguments)) {
+            if ($parameter->isDefaultValueAvailable()) {
+                return $parameter->getDefaultValue();
+            }
+
+            if ($type && $type->allowsNull()) {
+                return null;
+            }
+
+            throw ValidationException::withMessages([
+                $key => ["The {$key} field is required."],
+            ]);
+        }
+
+        $value = $arguments[$key];
+
+        if ($value === null) {
+            return null;
+        }
+
+        if (! $type instanceof ReflectionNamedType || $type->isBuiltin()) {
+            return $value;
+        }
+
+        $class = $type->getName();
+
+        if (! is_a($class, Model::class, true)) {
+            return $value;
+        }
+
+        if ($value instanceof $class) {
+            return $value;
+        }
+
+        $model = new $class;
+
+        $resolved = $model->resolveRouteBinding(
+            $value,
+            $model->getRouteKeyName(),
+        );
+
+        if ($resolved === null) {
+            throw (new ModelNotFoundException)->setModel($class, [$value]);
+        }
+
+        return $resolved;
+    }
+}

--- a/src/Attributes/Argument.php
+++ b/src/Attributes/Argument.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laravel\Mcp\Attributes;
 
 use Attribute;
+use Illuminate\Container\BoundMethod;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Container\ContextualAttribute;
 use Illuminate\Database\Eloquent\Model;
@@ -86,7 +87,7 @@ class Argument implements ContextualAttribute
     private static function resolveReflectionParameter(): ?ReflectionParameter
     {
         foreach (debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT) as $frame) {
-            if (($frame['class'] ?? null) !== \Illuminate\Container\BoundMethod::class) {
+            if (($frame['class'] ?? null) !== BoundMethod::class) {
                 continue;
             }
 

--- a/src/Server/AppResource.php
+++ b/src/Server/AppResource.php
@@ -30,9 +30,7 @@ abstract class AppResource extends Resource
     {
         $appMeta = $this->appMeta()->toArray();
 
-        if (! isset($appMeta['domain'])) {
-            $appMeta['domain'] = $this->toClaudeDomain(url()->current());
-        }
+        $appMeta['domain'] ??= $this->toClaudeDomain(url()->current());
 
         return $appMeta;
     }

--- a/src/Server/McpServiceProvider.php
+++ b/src/Server/McpServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp\Server;
 
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Http\Kernel as HttpKernelContract;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 use Illuminate\Support\Facades\Route;
@@ -99,7 +100,9 @@ class McpServiceProvider extends ServiceProvider
 
     protected function registerContainerCallbacks(): void
     {
-        $this->app->whenHasAttribute(ArgumentAttribute::class, ArgumentAttribute::resolve(...));
+        if ($this->app instanceof Container) {
+            $this->app->whenHasAttribute(ArgumentAttribute::class, ArgumentAttribute::resolve(...));
+        }
 
         $this->app->resolving(Request::class, function (Request $request, $app): void {
             if ($app->bound('mcp.request')) {

--- a/src/Server/McpServiceProvider.php
+++ b/src/Server/McpServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Http\Kernel as HttpKernelContract;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Mcp\Attributes\Argument as ArgumentAttribute;
 use Laravel\Mcp\Client\ClientManager;
 use Laravel\Mcp\Console\Commands\InspectorCommand;
 use Laravel\Mcp\Console\Commands\MakeAppResourceCommand;
@@ -98,6 +99,8 @@ class McpServiceProvider extends ServiceProvider
 
     protected function registerContainerCallbacks(): void
     {
+        $this->app->whenHasAttribute(ArgumentAttribute::class, ArgumentAttribute::resolve(...));
+
         $this->app->resolving(Request::class, function (Request $request, $app): void {
             if ($app->bound('mcp.request')) {
                 /** @var Request $currentRequest */

--- a/tests/Feature/ArgumentAttributeTest.php
+++ b/tests/Feature/ArgumentAttributeTest.php
@@ -52,9 +52,13 @@ beforeEach(function (): void {
 });
 
 it('resolves scalar arguments by attribute key for tools', function (): void {
-    ArgumentAttributeServer::tool(ArgumentAttributeScalarTool::class, [
+    $tool = ArgumentAttributeServer::tool(ArgumentAttributeScalarTool::class, [
         'meeting_id' => 'abc-123',
-    ])->assertSee('Meeting ID: abc-123');
+    ]);
+
+    dump($tool);
+
+    $tool->assertSee('Meeting ID: abc-123');
 });
 
 it('resolves eloquent models by attribute key for tools', function (): void {

--- a/tests/Feature/ArgumentAttributeTest.php
+++ b/tests/Feature/ArgumentAttributeTest.php
@@ -52,13 +52,9 @@ beforeEach(function (): void {
 });
 
 it('resolves scalar arguments by attribute key for tools', function (): void {
-    $tool = ArgumentAttributeServer::tool(ArgumentAttributeScalarTool::class, [
+    ArgumentAttributeServer::tool(ArgumentAttributeScalarTool::class, [
         'meeting_id' => 'abc-123',
-    ]);
-
-    dump($tool);
-
-    $tool->assertSee('Meeting ID: abc-123');
+    ])->assertSee('Meeting ID: abc-123');
 });
 
 it('resolves eloquent models by attribute key for tools', function (): void {

--- a/tests/Feature/ArgumentAttributeTest.php
+++ b/tests/Feature/ArgumentAttributeTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Mcp\Attributes\Argument;
+use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Tool;
+
+class ArgumentAttributeMeeting extends Model
+{
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    protected $table = 'argument_attribute_meetings';
+}
+
+class ArgumentAttributeServer extends Server
+{
+    protected array $tools = [
+        ArgumentAttributeScalarTool::class,
+        ArgumentAttributeMeetingTool::class,
+    ];
+}
+
+class ArgumentAttributeScalarTool extends Tool
+{
+    public function handle(#[Argument('meeting_id')] $meetingId): string
+    {
+        return "Meeting ID: {$meetingId}";
+    }
+}
+
+class ArgumentAttributeMeetingTool extends Tool
+{
+    public function handle(#[Argument('meeting_id')] ArgumentAttributeMeeting $meeting): string
+    {
+        return "Meeting: {$meeting->title}";
+    }
+}
+
+beforeEach(function (): void {
+    Schema::dropIfExists('argument_attribute_meetings');
+
+    Schema::create('argument_attribute_meetings', function (Blueprint $table): void {
+        $table->id();
+        $table->string('title');
+    });
+});
+
+it('resolves scalar arguments by attribute key for tools', function (): void {
+    ArgumentAttributeServer::tool(ArgumentAttributeScalarTool::class, [
+        'meeting_id' => 'abc-123',
+    ])->assertSee('Meeting ID: abc-123');
+});
+
+it('resolves eloquent models by attribute key for tools', function (): void {
+    $meeting = ArgumentAttributeMeeting::query()->create([
+        'title' => 'Weekly sync',
+    ]);
+
+    ArgumentAttributeServer::tool(ArgumentAttributeMeetingTool::class, [
+        'meeting_id' => $meeting->id,
+    ])->assertSee('Meeting: Weekly sync');
+});
+
+it('returns a not found error when the eloquent model cannot be resolved', function (): void {
+    ArgumentAttributeServer::tool(ArgumentAttributeMeetingTool::class, [
+        'meeting_id' => 99999,
+    ])->assertHasErrors(['No query results for model [ArgumentAttributeMeeting] 99999']);
+});


### PR DESCRIPTION
In MCP tools, it happens a lot that you accept one or more model ids. In the tool, you then have to manually convert those to Eloquent models before you can use them
```php
class ChangeTicketStatusTool extends Tool
{
	public function handle(Request $request)
	{
		$ticket = Ticket::find($request->get('ticket_id');
		$status = TicketStatus::find($request->get('ticket_status_id'));

		if ($ticket === null) {
            return Response::error('Ticket not found.');
		}

		if ($status === null) {
            return Response::error('Ticket status not found.');
		}

		// do something ...
	}
}
```

I think it would be nice if there was some model binding similar to route model binding. This PR makes that possible, so you dont have to do all that boilerplate yourself:

```php
class ChangeTicketStatusTool extends Tool
{
	public function handle(
		#[Argument('ticket_id')] Ticket $ticket,
		#[Argument('ticket_status_id')] TicketStatus $status
	) {
		// do something ...
	}
}
```