### PR TITLE
Serve legacy initialize clients alongside the modern protocol

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,9 +16,7 @@ In your application's `composer.json` file, update the `laravel/mcp` dependency:
 
 **Likelihood Of Impact: High**
 
-The server now supports only protocol revision `2026-07-28`. The protocol versions `2025-11-25`, `2025-06-18`, `2025-03-26`, and `2024-11-05` are no longer accepted.
-
-The `initialize` handshake has been replaced by the `server/discover` method. Without a handshake, every request must include the protocol version and client capabilities in its own `params._meta`:
+The server now speaks protocol revision `2026-07-28` by default. The `initialize` handshake has been replaced by the `server/discover` method, and every modern request must include the protocol version and client capabilities in its own `params._meta`:
 
 ```
 // Before...
@@ -33,7 +31,7 @@ The `initialize` handshake has been replaced by the `server/discover` method. Wi
 
 If your application only defines `Tool`, `Resource`, `Prompt`, and `Server` classes, no changes are required as long as your MCP client supports the `2026-07-28` revision. Both `Laravel\Mcp\Client` and the MCP Inspector support this revision.
 
-Clients that support only the `initialize` flow can no longer connect and will receive a `-32601` error. Re-registering `initialize` via `addMethod()` will not restore compatibility because every request must still pass the protocol metadata check.
+Clients that still open with `initialize` continue to work. The server answers the handshake with `2025-11-25` or `2025-06-18`, whichever the client requested, and serves the rest of that client's requests without requiring `_meta` or the MCP HTTP headers. Clients requesting `2025-03-26` or `2024-11-05` are offered `2025-11-25` instead. A request that carries `io.modelcontextprotocol/protocolVersion` or `io.modelcontextprotocol/clientCapabilities` in `_meta` is always treated as a `2026-07-28` request and validated as such.
 
 ## MCP HTTP Headers
 
@@ -70,7 +68,7 @@ $this->postJson('mcp-endpoint', $message, [
 ]);
 ```
 
-A mismatch returns an HTTP 400 response containing the JSON-RPC error code `-32020`. Requests to the removed `initialize` method are exempt from header validation, but still receive a `-32601` method-not-found error. The `Mcp-Name` header may be encoded as `=?base64?<b64>?=` when a name contains characters that are not valid in a raw header value.
+A mismatch returns an HTTP 400 response containing the JSON-RPC error code `-32020`. Requests from legacy `initialize` clients, which carry no protocol metadata in `_meta`, are exempt from header validation. The `Mcp-Name` header may be encoded as `=?base64?<b64>?=` when a name contains characters that are not valid in a raw header value.
 
 ## Session IDs
 
@@ -192,12 +190,6 @@ Mcp::oAuthRoutesFor('github', $handler, clientMetadataUri: 'oauth/github/metadat
 The `client_id` and default `redirect_uris` values are computed from your `APP_URL` and route table, while `token_endpoint_auth_method` is always `none`; these values may not be overridden. Any additional `redirect_uris` are included alongside the generated callback URL. The `client_secret`, `client_secret_expires_at`, and `registration_access_token` keys are stripped from the document.
 
 You should check for route collisions at this path and ensure `APP_URL` is correct in production because the document is built from that value rather than from the incoming request.
-
-## The `ping` Method
-
-**Likelihood Of Impact: Low**
-
-The `ping` method has been removed in favor of `server/discover`. Requests to `ping` now return a `-32601` error. Update any health checks or tooling that send a bare `ping` request.
 
 ## The MCP Apps Capability
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -33,6 +33,7 @@ use Laravel\Mcp\Server\Methods\ListPrompts;
 use Laravel\Mcp\Server\Methods\ListResources;
 use Laravel\Mcp\Server\Methods\ListResourceTemplates;
 use Laravel\Mcp\Server\Methods\ListTools;
+use Laravel\Mcp\Server\Methods\Ping;
 use Laravel\Mcp\Server\Methods\ReadResource;
 use Laravel\Mcp\Server\Prompt;
 use Laravel\Mcp\Server\Resource;
@@ -138,6 +139,7 @@ abstract class Server
         'completion/complete' => CompletionComplete::class,
         'server/discover' => Discover::class,
         'initialize' => Initialize::class,
+        'ping' => Ping::class,
         'subscriptions/listen' => Listen::class,
     ];
 
@@ -218,7 +220,7 @@ abstract class Server
 
             $requestId = $request->id;
 
