### PR TITLE
Add oauth client logo and uri

### DIFF
--- a/resources/views/mcp/authorize.blade.php
+++ b/resources/views/mcp/authorize.blade.php
@@ -51,10 +51,14 @@
             <!-- Header -->
             <div class="flex flex-col space-y-1.5 p-6">
                 <div class="flex items-center justify-center mb-4">
+                    @if ($client->logo_uri)
+                    <img src="{{ $client->logo_uri }}" alt="{{ $client->name }}" class="h-12 w-12 rounded object-contain">
+                    @else
                     <!-- Shield Icon -->
                     <svg class="h-12 w-12 text-primary" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.618 5.984A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.031 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path>
                     </svg>
+                    @endif
                 </div>
 
                 <h3 class="text-2xl font-semibold leading-none tracking-tight text-center">
@@ -64,6 +68,12 @@
                 <p class="text-sm text-muted-foreground text-center">
                     This application will be able to:<br/>Use available MCP functionality.
                 </p>
+
+                @if ($client->client_uri)
+                <a href="{{ $client->client_uri }}" target="_blank" rel="noopener noreferrer" class="text-sm text-primary underline text-center">
+                    {{ $client->client_uri }}
+                </a>
+                @endif
             </div>
 
             <!-- Content -->

--- a/resources/views/mcp/authorize.blade.php
+++ b/resources/views/mcp/authorize.blade.php
@@ -51,7 +51,7 @@
             <!-- Header -->
             <div class="flex flex-col space-y-1.5 p-6">
                 <div class="flex items-center justify-center mb-4">
-                    @if ($client->logo_uri)
+                    @if ($client->logo_uri ?? null)
                     <img src="{{ $client->logo_uri }}" alt="{{ $client->name }}" class="h-12 w-12 rounded object-contain">
                     @else
                     <!-- Shield Icon -->
@@ -69,7 +69,7 @@
                     This application will be able to:<br/>Use available MCP functionality.
                 </p>
 
-                @if ($client->client_uri)
+                @if ($client->client_uri ?? null)
                 <a href="{{ $client->client_uri }}" target="_blank" rel="noopener noreferrer" class="text-sm text-primary underline text-center">
                     {{ $client->client_uri }}
                 </a>

--- a/src/Server/AppResource.php
+++ b/src/Server/AppResource.php
@@ -30,9 +30,7 @@ abstract class AppResource extends Resource
     {
         $appMeta = $this->appMeta()->toArray();
 
-        if (! isset($appMeta['domain'])) {
-            $appMeta['domain'] = $this->toClaudeDomain(url()->current());
-        }
+        $appMeta['domain'] ??= $this->toClaudeDomain(url()->current());
 
         return $appMeta;
     }

--- a/src/Server/AppResource.php
+++ b/src/Server/AppResource.php
@@ -30,7 +30,9 @@ abstract class AppResource extends Resource
     {
         $appMeta = $this->appMeta()->toArray();
 
-        $appMeta['domain'] ??= $this->toClaudeDomain(url()->current());
+        if (! isset($appMeta['domain'])) {
+            $appMeta['domain'] = $this->toClaudeDomain(url()->current());
+        }
 
         return $appMeta;
     }

--- a/src/Server/Http/Controllers/OAuthRegisterController.php
+++ b/src/Server/Http/Controllers/OAuthRegisterController.php
@@ -28,7 +28,7 @@ class OAuthRegisterController
             'client_name' => ['nullable', 'string', 'min:1', 'max:255'],
             'name' => ['nullable', 'string', 'min:1', 'max:255'],
             'redirect_uris' => ['required', 'array', 'min:1'],
