### PR TITLE
Support nested request input with Laravel-style dot notation

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -49,11 +49,7 @@ class Request implements Arrayable
 
     protected function data(mixed $key = null, mixed $default = null): mixed
     {
-        if (is_null($key)) {
-            return $this->arguments;
-        }
-
-        return $this->arguments[$key] ?? $default;
+        return data_get($this->arguments, $key, $default);
     }
 
     public function get(string $key, mixed $default = null): mixed

--- a/tests/Unit/RequestTest.php
+++ b/tests/Unit/RequestTest.php
@@ -69,6 +69,18 @@ it('retrieves nested input using dot notation', function (): void {
         ->and($request->filled('user.country'))->toBeFalse();
 });
 
+it('does not resolve literal dotted keys', function (): void {
+    $request = new Request([
+        'limit.items' => 5,
+        'limit' => ['items' => 10],
+    ]);
+
+    expect($request->get('limit.items'))->toBe(10)
+        ->and($request->get('limit.items', 'fallback'))->toBe(10)
+        ->and((new Request(['limit.items' => 5]))->get('limit.items'))->toBeNull()
+        ->and((new Request(['limit.items' => 5]))->all())->toBe(['limit.items' => 5]);
+});
+
 it('may be returned as array', function (): void {
     $request = new Request([
         'name' => 'Alice',

--- a/tests/Unit/RequestTest.php
+++ b/tests/Unit/RequestTest.php
@@ -48,6 +48,27 @@ it('interact with data', function (): void {
         ->and($request->integer('city'))->toBe(0);
 });
 
+it('retrieves nested input using dot notation', function (): void {
+    $request = new Request([
+        'user' => [
+            'name' => 'Alice',
+            'email' => 'alice@example.com',
+        ],
+        'products' => [
+            ['name' => 'Widget'],
+            ['name' => 'Gadget'],
+        ],
+    ]);
+
+    expect($request->get('user.name'))->toBe('Alice')
+        ->and($request->get('user.missing', 'fallback'))->toBe('fallback')
+        ->and($request->get('products.0.name'))->toBe('Widget')
+        ->and($request->get('products.*.name'))->toBe(['Widget', 'Gadget'])
+        ->and($request->string('user.email')->value())->toBe('alice@example.com')
+        ->and($request->filled('user.name'))->toBeTrue()
+        ->and($request->filled('user.country'))->toBeFalse();
+});
+
 it('may be returned as array', function (): void {
     $request = new Request([
         'name' => 'Alice',


### PR DESCRIPTION
MCP requests do not support dot notation or wildcards like HTTP requests do in the Laravel core. This recently tripped us up when developing our own MCP. Adding `data_get` to the `Request::data()` method will bring the MCP request functionality inline with HTTP requests.

This is technically a breaking change as current consumers of this package could be using dots in key names e.g.

```php
 public function schema(JsonSchema $schema): array
  {
      return [
          'limit.items' => $schema->integer()
              ->description('Maximum number of items to return')
              ->min(1),
      ];
  }
```

With this change, `data_get` will look for `$this->arguments['limit']['items']` and not fallback to `$this->arguments['limit.items']`.

This is consistent with how the HTTP requests work I believe. Personally I think it's a valid tradeoff considering this project is pre-1.0 and support for dot notation and wildcards is quite helpful.

Let me know if there are any changes I can make to increase the chances of this being accepted.