-            if (array_key_exists(MetaKey::PROTOCOL_VERSION->value, $request->meta() ?? [])) {
+            if (! $request->isLegacy()) {
                 $this->validateProtocolMeta($request, $context);
             }
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -27,6 +27,7 @@ use Laravel\Mcp\Server\Methods\CompletionComplete;
 use Laravel\Mcp\Server\Methods\Concerns\ResolvesResources;
 use Laravel\Mcp\Server\Methods\Discover;
 use Laravel\Mcp\Server\Methods\GetPrompt;
+use Laravel\Mcp\Server\Methods\Initialize;
 use Laravel\Mcp\Server\Methods\Listen;
 use Laravel\Mcp\Server\Methods\ListPrompts;
 use Laravel\Mcp\Server\Methods\ListResources;
@@ -136,6 +137,7 @@ abstract class Server
         'prompts/get' => GetPrompt::class,
         'completion/complete' => CompletionComplete::class,
         'server/discover' => Discover::class,
+        'initialize' => Initialize::class,
         'subscriptions/listen' => Listen::class,
     ];
 
@@ -216,16 +218,9 @@ abstract class Server
 
             $requestId = $request->id;
 
-            if ($request->method === 'initialize' && ! isset($this->methods['initialize'])) {
-                throw new JsonRpcException(
-                    'The [initialize] handshake was removed in MCP '.ProtocolVersion::LATEST->value.'. Send the protocol version in the request [_meta] instead.',
-                    ErrorCode::METHOD_NOT_FOUND->value,
-                    $request->id,
-                    ['supported' => $context->supportedProtocolVersions],
-                );
+            if (array_key_exists(MetaKey::PROTOCOL_VERSION->value, $request->meta() ?? [])) {
+                $this->validateProtocolMeta($request, $context);
             }
-
-            $this->validateProtocolMeta($request, $context);
 
             if (! isset($this->methods[$request->method])) {
                 throw new JsonRpcException(

--- a/src/Server/Methods/Initialize.php
+++ b/src/Server/Methods/Initialize.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Server\Methods;
+
+use Laravel\Mcp\Enums\ProtocolVersion;
+use Laravel\Mcp\Server\Contracts\Method;
+use Laravel\Mcp\Server\ServerContext;
+use Laravel\Mcp\Transport\JsonRpcRequest;
+use Laravel\Mcp\Transport\JsonRpcResponse;
+
+class Initialize implements Method
+{
+    public function handle(JsonRpcRequest $request, ServerContext $context): JsonRpcResponse
+    {
+        $requested = $request->params['protocolVersion'] ?? null;
+
+        return JsonRpcResponse::result($request->id, [
+            'protocolVersion' => in_array($requested, ProtocolVersion::initializeSupported(), true)
+                ? $requested
+                : ProtocolVersion::initializeSupported()[0],
+            'capabilities' => $context->serverCapabilities ?: (object) [],
+            'serverInfo' => $context->implementation->toArray(),
+            'instructions' => $context->instructions,
+        ]);
+    }
+}

--- a/src/Server/Methods/Ping.php
+++ b/src/Server/Methods/Ping.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Mcp\Server\Methods;
+
+use Laravel\Mcp\Server\Contracts\Method;
+use Laravel\Mcp\Server\ServerContext;
+use Laravel\Mcp\Transport\JsonRpcRequest;
+use Laravel\Mcp\Transport\JsonRpcResponse;
+
+class Ping implements Method
+{
+    public function handle(JsonRpcRequest $request, ServerContext $context): JsonRpcResponse
+    {
+        return JsonRpcResponse::result($request->id, []);
+    }
+}

--- a/src/Server/Middleware/ValidateMcpHeaders.php
+++ b/src/Server/Middleware/ValidateMcpHeaders.php
@@ -28,20 +28,17 @@ class ValidateMcpHeaders
             return $next($request);
         }
 
-        $params = is_array($body['params'] ?? null) ? $body['params'] : [];
-        $meta = is_array($params['_meta'] ?? null) ? $params['_meta'] : [];
-
-        if (! array_key_exists(MetaKey::PROTOCOL_VERSION->value, $meta)) {
-            return $next($request);
-        }
-
         $message = new JsonRpcRequest(
             id: is_int($body['id']) || is_string($body['id']) ? $body['id'] : 0,
             method: $body['method'],
-            params: $params,
+            params: is_array($body['params'] ?? null) ? $body['params'] : [],
         );
 
-        $mismatch = $this->mismatch($request, RequestHeader::PROTOCOL_VERSION, $meta[MetaKey::PROTOCOL_VERSION->value] ?? null, true)
+        if ($message->isLegacy()) {
+            return $next($request);
+        }
+
+        $mismatch = $this->mismatch($request, RequestHeader::PROTOCOL_VERSION, $message->meta()[MetaKey::PROTOCOL_VERSION->value] ?? null, true)
             ?? $this->mismatch($request, RequestHeader::METHOD, $message->method, true)
             ?? $this->mismatch($request, RequestHeader::NAME, $message->name(), $message->requiresName());
 

--- a/src/Server/Middleware/ValidateMcpHeaders.php
+++ b/src/Server/Middleware/ValidateMcpHeaders.php
@@ -28,12 +28,12 @@ class ValidateMcpHeaders
             return $next($request);
         }
 
-        if ($body['method'] === 'initialize') {
-            return $next($request);
-        }
-
         $params = is_array($body['params'] ?? null) ? $body['params'] : [];
         $meta = is_array($params['_meta'] ?? null) ? $params['_meta'] : [];
+
+        if (! array_key_exists(MetaKey::PROTOCOL_VERSION->value, $meta)) {
+            return $next($request);
+        }
 
         $message = new JsonRpcRequest(
             id: is_int($body['id']) || is_string($body['id']) ? $body['id'] : 0,

--- a/src/Transport/JsonRpcRequest.php
+++ b/src/Transport/JsonRpcRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laravel\Mcp\Transport;
 
+use Laravel\Mcp\Enums\MetaKey;
 use Laravel\Mcp\Enums\RequestHeader;
 use Laravel\Mcp\Exceptions\JsonRpcException;
 use Laravel\Mcp\Request;
@@ -74,6 +75,14 @@ class JsonRpcRequest
     public function meta(): ?array
     {
         return isset($this->params['_meta']) && self::isObject($this->params['_meta']) ? $this->params['_meta'] : null;
+    }
+
+    public function isLegacy(): bool
+    {
+        $meta = $this->meta() ?? [];
+
+        return ! array_key_exists(MetaKey::PROTOCOL_VERSION->value, $meta)
+            && ! array_key_exists(MetaKey::CLIENT_CAPABILITIES->value, $meta);
     }
 
     /**

--- a/tests/Feature/Console/StartCommandTest.php
+++ b/tests/Feature/Console/StartCommandTest.php
@@ -8,22 +8,20 @@ use Symfony\Component\Process\Process;
 
 use function Orchestra\Testbench\remote;
 
-it('rejects the initialize handshake over http', function (): void {
+it('answers the legacy initialize handshake over http', function (): void {
     $response = $this->postJson('test-mcp', initializeMessage());
 
-    $response->assertStatus(404);
+    $response->assertStatus(200);
 
-    expect($response->json())->toEqual([
-        'jsonrpc' => '2.0',
-        'id' => 456,
-        'error' => [
-            'code' => -32601,
-            'message' => 'The [initialize] handshake was removed in MCP 2026-07-28. Send the protocol version in the request [_meta] instead.',
-            'data' => [
-                'supported' => ['2026-07-28'],
-            ],
-        ],
-    ]);
+    expect($response->json('result.protocolVersion'))->toBe('2025-11-25');
+});
+
+it('serves legacy requests without mcp headers over http', function (): void {
+    $response = $this->postJson('test-mcp', ['jsonrpc' => '2.0', 'id' => 2, 'method' => 'tools/list', 'params' => []]);
+
+    $response->assertStatus(200);
+
+    expect($response->json('result.tools'))->not->toBeEmpty();
 });
 
 it('does not return a session id over http', function (): void {

--- a/tests/Feature/Server/Middleware/ValidateMcpHeadersTest.php
+++ b/tests/Feature/Server/Middleware/ValidateMcpHeadersTest.php
@@ -129,6 +129,31 @@ it('answers an unknown method with a 404', function (): void {
     expect($response->json('error.code'))->toBe(-32601);
 });
 
+it('requires the protocol version header even when the body omits the meta member', function (): void {
+    $message = listToolsMessage();
+    unset($message['params']['_meta']['io.modelcontextprotocol/protocolVersion']);
+
+    $headers = mcpHeaders($message);
+    unset($headers['MCP-Protocol-Version']);
+
+    $response = $this->postJson('test-mcp', $message, $headers);
+
+    $response->assertStatus(400);
+
+    expect($response->json('error'))->toEqual([
+        'code' => -32020,
+        'message' => 'Header mismatch: The [MCP-Protocol-Version] header is required.',
+    ]);
+});
+
+it('skips header validation for a legacy request without protocol metadata', function (): void {
+    $response = $this->postJson('test-mcp', ['jsonrpc' => '2.0', 'id' => 3, 'method' => 'tools/list', 'params' => []]);
+
+    $response->assertStatus(200);
+
+    expect($response->json('result.tools'))->not->toBeEmpty();
+});
+
 it('requires the name header even when the body carries no usable name', function (): void {
     $message = callToolMessage();
     $message['params']['name'] = 123;

--- a/tests/Feature/Server/Middleware/ValidateMcpHeadersTest.php
+++ b/tests/Feature/Server/Middleware/ValidateMcpHeadersTest.php
@@ -129,23 +129,6 @@ it('answers an unknown method with a 404', function (): void {
     expect($response->json('error.code'))->toBe(-32601);
 });
 
-it('requires the protocol version header even when the body omits the meta member', function (): void {
-    $message = listToolsMessage();
-    unset($message['params']['_meta']['io.modelcontextprotocol/protocolVersion']);
-
-    $headers = mcpHeaders($message);
-    unset($headers['MCP-Protocol-Version']);
-
-    $response = $this->postJson('test-mcp', $message, $headers);
-
-    $response->assertStatus(400);
-
-    expect($response->json('error'))->toEqual([
-        'code' => -32020,
-        'message' => 'Header mismatch: The [MCP-Protocol-Version] header is required.',
-    ]);
-});
-
 it('requires the name header even when the body carries no usable name', function (): void {
     $message = callToolMessage();
     $message['params']['name'] = 123;

--- a/tests/Unit/ServerTest.php
+++ b/tests/Unit/ServerTest.php
@@ -40,6 +40,17 @@ it('falls back to the latest legacy version for an unknown initialize version', 
     expect(json_decode((string) $transport->sent[0], true)['result']['protocolVersion'])->toBe('2025-11-25');
 });
 
+it('falls back to the latest legacy version for a malformed initialize version', function (): void {
+    $transport = new ArrayTransport;
+    $server = new ExampleServer($transport);
+
+    $server->start();
+
+    ($transport->handler)(json_encode([...initializeMessage(), 'params' => ['protocolVersion' => 1]]));
+
+    expect(json_decode((string) $transport->sent[0], true)['result']['protocolVersion'])->toBe('2025-11-25');
+});
+
 it('serves a legacy request without protocol metadata', function (): void {
     $transport = new ArrayTransport;
     $server = new ExampleServer($transport);
@@ -90,6 +101,10 @@ it('rejects a request without the required protocol metadata', function (array $
         ],
     ]);
 })->with([
+    'missing version' => [
+        ['io.modelcontextprotocol/clientCapabilities' => []],
+        'Invalid params: The request [_meta] is missing the required [io.modelcontextprotocol/protocolVersion] member.',
+    ],
     'missing capabilities' => [
         ['io.modelcontextprotocol/protocolVersion' => '2026-07-28'],
         'Invalid params: The request [_meta] is missing the required [io.modelcontextprotocol/clientCapabilities] member.',
@@ -383,7 +398,7 @@ it('keeps the result type and metadata a method supplied itself', function (): v
     ]);
 });
 
-it('no longer answers a ping message', function (): void {
+it('answers a legacy ping message', function (): void {
     $transport = new ArrayTransport;
     $server = new ExampleServer($transport);
 
@@ -393,17 +408,18 @@ it('no longer answers a ping message', function (): void {
         'jsonrpc' => '2.0',
         'id' => 789,
         'method' => 'ping',
-        'params' => ['_meta' => protocolMeta()],
     ]);
 
     ($transport->handler)($payload);
 
     $response = json_decode((string) $transport->sent[0], true);
 
-    expect($response['error']['code'])->toBe(-32601);
+    expect($response['id'])->toBe(789)
+        ->and($response)->not->toHaveKey('error')
+        ->and($response['result'])->toBeArray();
 });
 
-it('lets a dual-era server serve initialize through addMethod', function (): void {
+it('lets addMethod override the built-in initialize handler', function (): void {
     $transport = new ArrayTransport;
     $server = new ExampleServer($transport);
 

--- a/tests/Unit/ServerTest.php
+++ b/tests/Unit/ServerTest.php
@@ -13,29 +13,42 @@ use Tests\Fixtures\CustomMethodHandler;
 use Tests\Fixtures\ExampleServer;
 use Tests\Fixtures\ThrowingMethodHandler;
 
-it('rejects the initialize handshake', function (): void {
+it('answers the legacy initialize handshake', function (): void {
     $transport = new ArrayTransport;
     $server = new ExampleServer($transport);
 
     $server->start();
 
-    $payload = json_encode(initializeMessage());
-
-    ($transport->handler)($payload);
+    ($transport->handler)(json_encode([...initializeMessage(), 'params' => ['protocolVersion' => '2025-06-18']]));
 
     $response = json_decode((string) $transport->sent[0], true);
 
-    expect($response)->toEqual([
-        'jsonrpc' => '2.0',
-        'id' => 456,
-        'error' => [
-            'code' => -32601,
-            'message' => 'The [initialize] handshake was removed in MCP 2026-07-28. Send the protocol version in the request [_meta] instead.',
-            'data' => [
-                'supported' => ['2026-07-28'],
-            ],
-        ],
-    ]);
+    expect($response['id'])->toBe(456)
+        ->and($response['result']['protocolVersion'])->toBe('2025-06-18')
+        ->and($response['result']['serverInfo']['name'])->toBe('Laravel MCP Server')
+        ->and($response['result'])->toHaveKeys(['capabilities', 'instructions']);
+});
+
+it('falls back to the latest legacy version for an unknown initialize version', function (): void {
+    $transport = new ArrayTransport;
+    $server = new ExampleServer($transport);
+
+    $server->start();
+
+    ($transport->handler)(json_encode([...initializeMessage(), 'params' => ['protocolVersion' => '2024-11-05']]));
+
+    expect(json_decode((string) $transport->sent[0], true)['result']['protocolVersion'])->toBe('2025-11-25');
+});
+
+it('serves a legacy request without protocol metadata', function (): void {
+    $transport = new ArrayTransport;
+    $server = new ExampleServer($transport);
+
+    $server->start();
+
+    ($transport->handler)(json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => 'tools/list', 'params' => []]));
+
+    expect(json_decode((string) $transport->sent[0], true)['result']['tools'])->not->toBeEmpty();
 });
 
 it('can handle a discover message', function (): void {
@@ -77,10 +90,6 @@ it('rejects a request without the required protocol metadata', function (array $
         ],
     ]);
 })->with([
-    'missing version' => [
-        ['io.modelcontextprotocol/clientCapabilities' => []],
-        'Invalid params: The request [_meta] is missing the required [io.modelcontextprotocol/protocolVersion] member.',
-    ],
     'missing capabilities' => [
         ['io.modelcontextprotocol/protocolVersion' => '2026-07-28'],
         'Invalid params: The request [_meta] is missing the required [io.modelcontextprotocol/clientCapabilities] member.',


### PR DESCRIPTION
Since 1.0 the server speaks only MCP `2026-07-28`, so clients that still open with `initialize` (claude.ai, Claude Desktop, ChatGPT connectors) get `-32601` and stop. The [specification allows a dual-era server](https://modelcontextprotocol.io/specification/2026-07-28/basic/versioning#backward-compatibility-with-initialization-based-versions), and supporting it is a small change, so the server now answers both eras on the same endpoint.


```mermaid
sequenceDiagram
    participant C as Client
    participant S as Server

    alt Modern client
        C->>S: server/discover or any method, _meta.protocolVersion = 2026-07-28
        S->>S: validate _meta, headers
        S-->>C: result (or -32022 with supported versions)
    else Legacy client
        C->>S: initialize {protocolVersion: 2025-06-18}
        S-->>C: {protocolVersion: 2025-06-18, capabilities, serverInfo}
        C->>S: notifications/initialized
        C->>S: tools/list (no _meta, no Mcp-* headers)
        S-->>C: result
    end
```

> [!NOTE]
> Legacy requests skip the `ValidateMcpHeaders` checks, because those clients never send `Mcp-Method` or `Mcp-Name`. Modern requests are validated exactly as before. No `MCP-Session-Id` is issued; the legacy specification treats it as optional.

Fixes #338