-            'redirect_uris.*' => ['required', 'string', function (string $attribute, $value, $fail): void {
+            'redirect_uris.*' => ['bail', 'required', 'string', function (string $attribute, $value, $fail): void {
                 if (! $this->isValidRedirectUri($value)) {
                     $fail($attribute.' is not a valid URL.');
 

--- a/src/Server/Http/Controllers/OAuthRegisterController.php
+++ b/src/Server/Http/Controllers/OAuthRegisterController.php
@@ -12,6 +12,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Laravel\Mcp\Server\Registrar;
+use RuntimeException;
 use Throwable;
 
 class OAuthRegisterController
@@ -52,6 +53,12 @@ class OAuthRegisterController
             }],
         ]);
 
+        // Preserve error precedence by adding metadata rules after redirect rules are expanded.
+        $validator->addRules([
+            'logo_uri' => ['nullable', 'string', 'url:http,https', 'max:2048'],
+            'client_uri' => ['nullable', 'string', 'url:http,https', 'max:2048'],
+        ]);
+
         if ($validator->fails()) {
             $errors = $validator->errors();
 
@@ -79,14 +86,23 @@ class OAuthRegisterController
         );
 
         try {
-            $client = $clients->createAuthorizationCodeGrantClient(
-                name: $this->resolveClientName($validated),
-                redirectUris: $validated['redirect_uris'],
-                confidential: false,
-                enableDeviceFlow: false,
-            );
+            $passport = 'Laravel\Passport\Passport';
 
-            $this->grantMcpScope($client);
+            /** @var Model $model */
+            $model = $passport::client();
+
+            [$client, $metadata] = $model->getConnection()->transaction(function () use ($clients, $validated): array {
+                $client = $clients->createAuthorizationCodeGrantClient(
+                    name: $this->resolveClientName($validated),
+                    redirectUris: $validated['redirect_uris'],
+                    confidential: false,
+                    enableDeviceFlow: false,
+                );
+
+                $this->grantMcpScope($client);
+
+                return [$client, $this->persistClientMetadata($client, $validated)];
+            });
         } catch (Throwable $throwable) {
             report($throwable);
 
@@ -103,6 +119,7 @@ class OAuthRegisterController
             'redirect_uris' => $client->redirect_uris,
             'scope' => Registrar::OAUTH_SCOPE,
             'token_endpoint_auth_method' => 'none',
+            ...$metadata,
         ], 201);
     }
 
@@ -119,6 +136,39 @@ class OAuthRegisterController
         }
 
         $client->forceFill(['scopes' => [...$scopes, Registrar::OAUTH_SCOPE]])->save();
+    }
+
+    /**
+     * @param  array<string, mixed>  $validated
+     * @return array<string, mixed>
+     */
+    protected function persistClientMetadata(mixed $client, array $validated): array
+    {
+        if (! $client instanceof Model) {
+            return [];
+        }
+
+        $columns = $client->getConnection()->getSchemaBuilder()->getColumnListing($client->getTable());
+        $supported = array_intersect(['logo_uri', 'client_uri'], $columns);
+        $metadata = array_intersect_key($validated, array_flip($supported));
+
+        if ($metadata !== []) {
+            if (! $client->forceFill($metadata)->save()) {
+                throw new RuntimeException('The client metadata could not be saved.');
+            }
+
+            $client->refresh();
+        }
+
+        $metadata = [];
+
+        foreach ($supported as $attribute) {
+            if (($value = $client->getAttribute($attribute)) !== null) {
+                $metadata[$attribute] = $value;
+            }
+        }
+
+        return $metadata;
     }
 
     /**

--- a/src/Server/Http/Controllers/OAuthRegisterController.php
+++ b/src/Server/Http/Controllers/OAuthRegisterController.php
@@ -12,7 +12,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Laravel\Mcp\Server\Registrar;
-use RuntimeException;
 use Throwable;
 
 class OAuthRegisterController
@@ -51,24 +50,17 @@ class OAuthRegisterController
                     $fail($attribute.' is not a permitted redirect domain.');
                 }
             }],
-        ]);
-
-        // Preserve error precedence by adding metadata rules after redirect rules are expanded.
-        $validator->addRules([
             'logo_uri' => ['nullable', 'string', 'url:http,https', 'max:2048'],
             'client_uri' => ['nullable', 'string', 'url:http,https', 'max:2048'],
         ]);
 
         if ($validator->fails()) {
             $errors = $validator->errors();
-
-            $isRedirectError = collect($errors->keys())->contains(
-                fn (string $key): bool => str_starts_with($key, 'redirect_uris')
-            );
+            $redirectError = $errors->first('redirect_uris*');
 
             return response()->json([
-                'error' => $isRedirectError ? 'invalid_redirect_uri' : 'invalid_client_metadata',
-                'error_description' => $errors->first(),
+                'error' => $redirectError !== '' ? 'invalid_redirect_uri' : 'invalid_client_metadata',
+                'error_description' => $redirectError !== '' ? $redirectError : $errors->first(),
             ], 400);
         }
 
@@ -86,23 +78,16 @@ class OAuthRegisterController
         );
 
         try {
-            $passport = 'Laravel\Passport\Passport';
+            $client = $clients->createAuthorizationCodeGrantClient(
+                name: $this->resolveClientName($validated),
+                redirectUris: $validated['redirect_uris'],
+                confidential: false,
+                enableDeviceFlow: false,
+            );
 
-            /** @var Model $model */
-            $model = $passport::client();
+            $this->grantMcpScope($client);
 
