### PR TITLE
Cover the well-known metadata routes not overriding the application's

### DIFF
--- a/tests/Unit/Server/RegistrarTest.php
+++ b/tests/Unit/Server/RegistrarTest.php
@@ -169,6 +169,59 @@ it('registers oauth routes', function (): void {
     expect($hasAuthServer)->toBeTrue();
 });
 
+it('leaves an application route for the authorization server metadata alone', function (): void {
+    Route::get('/.well-known/oauth-authorization-server', fn () => response()->json(['issuer' => 'the application']))
+        ->name('application.oauth.authorization-server');
+
+    (new Registrar)->oauthRoutes();
+
+    $registered = collect(Route::getRoutes()->getRoutes())
+        ->filter(fn ($route): bool => $route->uri() === '.well-known/oauth-authorization-server')
+        ->map(fn ($route) => $route->getName())
+        ->values();
+
+    expect($registered->all())->toBe(['application.oauth.authorization-server']);
+});
+
+it('leaves an application route for the protected resource metadata alone', function (): void {
+    Route::get('/.well-known/oauth-protected-resource', fn () => response()->json(['resource' => 'the application']))
+        ->name('application.oauth.protected-resource');
+
+    (new Registrar)->oauthRoutes();
+
+    $registered = collect(Route::getRoutes()->getRoutes())
+        ->filter(fn ($route): bool => $route->uri() === '.well-known/oauth-protected-resource')
+        ->map(fn ($route) => $route->getName())
+        ->values();
+
+    expect($registered->all())->toBe(['application.oauth.protected-resource']);
+});
+
+it('does not let the nested metadata route answer the bare path', function (): void {
+    // The nested parameter has to stay required. An optional one matches the
+    // bare path as well, so an application that already serves its own
+    // discovery document gets it silently replaced.
+    Route::get('/.well-known/oauth-authorization-server', fn () => response()->json(['issuer' => 'the application']))
+        ->name('application.oauth.authorization-server');
+
+    (new Registrar)->oauthRoutes();
+
+    $this->get('/.well-known/oauth-authorization-server')
+        ->assertOk()
+        ->assertJson(['issuer' => 'the application']);
+});
+
+it('still answers a nested metadata path when the application serves the bare one', function (): void {
+    Route::get('/.well-known/oauth-protected-resource', fn () => response()->json(['resource' => 'the application']))
+        ->name('application.oauth.protected-resource');
+
+    (new Registrar)->oauthRoutes();
+
+    $this->get('/.well-known/oauth-protected-resource/mcp')
+        ->assertOk()
+        ->assertJsonPath('resource', url('/mcp'));
+});
+
 it('registers oauth routes with custom prefix', function (): void {
     $registrar = new Registrar;
 


### PR DESCRIPTION
Tests only, no behaviour change.

Looking at #138, the collision it reports no longer happens on main. Two things stop it, and I could not find a test for either:

- `oauthRoutes()` checks for an existing GET route on the exact uri and skips registering its own
- the nested routes take `{path}` rather than `{path?}`

The second is the quiet one. An optional parameter matches the bare path as well, so `.well-known/oauth-authorization-server/{path?}` answers `.well-known/oauth-authorization-server` too, and an application that already serves a discovery document there gets it replaced. That is exactly what the route list in #138 shows. Nothing about the route looks wrong in `route:list` when it happens.

Four tests, in `RegistrarTest`:

- an application route for the authorization server metadata is left alone
- same for the protected resource metadata
- the nested route does not answer the bare path
- the nested path still works when the application owns the bare one

I checked they fail for the right reasons rather than assuming. Undoing the guard fails the first two, and making the nested parameter optional again fails the third. The fourth passes either way on purpose: it is there because requiring the parameter is the kind of change that could quietly cost the nested case, and nothing was asserting it.

Full suite green, 1248 passed. Pint leaves the file alone.

On #138 itself, the reporter also asked to be able to customise or opt out of the registration, along the lines of Nova's `PendingRouteRegistration`. That part is still open and I have not touched it here.