### PR TITLE
Updated HasStructuredContent so structured content always gets returned correctly.

### DIFF
--- a/src/Server/Concerns/HasStructuredContent.php
+++ b/src/Server/Concerns/HasStructuredContent.php
@@ -31,6 +31,6 @@ trait HasStructuredContent
             return $baseArray;
         }
 
-        return array_merge($baseArray, ['structuredContent' => $this->structuredContent]);
+        return array_merge($baseArray, ['structuredContent' => (object) $this->structuredContent]);
     }
 }

--- a/src/Server/Testing/TestResponse.php
+++ b/src/Server/Testing/TestResponse.php
@@ -403,7 +403,7 @@ class TestResponse
     {
         $structuredContent = $this->response->toArray()['result']['structuredContent'] ?? null;
 
-        if (is_array($structuredContent) === false) {
+        if (is_array($structuredContent) === false && ! is_object($structuredContent)) {
             return null;
         }
 

--- a/tests/Unit/Methods/CallToolTest.php
+++ b/tests/Unit/Methods/CallToolTest.php
@@ -640,7 +640,7 @@ it('returns structured content in tool response', function (): void {
 
     expect($payload['id'])->toEqual(1)
         ->and($payload['result'])->toHaveKey('structuredContent')
-        ->and($payload['result']['structuredContent'])->toEqual([
+        ->and($payload['result']['structuredContent'])->toEqual((object) [
             'temperature' => 22.5,
             'conditions' => 'Partly cloudy',
             'humidity' => 65,
@@ -685,7 +685,7 @@ it('returns structured content with meta in tool response', function (): void {
 
     expect($payload['id'])->toEqual(1)
         ->and($payload['result'])->toHaveKey('structuredContent')
-        ->and($payload['result']['structuredContent'])->toEqual([
+        ->and($payload['result']['structuredContent'])->toEqual((object) [
             'result' => 'The operation completed successfully',
         ])
         ->and($payload['result'])->toHaveKey('_meta')
@@ -728,7 +728,7 @@ it('returns ResponseFactory with structured content added via withStructuredCont
 
     expect($payload['id'])->toEqual(1)
         ->and($payload['result'])->toHaveKey('structuredContent')
-        ->and($payload['result']['structuredContent'])->toEqual([
+        ->and($payload['result']['structuredContent'])->toEqual((object) [
             'status' => 'success',
             'code' => 200,
         ])

--- a/tests/Unit/Server/Concerns/HasStructuredContentTest.php
+++ b/tests/Unit/Server/Concerns/HasStructuredContentTest.php
@@ -37,9 +37,32 @@ it('merges structured content into base array', function (): void {
     expect($result)->toEqual([
         'content' => [['type' => 'text', 'text' => 'Weather data']],
         'isError' => false,
-        'structuredContent' => [
+        'structuredContent' => (object) [
             'temperature' => 22.5,
             'humidity' => 65,
+        ],
+    ]);
+});
+
+it('casts structured content as object when a indexed array is used', function (): void {
+    $object = new class
+    {
+        use HasStructuredContent;
+    };
+
+    $object->setStructuredContent(['value1', 'value2']);
+
+    $result = $object->mergeStructuredContent([
+        'content' => [['type' => 'text', 'text' => 'value1, value2']],
+        'isError' => false,
+    ]);
+
+    expect($result)->toEqual([
+        'content' => [['type' => 'text', 'text' => 'value1, value2']],
+        'isError' => false,
+        'structuredContent' => (object) [
+            '0' => 'value1',
+            '1' => 'value2',
         ],
     ]);
 });


### PR DESCRIPTION
Currently when a indexed array is passed as a structured response, like this for example:

```php
$locations = Location::select('id', 'name')->get();

return $locations->isEmpty() ? Response::text('No results') : Response::structured($locations->toArray());
```

It gets returned in the response body as a array, this works in the MCP inspector since they ran into issues with this and loosened their specs. But as its invalid content according to the MCP spec, applications like Claude throw a "Tool execution failed" error.

I think this is the simplest solution, but id love to hear your take on this.