-            [$client, $metadata] = $model->getConnection()->transaction(function () use ($clients, $validated): array {
-                $client = $clients->createAuthorizationCodeGrantClient(
-                    name: $this->resolveClientName($validated),
-                    redirectUris: $validated['redirect_uris'],
-                    confidential: false,
-                    enableDeviceFlow: false,
-                );
-
-                $this->grantMcpScope($client);
-
-                return [$client, $this->persistClientMetadata($client, $validated)];
-            });
+            $metadata = $this->persistClientMetadata($client, $validated);
         } catch (Throwable $throwable) {
             report($throwable);
 
@@ -150,25 +135,13 @@ class OAuthRegisterController
 
         $columns = $client->getConnection()->getSchemaBuilder()->getColumnListing($client->getTable());
         $supported = array_intersect(['logo_uri', 'client_uri'], $columns);
-        $metadata = array_intersect_key($validated, array_flip($supported));
+        $metadata = array_filter(array_intersect_key($validated, array_flip($supported)));
 
         if ($metadata !== []) {
-            if (! $client->forceFill($metadata)->save()) {
-                throw new RuntimeException('The client metadata could not be saved.');
-            }
-
-            $client->refresh();
+            $client->forceFill($metadata)->save();
         }
 
-        $metadata = [];
-
-        foreach ($supported as $attribute) {
-            if (($value = $client->getAttribute($attribute)) !== null) {
-                $metadata[$attribute] = $value;
-            }
-        }
-
-        return $metadata;
+        return array_filter(array_map($client->getAttribute(...), array_combine($supported, $supported)));
     }
 
     /**

--- a/src/Server/Http/Controllers/OAuthRegisterController.php
+++ b/src/Server/Http/Controllers/OAuthRegisterController.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Laravel\Mcp\Server\Registrar;
@@ -135,13 +136,13 @@ class OAuthRegisterController
 
         $columns = $client->getConnection()->getSchemaBuilder()->getColumnListing($client->getTable());
         $supported = array_intersect(['logo_uri', 'client_uri'], $columns);
-        $metadata = array_filter(array_intersect_key($validated, array_flip($supported)));
+        $metadata = array_filter(Arr::only($validated, $supported));
 
         if ($metadata !== []) {
             $client->forceFill($metadata)->save();
         }
 
-        return array_filter(array_map($client->getAttribute(...), array_combine($supported, $supported)));
+        return array_filter($client->only($supported));
     }
 
     /**

--- a/tests/Fixtures/CustomPassportClient.php
+++ b/tests/Fixtures/CustomPassportClient.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Laravel\Passport\Client;
+
+class CustomPassportClient extends Client
+{
+    protected $connection = 'clients';
+
+    protected $table = 'registered_clients';
+
+    protected $guarded = ['*'];
+
+    public function setLogoUriAttribute(?string $value): void
+    {
+        $this->attributes['logo_uri'] = $value === null ? null : strtolower($value);
+    }
+}

--- a/tests/Fixtures/PassportClient.php
+++ b/tests/Fixtures/PassportClient.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Passport;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Client extends Model
+{
+    public $incrementing = false;
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    protected $keyType = 'string';
+
+    protected $table = 'oauth_clients';
+
+    protected function casts(): array
+    {
+        return [
+            'grant_types' => 'array',
+            'redirect_uris' => 'array',
+            'scopes' => 'array',
+        ];
+    }
+
+    public function getConnectionName(): ?string
+    {
+        return $this->connection ?? config('passport.connection');
+    }
+}

--- a/tests/Fixtures/PassportPassport.php
+++ b/tests/Fixtures/PassportPassport.php
@@ -8,8 +8,20 @@ class Passport
 {
     public static $scopes = [];
 
+    public static $clientModel = Client::class;
+
     public static function tokensCan($scopes): void
     {
         self::$scopes = $scopes;
+    }
+
+    public static function useClientModel(string $clientModel): void
+    {
+        static::$clientModel = $clientModel;
+    }
+
+    public static function client(): Client
+    {
+        return new static::$clientModel;
     }
 }

--- a/tests/Unit/Server/RegistrarTest.php
+++ b/tests/Unit/Server/RegistrarTest.php
@@ -365,6 +365,16 @@ it('rejects invalid registration metadata before creating a client', function (s
     'too long' => ['https://example.com/'.str_repeat('a', 2030)],
 ]);
 
+it('rejects non-string redirect URIs before creating a client', function (): void {
+    prepareOauthRegistration();
+
+    $this->postJson('/oauth/register', [
+        'redirect_uris' => [42],
+    ])->assertBadRequest()->assertJson(['error' => 'invalid_redirect_uri']);
+
+    $this->assertDatabaseCount('oauth_clients', 0);
+});
+
 it('keeps redirect errors ahead of metadata errors', function (): void {
     prepareOauthRegistration();
 

--- a/tests/Unit/Server/RegistrarTest.php
+++ b/tests/Unit/Server/RegistrarTest.php
@@ -386,6 +386,60 @@ it('keeps redirect errors ahead of metadata errors', function (): void {
     ]);
 });
 
+it('describes the redirect error when an earlier rule also fails', function (): void {
+    prepareOauthRegistration();
+
+    $this->postJson('/oauth/register', [
+        'client_name' => 123,
+        'redirect_uris' => ['not-a-url'],
+    ])->assertBadRequest()->assertExactJson([
+        'error' => 'invalid_redirect_uri',
+        'error_description' => 'redirect_uris.0 is not a valid URL.',
+    ]);
+});
+
+it('renders client metadata on the authorize view', function (array $metadataColumns, array $attributes, array $expected, array $missing): void {
+    $this->withoutVite();
+    prepareOauthRegistration(metadataColumns: $metadataColumns);
+    Route::post('oauth/authorize', fn (): null => null)->name('passport.authorizations.approve');
+    Route::delete('oauth/authorize', fn (): null => null)->name('passport.authorizations.deny');
+    Model::preventAccessingMissingAttributes();
+
+    $client = Passport::client()->forceFill(['id' => 'client-id', 'name' => 'Example', 'grant_types' => [], 'redirect_uris' => [], ...$attributes]);
+    $client->save();
+
+    $html = view('mcp::authorize', [
+        'client' => $client->fresh(),
+        'user' => (object) ['email' => 'user@example.com'],
+        'scopes' => [],
+        'authToken' => 'token',
+        'appearance' => 'light',
+    ])->render();
+
+    Model::preventAccessingMissingAttributes(false);
+
+    foreach ($expected as $fragment) {
+        expect($html)->toContain($fragment);
+    }
+
+    foreach ($missing as $fragment) {
+        expect($html)->not->toContain($fragment);
+    }
+})->with([
+    'with metadata' => [
+        ['logo_uri', 'client_uri'],
+        ['logo_uri' => 'https://example.com/logo.png', 'client_uri' => 'https://example.com'],
+        ['<img src="https://example.com/logo.png"', '<a href="https://example.com"'],
+        ['h-12 w-12 text-primary'],
+    ],
+    'without columns' => [
+        [],
+        [],
+        ['h-12 w-12 text-primary'],
+        ['<img', '<a href='],
+    ],
+]);
+
 it('returns metadata transformed by a custom client model', function (): void {
     $repository = prepareOauthRegistration(clientModel: CustomPassportClient::class);
 

--- a/tests/Unit/Server/RegistrarTest.php
+++ b/tests/Unit/Server/RegistrarTest.php
@@ -314,6 +314,18 @@ it('handles oauth registration endpoint', function (): void {
     ]);
 });
 
+it('ignores registration metadata when the client is not an eloquent model', function (): void {
+    ensureMockClientRepository();
+    (new Registrar)->oauthRoutes();
+    $this->app->instance(ClientRepository::class, new ClientRepository);
+
+    $this->postJson('/oauth/register', [
+        'redirect_uris' => ['http://localhost:3000/callback'],
+        'logo_uri' => 'https://example.com/logo.png',
+        'client_uri' => 'https://example.com',
+    ])->assertCreated()->assertJsonMissingPath('logo_uri')->assertJsonMissingPath('client_uri');
+});
+
 it('persists and returns supported registration metadata', function (array $expected): void {
     config()->set('passport.connection', 'clients');
     $repository = prepareOauthRegistration(metadataColumns: array_keys($expected));

--- a/tests/Unit/Server/RegistrarTest.php
+++ b/tests/Unit/Server/RegistrarTest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Exceptions;
 use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Facades\Schema;
 use Laravel\Mcp\Server\Registrar;
+use Laravel\Passport\Client;
 use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Passport;
+use Tests\Fixtures\CustomPassportClient;
 use Tests\Fixtures\ExampleServer;
 
 function ensureMockClientRepository(): void
@@ -16,16 +18,37 @@ function ensureMockClientRepository(): void
     if (! class_exists(ClientRepository::class)) {
         require_once __DIR__.'/../../Fixtures/PassportClientRepository.php';
     }
+
+    if (! class_exists(Client::class)) {
+        require_once __DIR__.'/../../Fixtures/PassportClient.php';
+    }
+
+    if (! class_exists(Passport::class)) {
+        require_once __DIR__.'/../../Fixtures/PassportPassport.php';
+    }
 }
 
-function createOauthClientsTable(bool $withScopesColumn, ?string $scopesDefault = null): void
+afterEach(function (): void {
+    if (class_exists(Passport::class)) {
+        Passport::useClientModel(Client::class);
+    }
+});
+
+function createOauthClientsTable(bool $withScopesColumn, ?string $scopesDefault = null, array $metadataColumns = []): void
 {
-    Schema::dropIfExists('oauth_clients');
-    Schema::create('oauth_clients', function (Blueprint $table) use ($withScopesColumn, $scopesDefault): void {
+    $model = Passport::client();
+    $schema = $model->getConnection()->getSchemaBuilder();
+
+    $schema->dropIfExists($model->getTable());
+    $schema->create($model->getTable(), function (Blueprint $table) use ($withScopesColumn, $scopesDefault, $metadataColumns): void {
         $table->string('id')->primary();
         $table->string('name');
         $table->json('grant_types');
         $table->json('redirect_uris');
+
+        foreach ($metadataColumns as $column) {
+            $table->text($column)->nullable();
+        }
 
         if ($withScopesColumn && $scopesDefault !== null) {
             $table->json('scopes')->default($scopesDefault);
@@ -37,37 +60,15 @@ function createOauthClientsTable(bool $withScopesColumn, ?string $scopesDefault 
 
 function databaseClientRepository(?array $initialScopes = null): object
 {
-    $prototype = new class extends Model
-    {
-        public $incrementing = false;
-
-        public $timestamps = false;
-
-        protected $guarded = [];
-
-        protected $keyType = 'string';
-
-        protected $table = 'oauth_clients';
-
-        protected function casts(): array
-        {
-            return [
-                'grant_types' => 'array',
-                'redirect_uris' => 'array',
-                'scopes' => 'array',
-            ];
-        }
-    };
-
-    return new class($prototype, $initialScopes)
+    return new class($initialScopes)
     {
         public Model $client;
 
-        public function __construct(protected Model $prototype, protected ?array $initialScopes = null) {}
+        public function __construct(protected ?array $initialScopes = null) {}
 
         public function createAuthorizationCodeGrantClient(string $name, array $redirectUris, bool $confidential = true, $user = null, bool $enableDeviceFlow = false): Model
         {
-            $client = $this->prototype->newInstance([
+            $client = Passport::client()->forceFill([
                 'id' => 'test-client-id',
                 'name' => $name,
                 'grant_types' => ['authorization_code'],
@@ -79,6 +80,20 @@ function databaseClientRepository(?array $initialScopes = null): object
             return $this->client = $client;
         }
     };
+}
+
+function prepareOauthRegistration(array $metadataColumns = ['logo_uri', 'client_uri'], string $clientModel = Client::class): object
+{
+    ensureMockClientRepository();
+    config()->set('database.connections.clients', ['driver' => 'sqlite', 'database' => ':memory:']);
+    Passport::useClientModel($clientModel);
+    createOauthClientsTable(withScopesColumn: false, metadataColumns: $metadataColumns);
+
+    $repository = databaseClientRepository();
+    app()->instance(ClientRepository::class, $repository);
+    (new Registrar)->oauthRoutes();
+
+    return $repository;
 }
 
 it('registers a local server and retrieves it', function (): void {
@@ -299,6 +314,102 @@ it('handles oauth registration endpoint', function (): void {
         'token_endpoint_auth_method' => 'none',
     ]);
 });
+
+it('persists and returns supported registration metadata', function (array $expected): void {
+    config()->set('passport.connection', 'clients');
+    $repository = prepareOauthRegistration(metadataColumns: array_keys($expected));
+
+    $response = $this->postJson('/oauth/register', [
+        'redirect_uris' => ['https://example.com/callback'],
+        'logo_uri' => 'https://example.com/logo.png',
+        'client_uri' => 'http://example.com',
+    ])->assertCreated();
+
+    expect($response->collect()->only(['logo_uri', 'client_uri'])->all())->toBe($expected)
+        ->and($repository->client->fresh()->only(array_keys($expected)))->toBe($expected);
+})->with([
+    'both columns' => [['logo_uri' => 'https://example.com/logo.png', 'client_uri' => 'http://example.com']],
+    'logo only' => [['logo_uri' => 'https://example.com/logo.png']],
+    'website only' => [['client_uri' => 'http://example.com']],
+    'neither column' => [[]],
+]);
+
+it('omits missing or null registration metadata from the response', function (array $metadata): void {
+    $repository = prepareOauthRegistration();
+
+    $this->postJson('/oauth/register', [
+        'redirect_uris' => ['https://example.com/callback'],
+        ...$metadata,
+    ])->assertCreated()->assertJsonMissingPath('logo_uri')->assertJsonMissingPath('client_uri');
+
+    expect($repository->client->fresh()->only(['logo_uri', 'client_uri']))
+        ->toBe(['logo_uri' => null, 'client_uri' => null]);
+})->with([
+    'omitted' => [[]],
+    'null' => [['logo_uri' => null, 'client_uri' => null]],
+]);
+
+it('rejects invalid registration metadata before creating a client', function (string $attribute, mixed $value): void {
+    prepareOauthRegistration();
+
+    $this->postJson('/oauth/register', [
+        'redirect_uris' => ['https://example.com/callback'],
+        $attribute => $value,
+    ])->assertBadRequest()->assertJson(['error' => 'invalid_client_metadata']);
+
+    $this->assertDatabaseCount('oauth_clients', 0);
+})->with(['logo_uri', 'client_uri'])->with([
+    'invalid URL' => ['not-a-url'],
+    'unsupported scheme' => ['ftp://example.com/logo.png'],
+    'non-string' => [['https://example.com']],
+    'too long' => ['https://example.com/'.str_repeat('a', 2030)],
+]);
+
+it('keeps redirect errors ahead of metadata errors', function (): void {
+    prepareOauthRegistration();
+
+    $this->postJson('/oauth/register', [
+        'redirect_uris' => ['not-a-url'],
+        'logo_uri' => 'not-a-url',
+    ])->assertBadRequest()->assertExactJson([
+        'error' => 'invalid_redirect_uri',
+        'error_description' => 'redirect_uris.0 is not a valid URL.',
+    ]);
+});
+
+it('returns metadata transformed by a custom client model', function (): void {
+    $repository = prepareOauthRegistration(clientModel: CustomPassportClient::class);
+
+    $this->postJson('/oauth/register', [
+        'redirect_uris' => ['https://example.com/callback'],
+        'logo_uri' => 'https://example.com/LOGO.png',
+    ])->assertCreated()->assertJsonPath('logo_uri', 'https://example.com/logo.png');
+
+    expect($repository->client->fresh()->logo_uri)->toBe('https://example.com/logo.png');
+});
+
+it('rolls back registration when metadata cannot be saved', function (bool $cancelSave): void {
+    Exceptions::fake();
+    $repository = prepareOauthRegistration(clientModel: CustomPassportClient::class);
+    CustomPassportClient::updating(function () use ($cancelSave): bool {
+        if ($cancelSave) {
+            return false;
+        }
+
+        throw new RuntimeException('Private metadata failure details.');
+    });
+
+    $this->postJson('/oauth/register', [
+        'redirect_uris' => ['https://example.com/callback'],
+        'logo_uri' => 'https://example.com/logo.png',
+    ])->assertStatus(500)->assertExactJson([
+        'error' => 'server_error',
+        'error_description' => 'The client could not be registered.',
+    ]);
+
+    expect($repository->client->newQuery()->count())->toBe(0);
+    Exceptions::assertReported(RuntimeException::class);
+})->with(['exception' => false, 'save cancelled' => true]);
 
 it('persists the advertised mcp scope when passport clients are scope-restricted by default', function (): void {
     ensureMockClientRepository();

--- a/tests/Unit/Server/RegistrarTest.php
+++ b/tests/Unit/Server/RegistrarTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Exceptions;
 use Illuminate\Support\Facades\Route;
 use Laravel\Mcp\Server\Registrar;
 use Laravel\Passport\Client;
@@ -397,29 +396,6 @@ it('returns metadata transformed by a custom client model', function (): void {
 
     expect($repository->client->fresh()->logo_uri)->toBe('https://example.com/logo.png');
 });
-
-it('rolls back registration when metadata cannot be saved', function (bool $cancelSave): void {
-    Exceptions::fake();
-    $repository = prepareOauthRegistration(clientModel: CustomPassportClient::class);
-    CustomPassportClient::updating(function () use ($cancelSave): bool {
-        if ($cancelSave) {
-            return false;
-        }
-
-        throw new RuntimeException('Private metadata failure details.');
-    });
-
-    $this->postJson('/oauth/register', [
-        'redirect_uris' => ['https://example.com/callback'],
-        'logo_uri' => 'https://example.com/logo.png',
-    ])->assertStatus(500)->assertExactJson([
-        'error' => 'server_error',
-        'error_description' => 'The client could not be registered.',
-    ]);
-
-    expect($repository->client->newQuery()->count())->toBe(0);
-    Exceptions::assertReported(RuntimeException::class);
-})->with(['exception' => false, 'save cancelled' => true]);
 
 it('persists the advertised mcp scope when passport clients are scope-restricted by default', function (): void {
     ensureMockClientRepository();


### PR DESCRIPTION
Adds optional `logo_uri` and `client_uri` support to the MCP's OAuth registration endpoint, so apps can display the registering client’s logo and website.

Supported fields are persisted using Passport’s configured client model and connection. Fields without corresponding columns are ignored. Applications can opt in by adding either or both columns to their `oauth_clients` table:

```php
use Illuminate\Database\Schema\Blueprint;
use Illuminate\Support\Facades\Schema;

public function up(): void
{
    Schema::table('oauth_clients', function (Blueprint $table): void {
        $table->text('logo_uri')->nullable();
        $table->text('client_uri')->nullable();
    });
}
```

Also adds `bail` to the `redirect_uris.*` rules so a non-string redirect URI returns `invalid_redirect_uri` instead of reaching the closure and throwing a `TypeError` under `strict_types`.
